### PR TITLE
Add unit tests for shared package

### DIFF
--- a/packages/shared/src/env.test.ts
+++ b/packages/shared/src/env.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Use vi.hoisted to avoid hoisting issues with vi.mock
+const { mockResource } = vi.hoisted(() => ({
+  mockResource: {} as Record<string, unknown>,
+}));
+
+vi.mock("sst", () => ({
+  Resource: new Proxy(mockResource, {
+    get(target, prop: string | symbol) {
+      if (typeof prop === "string" && prop in target) return target[prop];
+      throw new Error(`Resource ${String(prop)} not found`);
+    },
+  }),
+}));
+
+import {
+  getRequiredEnv,
+  getOptionalEnv,
+  getDatabaseUrl,
+  getSecretValue,
+  isProduction,
+  isDevelopment,
+} from "./env.js";
+
+describe("getRequiredEnv", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns the value when env var is set", () => {
+    process.env.TEST_VAR = "test-value";
+    expect(getRequiredEnv("TEST_VAR")).toBe("test-value");
+  });
+
+  it("throws when env var is not set", () => {
+    delete process.env.MISSING_VAR;
+    expect(() => getRequiredEnv("MISSING_VAR")).toThrow(
+      "Missing required environment variable: MISSING_VAR",
+    );
+  });
+
+  it("throws when env var is empty string", () => {
+    process.env.EMPTY_VAR = "";
+    expect(() => getRequiredEnv("EMPTY_VAR")).toThrow(
+      "Missing required environment variable: EMPTY_VAR",
+    );
+  });
+});
+
+describe("getOptionalEnv", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns the value when env var is set", () => {
+    process.env.OPT_VAR = "optional-value";
+    expect(getOptionalEnv("OPT_VAR")).toBe("optional-value");
+  });
+
+  it("returns undefined when env var is not set and no default", () => {
+    delete process.env.MISSING_OPT;
+    expect(getOptionalEnv("MISSING_OPT")).toBeUndefined();
+  });
+
+  it("returns default value when env var is not set", () => {
+    delete process.env.MISSING_WITH_DEFAULT;
+    expect(getOptionalEnv("MISSING_WITH_DEFAULT", "fallback")).toBe("fallback");
+  });
+
+  it("returns default value when env var is empty string", () => {
+    process.env.EMPTY_OPT = "";
+    expect(getOptionalEnv("EMPTY_OPT", "fallback")).toBe("fallback");
+  });
+
+  it("returns actual value over default when set", () => {
+    process.env.SET_VAR = "actual";
+    expect(getOptionalEnv("SET_VAR", "fallback")).toBe("actual");
+  });
+});
+
+describe("getDatabaseUrl", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    // Clear mock resource
+    Object.keys(mockResource).forEach((key) => delete mockResource[key]);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns DATABASE_URL when set", () => {
+    process.env.DATABASE_URL = "postgresql://localhost:5432/test";
+    expect(getDatabaseUrl()).toBe("postgresql://localhost:5432/test");
+  });
+
+  it("returns SST Resource URL when DATABASE_URL is not set", () => {
+    delete process.env.DATABASE_URL;
+    mockResource.Database = {
+      host: "db.example.com",
+      port: "5432",
+      username: "user",
+      password: "pass",
+      database: "mydb",
+    };
+
+    expect(getDatabaseUrl()).toBe(
+      "postgresql://user:pass@db.example.com:5432/mydb",
+    );
+  });
+
+  it("URL-encodes special characters in username and password", () => {
+    delete process.env.DATABASE_URL;
+    mockResource.Database = {
+      host: "db.example.com",
+      port: "5432",
+      username: "user@domain",
+      password: "p@ss:word/123",
+      database: "mydb",
+    };
+
+    const url = getDatabaseUrl();
+    expect(url).toContain("user%40domain");
+    expect(url).toContain("p%40ss%3Aword%2F123");
+  });
+
+  it("throws when neither DATABASE_URL nor SST Resource is available", () => {
+    delete process.env.DATABASE_URL;
+    // mockResource.Database is not set, so accessing it will throw
+
+    expect(() => getDatabaseUrl()).toThrow(
+      "DATABASE_URL is not set and SST Database resource is not available",
+    );
+  });
+
+  it("prefers DATABASE_URL over SST Resource", () => {
+    process.env.DATABASE_URL = "postgresql://env-url/db";
+    mockResource.Database = {
+      host: "sst-host",
+      port: "5432",
+      username: "sst-user",
+      password: "sst-pass",
+      database: "sst-db",
+    };
+
+    expect(getDatabaseUrl()).toBe("postgresql://env-url/db");
+  });
+});
+
+describe("getSecretValue", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    Object.keys(mockResource).forEach((key) => delete mockResource[key]);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns env var value when set", () => {
+    process.env.API_KEY = "env-secret";
+    expect(getSecretValue("API_KEY", "ApiKey")).toBe("env-secret");
+  });
+
+  it("returns SST Resource value when env var is not set", () => {
+    delete process.env.API_KEY;
+    mockResource.ApiKey = { value: "sst-secret" };
+
+    expect(getSecretValue("API_KEY", "ApiKey")).toBe("sst-secret");
+  });
+
+  it("prefers env var over SST Resource", () => {
+    process.env.API_KEY = "env-secret";
+    mockResource.ApiKey = { value: "sst-secret" };
+
+    expect(getSecretValue("API_KEY", "ApiKey")).toBe("env-secret");
+  });
+
+  it("throws when neither source has the secret", () => {
+    delete process.env.MISSING_SECRET;
+    // mockResource.MissingSecret not set
+
+    expect(() => getSecretValue("MISSING_SECRET", "MissingSecret")).toThrow(
+      "Missing required secret. Checked: MISSING_SECRET, Resource.MissingSecret",
+    );
+  });
+
+  it("throws with only env key in message when no SST resource name provided", () => {
+    delete process.env.ONLY_ENV;
+
+    expect(() => getSecretValue("ONLY_ENV")).toThrow(
+      "Missing required secret. Checked: ONLY_ENV",
+    );
+  });
+
+  it("works without SST resource name parameter", () => {
+    process.env.ENV_ONLY_SECRET = "value";
+    expect(getSecretValue("ENV_ONLY_SECRET")).toBe("value");
+  });
+});
+
+describe("isProduction", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns true when NODE_ENV is production", () => {
+    process.env.NODE_ENV = "production";
+    expect(isProduction()).toBe(true);
+  });
+
+  it("returns false when NODE_ENV is development", () => {
+    process.env.NODE_ENV = "development";
+    expect(isProduction()).toBe(false);
+  });
+
+  it("returns false when NODE_ENV is not set", () => {
+    delete process.env.NODE_ENV;
+    expect(isProduction()).toBe(false);
+  });
+});
+
+describe("isDevelopment", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("returns true when NODE_ENV is development", () => {
+    process.env.NODE_ENV = "development";
+    expect(isDevelopment()).toBe(true);
+  });
+
+  it("returns true when NODE_ENV is not set", () => {
+    delete process.env.NODE_ENV;
+    expect(isDevelopment()).toBe(true);
+  });
+
+  it("returns false when NODE_ENV is production", () => {
+    process.env.NODE_ENV = "production";
+    expect(isDevelopment()).toBe(false);
+  });
+
+  it("returns false when NODE_ENV is test", () => {
+    process.env.NODE_ENV = "test";
+    expect(isDevelopment()).toBe(false);
+  });
+});

