### PR TITLE
Add issue tracking and TODO comment guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,17 @@ For any implementation task:
 - If the plan changes during implementation (additional fixes, scope adjustments, new files added), update the GitHub issue to match (`gh issue edit`).
 - PR descriptions should clearly separate categories of changes (e.g., "Implementation", "Tests", "Formatting") so reviewers can understand what was built vs. what was cleaned up.
 
+## Issue Tracking
+
+Proactively create GitHub issues (`gh issue create`) whenever you encounter:
+
+- **Unimplemented features**: TODOs, placeholder responses, hardcoded stubs, or any code path that is clearly incomplete.
+- **Future feature ideas**: When a conversation surfaces a new idea or improvement that isn't being implemented right now, capture it as an issue so it isn't lost.
+
+Each issue should include a clear title, a description of what needs to be done (with relevant file paths), and a priority note if obvious. Label issues with `enhancement` or `bug` as appropriate. If the new issue depends on or relates to existing issues, reference them (e.g., "Depends on #5").
+
+When writing code that is intentionally incomplete or deferred, add a `// TODO:` comment in the source with a short explanation and reference the GitHub issue number (e.g., `// TODO: Wire to agent graph (#5)`). This keeps the codebase searchable and links inline markers to tracked work.
+
 ## Key Conventions
 
 - **Package manager**: pnpm 9.x with workspaces. Node >= 20 required.


### PR DESCRIPTION
## Summary

- Add **Issue Tracking** section to `CLAUDE.md` instructing Claude Code to proactively create GitHub issues for unimplemented features and future ideas
- Add guidance to leave `// TODO:` comments in source referencing the corresponding issue number

Closes #11

## Test plan

- [ ] Verify `CLAUDE.md` renders correctly on GitHub
- [ ] Confirm new section appears between "Workflow" and "Key Conventions"

🤖 Generated with [Claude Code](https://claude.com/claude-code)