--- a/packages/shared/src/errors.test.ts
+++ b/packages/shared/src/errors.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "vitest";
+import {
+  AppError,
+  NotFoundError,
+  ValidationError,
+  AuthenticationError,
+  RateLimitError,
+  ExternalServiceError,
+  IngestionError,
+} from "./errors.js";
+
+describe("AppError", () => {
+  it("creates error with default values", () => {
+    const error = new AppError("Something went wrong");
+
+    expect(error.message).toBe("Something went wrong");
+    expect(error.code).toBe("INTERNAL_ERROR");
+    expect(error.statusCode).toBe(500);
+    expect(error.isOperational).toBe(true);
+    expect(error.context).toBeUndefined();
+    expect(error.name).toBe("AppError");
+  });
+
+  it("creates error with custom options", () => {
+    const error = new AppError("Custom error", {
+      code: "CUSTOM_CODE",
+      statusCode: 418,
+      isOperational: false,
+      context: { userId: "123" },
+    });
+
+    expect(error.code).toBe("CUSTOM_CODE");
+    expect(error.statusCode).toBe(418);
+    expect(error.isOperational).toBe(false);
+    expect(error.context).toEqual({ userId: "123" });
+  });
+
+  it("supports error cause", () => {
+    const cause = new Error("Original error");
+    const error = new AppError("Wrapped error", { cause });
+
+    expect(error.cause).toBe(cause);
+  });
+
+  it("is instanceof Error", () => {
+    const error = new AppError("Test");
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(AppError);
+  });
+
+  it("has stack trace", () => {
+    const error = new AppError("Test");
+    expect(error.stack).toBeDefined();
+    expect(error.stack).toContain("AppError");
+  });
+
+  describe("toJSON", () => {
+    it("serializes error without context", () => {
+      const error = new AppError("Test message", {
+        code: "TEST_CODE",
+        statusCode: 400,
+      });
+
+      const json = error.toJSON();
+
+      expect(json).toEqual({
+        name: "AppError",
+        message: "Test message",
+        code: "TEST_CODE",
+        statusCode: 400,
+        isOperational: true,
+      });
+    });
+
+    it("serializes error with context", () => {
+      const error = new AppError("Test", {
+        context: { key: "value" },
+      });
+
+      const json = error.toJSON();
+
+      expect(json.context).toEqual({ key: "value" });
+    });
+  });
+});
+
+describe("NotFoundError", () => {
+  it("has correct defaults", () => {
+    const error = new NotFoundError();
+
+    expect(error.message).toBe("Resource not found");
+    expect(error.code).toBe("NOT_FOUND");
+    expect(error.statusCode).toBe(404);
+    expect(error.isOperational).toBe(true);
+    expect(error.name).toBe("NotFoundError");
+  });
+
+  it("accepts custom message", () => {
+    const error = new NotFoundError("User not found");
+    expect(error.message).toBe("User not found");
+  });
+
+  it("accepts custom code", () => {
+    const error = new NotFoundError("Not found", { code: "USER_NOT_FOUND" });
+    expect(error.code).toBe("USER_NOT_FOUND");
+  });
+
+  it("accepts context", () => {
+    const error = new NotFoundError("Not found", { context: { id: "123" } });
+    expect(error.context).toEqual({ id: "123" });
+  });
+
+  it("is instanceof AppError", () => {
+    const error = new NotFoundError();
+    expect(error).toBeInstanceOf(AppError);
+    expect(error).toBeInstanceOf(NotFoundError);
+  });
+});
+
+describe("ValidationError", () => {
+  it("has correct defaults", () => {
+    const error = new ValidationError();
+
+    expect(error.message).toBe("Validation failed");
+    expect(error.code).toBe("VALIDATION_ERROR");
+    expect(error.statusCode).toBe(400);
+    expect(error.isOperational).toBe(true);
+    expect(error.name).toBe("ValidationError");
+  });
+
+  it("accepts custom message and context", () => {
+    const error = new ValidationError("Invalid email format", {
+      context: { field: "email", value: "invalid" },
+    });
+
+    expect(error.message).toBe("Invalid email format");
+    expect(error.context).toEqual({ field: "email", value: "invalid" });
+  });
+});
+
+describe("AuthenticationError", () => {
+  it("has correct defaults", () => {
+    const error = new AuthenticationError();
+
+    expect(error.message).toBe("Authentication required");
+    expect(error.code).toBe("AUTHENTICATION_ERROR");
+    expect(error.statusCode).toBe(401);
+    expect(error.isOperational).toBe(true);
+    expect(error.name).toBe("AuthenticationError");
+  });
+
+  it("accepts custom message", () => {
+    const error = new AuthenticationError("Invalid token");
+    expect(error.message).toBe("Invalid token");
+  });
+});
+
+describe("RateLimitError", () => {
+  it("has correct defaults", () => {
+    const error = new RateLimitError();
+
+    expect(error.message).toBe("Rate limit exceeded");
+    expect(error.code).toBe("RATE_LIMIT_EXCEEDED");
+    expect(error.statusCode).toBe(429);
+    expect(error.isOperational).toBe(true);
+    expect(error.name).toBe("RateLimitError");
+  });
+
+  it("accepts context with retry info", () => {
+    const error = new RateLimitError("Too many requests", {
+      context: { retryAfter: 60 },
+    });
+
+    expect(error.context).toEqual({ retryAfter: 60 });
+  });
+});
+
+describe("ExternalServiceError", () => {
+  it("has correct defaults", () => {
+    const error = new ExternalServiceError();
+
+    expect(error.message).toBe("External service failure");
+    expect(error.code).toBe("EXTERNAL_SERVICE_ERROR");
+    expect(error.statusCode).toBe(502);
+    expect(error.isOperational).toBe(true);
+    expect(error.name).toBe("ExternalServiceError");
+  });
+
+  it("accepts cause for wrapped errors", () => {
+    const cause = new Error("Connection refused");
+    const error = new ExternalServiceError("Anthropic API failed", { cause });
+
+    expect(error.cause).toBe(cause);
+  });
+});
+
+describe("IngestionError", () => {
+  it("has correct defaults", () => {
+    const error = new IngestionError();
+
+    expect(error.message).toBe("Document ingestion failed");
+    expect(error.code).toBe("INGESTION_ERROR");
+    expect(error.statusCode).toBe(500);
+    expect(error.isOperational).toBe(true);
+    expect(error.name).toBe("IngestionError");
+  });
+
+  it("accepts context with document info", () => {
+    const error = new IngestionError("Failed to parse PDF", {
+      context: { documentId: "doc-123", source: "usada.org" },
+    });
+
+    expect(error.context).toEqual({
+      documentId: "doc-123",
+      source: "usada.org",
+    });
+  });
+});

--- a/packages/shared/src/logger.test.ts
+++ b/packages/shared/src/logger.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createLogger, logger } from "./logger.js";
+
+describe("createLogger", () => {
+  const originalEnv = process.env;
+  let stdoutWrite: typeof process.stdout.write;
+  let stderrWrite: typeof process.stderr.write;
+  let stdoutCalls: string[];
+  let stderrCalls: string[];
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    stdoutCalls = [];
+    stderrCalls = [];
+
+    stdoutWrite = process.stdout.write;
+    stderrWrite = process.stderr.write;
+
+    process.stdout.write = ((chunk: string) => {
+      stdoutCalls.push(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+
+    process.stderr.write = ((chunk: string) => {
+      stderrCalls.push(chunk);
+      return true;
+    }) as typeof process.stderr.write;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    process.stdout.write = stdoutWrite;
+    process.stderr.write = stderrWrite;
+  });
+
+  describe("log levels", () => {
+    it("logs info messages to stdout", () => {
+      const log = createLogger();
+      log.info("Test message");
+
+      expect(stdoutCalls).toHaveLength(1);
+      const output = JSON.parse(stdoutCalls[0].replace("\n", ""));
+      expect(output.level).toBe("info");
+      expect(output.message).toBe("Test message");
+      expect(output.timestamp).toBeDefined();
+    });
+
+    it("logs error messages to stderr", () => {
+      const log = createLogger();
+      log.error("Error message");
+
+      expect(stderrCalls).toHaveLength(1);
+      const output = JSON.parse(stderrCalls[0].replace("\n", ""));
+      expect(output.level).toBe("error");
+      expect(output.message).toBe("Error message");
+    });
+
+    it("logs warn messages to stdout", () => {
+      const log = createLogger();
+      log.warn("Warning message");
+
+      expect(stdoutCalls).toHaveLength(1);
+      const output = JSON.parse(stdoutCalls[0].replace("\n", ""));
+      expect(output.level).toBe("warn");
+    });
+
+    it("logs debug messages when LOG_LEVEL is debug", () => {
+      process.env.LOG_LEVEL = "debug";
+      const log = createLogger();
+      log.debug("Debug message");
+
+      expect(stdoutCalls).toHaveLength(1);
+      const output = JSON.parse(stdoutCalls[0].replace("\n", ""));
+      expect(output.level).toBe("debug");
+    });
+  });
+
+  describe("log level filtering", () => {
+    it("filters debug messages at info level (default)", () => {
+      delete process.env.LOG_LEVEL;
+      const log = createLogger();
+      log.debug("Should not appear");
+
+      expect(stdoutCalls).toHaveLength(0);
+    });
+
+    it("filters debug and info at warn level", () => {
+      process.env.LOG_LEVEL = "warn";
+      const log = createLogger();
+      log.debug("Debug");
+      log.info("Info");
+      log.warn("Warn");
+      log.error("Error");
+
+      expect(stdoutCalls).toHaveLength(1); // warn
+      expect(stderrCalls).toHaveLength(1); // error
+    });
+
+    it("only shows errors at error level", () => {
+      process.env.LOG_LEVEL = "error";
+      const log = createLogger();
+      log.debug("Debug");
+      log.info("Info");
+      log.warn("Warn");
+      log.error("Error");
+
+      expect(stdoutCalls).toHaveLength(0);
+      expect(stderrCalls).toHaveLength(1);
+    });
+
+    it("shows all levels at debug level", () => {
+      process.env.LOG_LEVEL = "debug";
+      const log = createLogger();
+      log.debug("Debug");
+      log.info("Info");
+      log.warn("Warn");
+      log.error("Error");
+
+      expect(stdoutCalls).toHaveLength(3); // debug, info, warn
+      expect(stderrCalls).toHaveLength(1); // error
+    });
+
+    it("defaults to info level for invalid LOG_LEVEL", () => {
+      process.env.LOG_LEVEL = "invalid";
+      const log = createLogger();
+      log.debug("Debug");
+      log.info("Info");
+
+      expect(stdoutCalls).toHaveLength(1); // only info
+    });
+
+    it("handles case-insensitive LOG_LEVEL", () => {
+      process.env.LOG_LEVEL = "DEBUG";
+      const log = createLogger();
+      log.debug("Debug");
+
+      expect(stdoutCalls).toHaveLength(1);
+    });
+  });
+
+  describe("context", () => {
+    it("includes default context in all log entries", () => {
+      const log = createLogger({ service: "test-service" });
+      log.info("Test");
+
+      const output = JSON.parse(stdoutCalls[0].replace("\n", ""));
+      expect(output.service).toBe("test-service");
+    });
+
+    it("includes call-time context", () => {
+      const log = createLogger();
+      log.info("Test", { requestId: "req-123" });
+
+      const output = JSON.parse(stdoutCalls[0].replace("\n", ""));
+      expect(output.requestId).toBe("req-123");
+    });
+
+    it("merges default and call-time context", () => {
+      const log = createLogger({ service: "my-service" });
+      log.info("Test", { requestId: "req-123" });
+
+      const output = JSON.parse(stdoutCalls[0].replace("\n", ""));
+      expect(output.service).toBe("my-service");
+      expect(output.requestId).toBe("req-123");
+    });
+
+    it("call-time context overrides default context", () => {
+      const log = createLogger({ service: "default" });
+      log.info("Test", { service: "override" });
+
+      const output = JSON.parse(stdoutCalls[0].replace("\n", ""));
+      expect(output.service).toBe("override");
+    });
+  });
+
+  describe("child logger", () => {
+    it("creates child with merged context", () => {
+      const parent = createLogger({ service: "parent" });
+      const child = parent.child({ component: "child" });
+      child.info("Test");
+
+      const output = JSON.parse(stdoutCalls[0].replace("\n", ""));
+      expect(output.service).toBe("parent");
+      expect(output.component).toBe("child");
+    });
+
+    it("child can override parent context", () => {
+      const parent = createLogger({ service: "parent" });
+      const child = parent.child({ service: "child" });
+      child.info("Test");
+
+      const output = JSON.parse(stdoutCalls[0].replace("\n", ""));
+      expect(output.service).toBe("child");
+    });
+
+    it("child does not affect parent", () => {
+      const parent = createLogger({ service: "parent" });
+      parent.child({ extra: "child-only" });
+      parent.info("Parent log");
+
+      const output = JSON.parse(stdoutCalls[0].replace("\n", ""));
+      expect(output.service).toBe("parent");
+      expect(output.extra).toBeUndefined();
+    });
+
+    it("supports nested children", () => {
+      const root = createLogger({ level: "root" });
+      const child1 = root.child({ level: "child1" });
+      const child2 = child1.child({ level: "child2" });
+      child2.info("Test");
+
+      const output = JSON.parse(stdoutCalls[0].replace("\n", ""));
+      expect(output.level).toBe("child2"); // level from context overrides log level key
+    });
+  });
+
+  describe("output format", () => {
+    it("outputs valid JSON with newline", () => {
+      const log = createLogger();
+      log.info("Test");
+
+      const call = stdoutCalls[0];
+      expect(call.endsWith("\n")).toBe(true);
+      expect(() => JSON.parse(call)).not.toThrow();
+    });
+
+    it("includes ISO timestamp", () => {
+      const log = createLogger();
+      log.info("Test");
+
+      const output = JSON.parse(stdoutCalls[0].replace("\n", ""));
+      expect(output.timestamp).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/,
+      );
+    });
+  });
+});
+
+describe("logger (default export)", () => {
+  let stdoutWrite: typeof process.stdout.write;
+  let stdoutCalls: string[];
+
+  beforeEach(() => {
+    stdoutCalls = [];
+    stdoutWrite = process.stdout.write;
+    process.stdout.write = ((chunk: string) => {
+      stdoutCalls.push(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+  });
+
+  afterEach(() => {
+    process.stdout.write = stdoutWrite;
+  });
+
+  it("is preconfigured with usopc-agent service", () => {
+    logger.info("Test");
+
+    const output = JSON.parse(stdoutCalls[0].replace("\n", ""));
+    expect(output.service).toBe("usopc-agent");
+  });
+
+  it("has all log methods", () => {
+    expect(typeof logger.debug).toBe("function");
+    expect(typeof logger.info).toBe("function");
+    expect(typeof logger.warn).toBe("function");
+    expect(typeof logger.error).toBe("function");
+    expect(typeof logger.child).toBe("function");
+  });
+});

--- a/packages/shared/src/validation.test.ts
+++ b/packages/shared/src/validation.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import {
+  paginationSchema,
+  uuidSchema,
+  sportOrgIdSchema,
+  topicDomainSchema,
+  channelSchema,
+  TOPIC_DOMAINS,
+  CHANNELS,
+} from "./validation.js";
+
+describe("paginationSchema", () => {
+  it("uses default values when not provided", () => {
+    const result = paginationSchema.parse({});
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+  });
+
+  it("accepts valid page and limit", () => {
+    const result = paginationSchema.parse({ page: 5, limit: 50 });
+    expect(result.page).toBe(5);
+    expect(result.limit).toBe(50);
+  });
+
+  it("coerces string numbers to integers", () => {
+    const result = paginationSchema.parse({ page: "3", limit: "25" });
+    expect(result.page).toBe(3);
+    expect(result.limit).toBe(25);
+  });
+
+  it("rejects page less than 1", () => {
+    expect(() => paginationSchema.parse({ page: 0 })).toThrow();
+    expect(() => paginationSchema.parse({ page: -1 })).toThrow();
+  });
+
+  it("rejects limit less than 1", () => {
+    expect(() => paginationSchema.parse({ limit: 0 })).toThrow();
+    expect(() => paginationSchema.parse({ limit: -5 })).toThrow();
+  });
+
+  it("rejects limit greater than 100", () => {
+    expect(() => paginationSchema.parse({ limit: 101 })).toThrow();
+    expect(() => paginationSchema.parse({ limit: 1000 })).toThrow();
+  });
+
+  it("accepts limit at boundaries", () => {
+    expect(paginationSchema.parse({ limit: 1 }).limit).toBe(1);
+    expect(paginationSchema.parse({ limit: 100 }).limit).toBe(100);
+  });
+
+  it("rejects floats (requires integers)", () => {
+    expect(() => paginationSchema.parse({ page: 2.7, limit: 30.9 })).toThrow();
+    expect(() =>
+      paginationSchema.parse({ page: 2.0, limit: 30 }),
+    ).not.toThrow(); // .0 is valid
+  });
+});
+
+describe("uuidSchema", () => {
+  it("accepts valid UUID v4", () => {
+    const uuid = "550e8400-e29b-41d4-a716-446655440000";
+    expect(uuidSchema.parse(uuid)).toBe(uuid);
+  });
+
+  it("accepts valid UUID with uppercase", () => {
+    const uuid = "550E8400-E29B-41D4-A716-446655440000";
+    expect(uuidSchema.parse(uuid)).toBe(uuid);
+  });
+
+  it("rejects invalid UUID format", () => {
+    expect(() => uuidSchema.parse("not-a-uuid")).toThrow();
+    expect(() => uuidSchema.parse("550e8400-e29b-41d4-a716")).toThrow();
+    expect(() => uuidSchema.parse("")).toThrow();
+  });
+
+  it("rejects UUID with invalid characters", () => {
+    expect(() =>
+      uuidSchema.parse("550e8400-e29b-41d4-a716-44665544000g"),
+    ).toThrow();
+  });
+});
+
+describe("sportOrgIdSchema", () => {
+  it("accepts valid sport org ID", () => {
+    expect(sportOrgIdSchema.parse("usa-swimming")).toBe("usa-swimming");
+  });
+
+  it("trims whitespace", () => {
+    expect(sportOrgIdSchema.parse("  usa-track  ")).toBe("usa-track");
+  });
+
+  it("lowercases input", () => {
+    expect(sportOrgIdSchema.parse("USA-GYMNASTICS")).toBe("usa-gymnastics");
+    expect(sportOrgIdSchema.parse("UsA-TeNnIs")).toBe("usa-tennis");
+  });
+
+  it("trims and lowercases together", () => {
+    expect(sportOrgIdSchema.parse("  USA-FENCING  ")).toBe("usa-fencing");
+  });
+
+  it("rejects empty string", () => {
+    expect(() => sportOrgIdSchema.parse("")).toThrow();
+  });
+
+  it("rejects whitespace-only string", () => {
+    expect(() => sportOrgIdSchema.parse("   ")).toThrow();
+  });
+
+  it("accepts single character", () => {
+    expect(sportOrgIdSchema.parse("x")).toBe("x");
+  });
+});
+
+describe("topicDomainSchema", () => {
+  it("accepts all valid topic domains", () => {
+    TOPIC_DOMAINS.forEach((domain) => {
+      expect(topicDomainSchema.parse(domain)).toBe(domain);
+    });
+  });
+
+  it("includes expected domains", () => {
+    expect(TOPIC_DOMAINS).toContain("team_selection");
+    expect(TOPIC_DOMAINS).toContain("dispute_resolution");
+    expect(TOPIC_DOMAINS).toContain("safesport");
+    expect(TOPIC_DOMAINS).toContain("anti_doping");
+    expect(TOPIC_DOMAINS).toContain("eligibility");
+    expect(TOPIC_DOMAINS).toContain("governance");
+    expect(TOPIC_DOMAINS).toContain("athlete_rights");
+  });
+
+  it("has exactly 7 domains", () => {
+    expect(TOPIC_DOMAINS.length).toBe(7);
+  });
+
+  it("rejects invalid domain", () => {
+    expect(() => topicDomainSchema.parse("invalid_domain")).toThrow();
+    expect(() => topicDomainSchema.parse("")).toThrow();
+    expect(() => topicDomainSchema.parse("TEAM_SELECTION")).toThrow(); // case sensitive
+  });
+});
+
+describe("channelSchema", () => {
+  it("accepts all valid channels", () => {
+    CHANNELS.forEach((channel) => {
+      expect(channelSchema.parse(channel)).toBe(channel);
+    });
+  });
+
+  it("includes expected channels", () => {
+    expect(CHANNELS).toContain("web");
+    expect(CHANNELS).toContain("api");
+    expect(CHANNELS).toContain("slack");
+  });
+
+  it("has exactly 3 channels", () => {
+    expect(CHANNELS.length).toBe(3);
+  });
+
+  it("rejects invalid channel", () => {
+    expect(() => channelSchema.parse("discord")).toThrow();
+    expect(() => channelSchema.parse("")).toThrow();
+    expect(() => channelSchema.parse("WEB")).toThrow(); // case sensitive
+  });
+});


### PR DESCRIPTION
## Summary

Adds comprehensive unit tests for the `@usopc/shared` package, covering all exported utilities.

Closes #10

## Tests Added

### env.test.ts (26 tests)
- `getRequiredEnv()` — returns value, throws on missing/empty
- `getOptionalEnv()` — returns value, default, or undefined
- `getDatabaseUrl()` — env var priority, SST Resource fallback, URL encoding
- `getSecretValue()` — env var priority, SST Resource fallback, error messages
- `isProduction()` / `isDevelopment()` — NODE_ENV checks

### errors.test.ts (22 tests)
- `AppError` — defaults, custom options, toJSON serialization
- `NotFoundError`, `ValidationError`, `AuthenticationError`, `RateLimitError`, `ExternalServiceError`, `IngestionError` — status codes, default messages, context handling

### logger.test.ts (22 tests)
- Log levels (debug, info, warn, error)
- Level filtering based on LOG_LEVEL env var
- Default and call-time context merging
- Child logger context inheritance
- JSON output format with timestamps

### validation.test.ts (27 tests)
- `paginationSchema` — defaults, coercion, min/max bounds
- `uuidSchema` — valid/invalid UUID formats
- `sportOrgIdSchema` — trim, lowercase, min length
- `topicDomainSchema` — all 7 domains
- `channelSchema` — web, api, slack

## Verification

- [x] `pnpm --filter @usopc/shared test` — 97 tests pass
- [x] `pnpm --filter @usopc/shared typecheck` — passes
- [x] `npx prettier --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)