### PR TITLE
docs: Consolidate documentation into docs/ folder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,105 +6,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 USOPC Athlete Support Agent — an AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Built as a serverless monorepo deployed to AWS via SST v3.
 
-## Commands
-
-```bash
-# Monorepo-wide (via Turbo)
-pnpm build          # Build all packages
-pnpm dev            # Run dev servers via SST (injects secrets)
-pnpm test           # Run all tests
-pnpm typecheck      # Type-check all packages
-pnpm lint           # Lint all packages
-
-# Single-package testing
-pnpm --filter @usopc/core test
-pnpm --filter @usopc/ingestion test
-pnpm --filter @usopc/api test
-
-# Single test file (vitest pattern)
-pnpm --filter @usopc/ingestion test -- src/db.test.ts
-
-# Database (local Docker Postgres with pgvector)
-pnpm db:up          # Start Postgres container
-pnpm db:down        # Stop container
-pnpm db:migrate     # Run migrations (via @usopc/api)
-
-# Ingestion scripts (require SST context)
-pnpm ingest                        # Run document ingestion
-pnpm ingest -- --source <id>       # Ingest single source
-pnpm seed                          # Seed Postgres database
-pnpm seed:dynamodb                 # Seed DynamoDB source configs from JSON
-pnpm seed:dynamodb -- --dry-run    # Preview migration
-pnpm sources list                  # List source configs from DynamoDB
-pnpm sources show <id>             # Show source details
-pnpm sources enable <id>           # Enable a source
-pnpm sources disable <id>          # Disable a source
-
-# Local development database
-export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/usopc_athlete_support
-```
-
-## Architecture
-
-```
-packages/
-  core/        @usopc/core       — LangGraph agent, RAG, vector store, tools
-  ingestion/   @usopc/ingestion  — Document ETL: load → clean → split → embed → store
-  shared/      @usopc/shared     — Logger, env helpers, error classes, Zod schemas
-
-apps/
-  api/         @usopc/api        — tRPC + Hono backend (Lambda)
-  slack/       @usopc/slack      — Slack Bolt bot (Lambda)
-  web/         @usopc/web        — Next.js 15 frontend (React 19, Tailwind 4)
-```
-
-**Dependency flow**: `apps/*` → `packages/core` → `packages/shared`; `packages/ingestion` → `packages/core` + `packages/shared`.
-
-### AI Agent (LangGraph)
-
-The core agent is a compiled LangGraph state machine in `packages/core/src/agent/graph.ts`:
-
-```
-START → classifier → (routeByDomain) → clarify | retriever | escalate
-  clarify → END
-  retriever → (needsMoreInfo) → synthesizer | researcher
-  researcher → synthesizer
-  synthesizer → citationBuilder → disclaimerGuard → END
-  escalate → citationBuilder → disclaimerGuard → END
-```
-
-Key nodes: classifier (query analysis + clarification detection), clarify (asks for more info on ambiguous queries), retriever (pgvector RAG), researcher (Tavily web search), synthesizer (Anthropic, with intent-based response formatting), citationBuilder, disclaimerGuard, escalate. Agent tools are in `packages/core/src/tools/`.
-
-### Ingestion Pipeline
-
-Fan-out architecture via SQS FIFO queue (production only):
-
-- **Source configs**: Stored in DynamoDB (`SourceConfigs` table) in production, loaded from `data/sources/*.json` in development. Entity class in `packages/ingestion/src/entities/SourceConfigEntity.ts`.
-- **Cron** (`packages/ingestion/src/cron.ts`): Weekly EventBridge trigger. Loads source configs, fetches content with retry logic (`fetchWithRetry`), computes SHA-256 hash, skips unchanged sources, enqueues changed ones to SQS. Tracks success/failure in DynamoDB.
-- **Worker** (`packages/ingestion/src/worker.ts`): Processes one source per SQS message. Pipeline: load (PDF/HTML/text) → clean → split → enrich metadata → extract sections → batch embed (OpenAI) → store in pgvector. Handles `QuotaExhaustedError` by purging the queue.
-- **Document storage**: Fetched documents cached in S3 (`DocumentsBucket`) for resilience and audit trail.
-
-### Infrastructure (SST)
-
-Defined in `sst.config.ts`. Production uses Aurora Serverless v2 with pgvector; dev stages use local Docker Postgres at `postgresql://postgres:postgres@localhost:5432/usopc_athlete_support`.
-
-**SST Resources:**
-- **Secrets**: `AnthropicApiKey`, `OpenaiApiKey`, `TavilyApiKey`, `LangchainApiKey`, `SlackBotToken`, `SlackSigningSecret`
-- **DynamoDB**: `SourceConfigs` table (source config management with GSIs for ngbId and enabled status)
-- **S3**: `DocumentsBucket` (cached documents with versioning)
-- **APIs**: `Api` (main tRPC), `SlackApi` (Slack events)
-
-Use `pnpm dev` (which runs `sst dev`) for local development to inject secrets. For scripts needing SST resources, use `sst shell -- <command>` or the wrapped npm scripts.
-
-## Formatting
-
-Prettier with default settings (no config file). `.prettierignore` excludes `pnpm-lock.yaml` and auto-generated `sst-env.d.ts` files. Always format files before committing:
-
-```bash
-npx prettier --write "path/to/file.ts"   # Format specific files
-npx prettier --check .                   # Check entire repo
-```
-
 ## Workflow
 
 **Never commit directly to `main`.** Always create a feature branch and open a pull request.
@@ -165,16 +66,33 @@ Each issue should include a clear title, a description of what needs to be done 
 
 When writing code that is intentionally incomplete or deferred, add a `// TODO:` comment in the source with a short explanation and reference the GitHub issue number (e.g., `// TODO: Wire to agent graph (#5)`). This keeps the codebase searchable and links inline markers to tracked work.
 
-## Key Conventions
+## Documentation
+
+Detailed documentation is in the `docs/` folder:
+
+- [Architecture](./docs/architecture.md) — Package structure, AI agent (LangGraph), ingestion pipeline, infrastructure (SST)
+- [Commands](./docs/commands.md) — Full CLI commands reference
+- [Deployment](./docs/deployment.md) — Production deployment guide
+- [Conventions](./docs/conventions.md) — Formatting, testing, and technical conventions
+
+## Quick Reference
+
+### Common Commands
+
+```bash
+pnpm dev                              # Start dev servers via SST
+pnpm test                             # Run all tests
+pnpm --filter @usopc/<pkg> test       # Test single package
+pnpm typecheck                        # Type-check all packages
+npx prettier --write <files>          # Format files
+```
+
+### Key Conventions
 
 - **Package manager**: pnpm 9.x with workspaces. Node >= 20 required.
-- **Module system**: ESM throughout. TypeScript with `"module": "ESNext"`, `"moduleResolution": "bundler"`. Use `.js` extensions in imports (e.g., `import { foo } from "./bar.js"`).
-- **Testing**: Vitest with no config files — uses defaults. Tests are co-located as `*.test.ts` in `src/`. Mocking pattern: `vi.mock()` with factory functions, declare mock fns above the `vi.mock()` call (but beware hoisting — class definitions used inside `vi.mock()` factories must be defined inside the factory or imported after).
-- **Build orchestration**: Turbo. `build`, `test`, `typecheck`, and `lint` depend on `^build` (deps build first).
-- **Environment resolution**: `@usopc/shared` provides `getDatabaseUrl()` (checks `DATABASE_URL` env, then SST Resource), `getSecretValue(envKey, sstResourceName)` (checks env, then SST Secret), and `getOptionalSecretValue(envKey, sstResourceName, defaultValue)` for optional config with defaults.
-- **Configuration via SST Secrets**: Always use SST secrets for configuration values, not plain environment variables. For required secrets, use `new sst.Secret("Name")`. For optional config with defaults, use `new sst.Secret("Name", "defaultValue")` and read via `getOptionalSecretValue()`. Never rely on `getOptionalEnv()` for configuration that should be managed through SST.
-- **SST secret naming**: SST secrets use PascalCase (`OpenaiApiKey`), env vars use SCREAMING_SNAKE_CASE (`OPENAI_API_KEY`). Use `getSecretValue("OPENAI_API_KEY", "OpenaiApiKey")` to check both.
-- **Scripts needing AWS resources**: Wrap with `sst shell --` in package.json (e.g., `"ingest": "sst shell -- tsx src/scripts/ingest.ts"`). This injects SST Resource bindings. Don't add `process.env.SOME_CONFIG` fallbacks—use SST Resources only.
-- **DynamoDB GSI keys cannot be null**: When using a Global Secondary Index, omit the attribute entirely rather than setting it to `null`. This creates a sparse index where items without the attribute aren't indexed.
-- **Path resolution in scripts**: Scripts in `packages/*/src/scripts/` need 4 levels up (`../../../../`) to reach repo root.
-- **Database**: PostgreSQL with pgvector. Schema includes `document_chunks` (embeddings with HNSW index), `conversations`, `messages`, `feedback`, `ingestion_status`. Migrations run through the API package.
+- **Module system**: ESM throughout. Use `.js` extensions in imports.
+- **Testing**: Vitest, tests co-located as `*.test.ts` in `src/`.
+- **SST secret naming**: PascalCase for SST (`OpenaiApiKey`), SCREAMING_SNAKE_CASE for env vars (`OPENAI_API_KEY`).
+- **Scripts needing AWS**: Wrap with `sst shell --` in package.json.
+
+See [docs/conventions.md](./docs/conventions.md) for the full list.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,88 @@
+# Architecture
+
+USOPC Athlete Support Agent is a serverless monorepo deployed to AWS via [SST v3](https://sst.dev/).
+
+## Package Structure
+
+```
+packages/
+  core/        @usopc/core       — LangGraph agent, RAG, vector store, tools
+  ingestion/   @usopc/ingestion  — Document ETL: load → clean → split → embed → store
+  shared/      @usopc/shared     — Logger, env helpers, error classes, Zod schemas
+
+apps/
+  api/         @usopc/api        — tRPC + Hono backend (Lambda)
+  slack/       @usopc/slack      — Slack Bolt bot (Lambda)
+  web/         @usopc/web        — Next.js 15 frontend (React 19, Tailwind 4)
+```
+
+**Dependency flow**: `apps/*` → `packages/core` → `packages/shared`; `packages/ingestion` → `packages/core` + `packages/shared`.
+
+## AI Agent (LangGraph)
+
+The core agent is a compiled [LangGraph](https://langchain-ai.github.io/langgraph/) state machine in `packages/core/src/agent/graph.ts`:
+
+```
+START → classifier → clarify | retriever | escalate
+             ↓            ↓          ↓
+        needsClarification?      needsMoreInfo?
+             ↓                  ↓       ↓
+            END          synthesizer  researcher
+                              ↓           ↓
+                              └─────┬─────┘
+                                    ↓
+                             citationBuilder → disclaimerGuard → END
+```
+
+**Routing logic**:
+
+```
+START → classifier → (routeByDomain) → clarify | retriever | escalate
+  clarify → END
+  retriever → (needsMoreInfo) → synthesizer | researcher
+  researcher → synthesizer
+  synthesizer → citationBuilder → disclaimerGuard → END
+  escalate → citationBuilder → disclaimerGuard → END
+```
+
+**Nodes**:
+
+- `classifier`: Analyzes query to determine domain, intent, and whether clarification is needed
+- `clarify`: Returns a clarifying question when the query is ambiguous
+- `retriever`: Performs pgvector similarity search on embedded documents
+- `researcher`: Queries Tavily for additional web context
+- `synthesizer`: Generates the response via Claude (with adaptive formatting based on query intent)
+- `citationBuilder`: Extracts and formats source citations
+- `disclaimerGuard`: Adds disclaimers for sensitive topics
+- `escalate`: Routes urgent matters (abuse reports, imminent deadlines) to appropriate authorities
+
+Agent tools are in `packages/core/src/tools/`.
+
+## Ingestion Pipeline
+
+Fan-out architecture via SQS FIFO queue (production only):
+
+- **Source configs**: Stored in DynamoDB (`SourceConfigs` table) in production, loaded from `data/sources/*.json` in development. Entity class in `packages/ingestion/src/entities/SourceConfigEntity.ts`.
+- **Cron** (`packages/ingestion/src/cron.ts`): Weekly EventBridge trigger. Loads source configs, fetches content with retry logic (`fetchWithRetry`), computes SHA-256 hash, skips unchanged sources, enqueues changed ones to SQS. Tracks success/failure in DynamoDB.
+- **Worker** (`packages/ingestion/src/worker.ts`): Processes one source per SQS message. Pipeline: load (PDF/HTML/text) → clean → split → enrich metadata → extract sections → batch embed (OpenAI) → store in pgvector. Handles `QuotaExhaustedError` by purging the queue.
+- **Document storage**: Fetched documents cached in S3 (`DocumentsBucket`) for resilience and audit trail.
+
+## Infrastructure (SST)
+
+Defined in `sst.config.ts`. Production uses Aurora Serverless v2 with pgvector; dev stages use local Docker Postgres at `postgresql://postgres:postgres@localhost:5432/usopc_athlete_support`.
+
+| Component | Development                         | Production               |
+| --------- | ----------------------------------- | ------------------------ |
+| Database  | Local Docker Postgres with pgvector | Aurora Serverless v2     |
+| API       | Local Lambda emulation via SST      | API Gateway + Lambda     |
+| Web       | Next.js dev server                  | CloudFront + Lambda@Edge |
+| Secrets   | SST dev secrets                     | SST encrypted secrets    |
+
+**SST Resources:**
+
+- **Secrets**: `AnthropicApiKey`, `OpenaiApiKey`, `TavilyApiKey`, `LangchainApiKey`, `SlackBotToken`, `SlackSigningSecret`
+- **DynamoDB**: `SourceConfigs` table (source config management with GSIs for ngbId and enabled status)
+- **S3**: `DocumentsBucket` (cached documents with versioning)
+- **APIs**: `Api` (main tRPC), `SlackApi` (Slack events)
+
+Use `pnpm dev` (which runs `sst dev`) for local development to inject secrets. For scripts needing SST resources, use `sst shell -- <command>` or the wrapped npm scripts.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,58 @@
+# Commands Reference
+
+## Monorepo-wide (via Turbo)
+
+```bash
+pnpm build          # Build all packages
+pnpm dev            # Run dev servers via SST (injects secrets)
+pnpm test           # Run all tests
+pnpm typecheck      # Type-check all packages
+pnpm lint           # Lint all packages
+```
+
+## Single-package Commands
+
+```bash
+# Testing a specific package
+pnpm --filter @usopc/core test
+pnpm --filter @usopc/ingestion test
+pnpm --filter @usopc/api test
+
+# Single test file (vitest pattern)
+pnpm --filter @usopc/ingestion test -- src/db.test.ts
+
+# Type-check a specific package
+pnpm --filter @usopc/api typecheck
+```
+
+## Database (Local Docker Postgres with pgvector)
+
+```bash
+pnpm db:up          # Start Postgres container
+pnpm db:down        # Stop container
+pnpm db:migrate     # Run migrations (via @usopc/api)
+
+# Local development database URL
+export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/usopc_athlete_support
+```
+
+## Ingestion Scripts
+
+All ingestion scripts require SST context (secrets and resources).
+
+```bash
+pnpm ingest                        # Run document ingestion
+pnpm ingest -- --source <id>       # Ingest single source
+pnpm seed                          # Seed Postgres database
+pnpm seed:dynamodb                 # Seed DynamoDB source configs from JSON
+pnpm seed:dynamodb -- --dry-run    # Preview migration
+```
+
+## Source Management
+
+```bash
+pnpm sources list                  # List source configs from DynamoDB
+pnpm sources show <id>             # Show source details
+pnpm sources enable <id>           # Enable a source
+pnpm sources disable <id>          # Disable a source
+```

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,24 @@
+# Conventions
+
+## Formatting
+
+Prettier with default settings (no config file). `.prettierignore` excludes `pnpm-lock.yaml` and auto-generated `sst-env.d.ts` files. Always format files before committing:
+
+```bash
+npx prettier --write "path/to/file.ts"   # Format specific files
+npx prettier --check .                   # Check entire repo
+```
+
+## Key Conventions
+
+- **Package manager**: pnpm 9.x with workspaces. Node >= 20 required.
+- **Module system**: ESM throughout. TypeScript with `"module": "ESNext"`, `"moduleResolution": "bundler"`. Use `.js` extensions in imports (e.g., `import { foo } from "./bar.js"`).
+- **Testing**: Vitest with no config files — uses defaults. Tests are co-located as `*.test.ts` in `src/`. Mocking pattern: `vi.mock()` with factory functions, declare mock fns above the `vi.mock()` call (but beware hoisting — class definitions used inside `vi.mock()` factories must be defined inside the factory or imported after).
+- **Build orchestration**: Turbo. `build`, `test`, `typecheck`, and `lint` depend on `^build` (deps build first).
+- **Environment resolution**: `@usopc/shared` provides `getDatabaseUrl()` (checks `DATABASE_URL` env, then SST Resource), `getSecretValue(envKey, sstResourceName)` (checks env, then SST Secret), and `getOptionalSecretValue(envKey, sstResourceName, defaultValue)` for optional config with defaults.
+- **Configuration via SST Secrets**: Always use SST secrets for configuration values, not plain environment variables. For required secrets, use `new sst.Secret("Name")`. For optional config with defaults, use `new sst.Secret("Name", "defaultValue")` and read via `getOptionalSecretValue()`. Never rely on `getOptionalEnv()` for configuration that should be managed through SST.
+- **SST secret naming**: SST secrets use PascalCase (`OpenaiApiKey`), env vars use SCREAMING_SNAKE_CASE (`OPENAI_API_KEY`). Use `getSecretValue("OPENAI_API_KEY", "OpenaiApiKey")` to check both.
+- **Scripts needing AWS resources**: Wrap with `sst shell --` in package.json (e.g., `"ingest": "sst shell -- tsx src/scripts/ingest.ts"`). This injects SST Resource bindings. Don't add `process.env.SOME_CONFIG` fallbacks—use SST Resources only.
+- **DynamoDB GSI keys cannot be null**: When using a Global Secondary Index, omit the attribute entirely rather than setting it to `null`. This creates a sparse index where items without the attribute aren't indexed.
+- **Path resolution in scripts**: Scripts in `packages/*/src/scripts/` need 4 levels up (`../../../../`) to reach repo root.
+- **Database**: PostgreSQL with pgvector. Schema includes `document_chunks` (embeddings with HNSW index), `conversations`, `messages`, `feedback`, `ingestion_status`. Migrations run through the API package.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,50 @@
+# Production Deployment
+
+## Prerequisites
+
+- AWS account with appropriate permissions
+- SST CLI installed (`pnpm add -g sst`)
+- Production secrets configured
+
+## 1. Set Production Secrets
+
+```bash
+sst secret set AnthropicApiKey <key> --stage production
+sst secret set OpenaiApiKey <key> --stage production
+sst secret set TavilyApiKey <key> --stage production
+sst secret set SlackBotToken <token> --stage production
+sst secret set SlackSigningSecret <secret> --stage production
+```
+
+## 2. Deploy
+
+```bash
+sst deploy --stage production
+```
+
+This provisions:
+
+- Aurora Serverless v2 PostgreSQL cluster with pgvector
+- API Gateway + Lambda for the tRPC API
+- API Gateway + Lambda for Slack webhooks
+- CloudFront distribution + Lambda@Edge for the Next.js app
+- EventBridge + SQS + Lambda for the weekly ingestion pipeline
+
+## 3. Run Initial Ingestion
+
+After the first deployment, trigger the ingestion pipeline to populate the knowledge base:
+
+```bash
+# Via AWS Console: manually invoke the IngestionCron Lambda
+# Or wait for the weekly scheduled trigger
+```
+
+## Environment Outputs
+
+After deployment, SST outputs the service URLs:
+
+```
+apiUrl:   https://xxx.execute-api.us-east-1.amazonaws.com
+webUrl:   https://xxx.cloudfront.net
+slackUrl: https://xxx.execute-api.us-east-1.amazonaws.com/slack/events
+```


### PR DESCRIPTION
## Summary

- Extract shared content from README.md and CLAUDE.md into dedicated docs/ files to eliminate duplication
- Create `docs/` folder with focused, single-purpose documentation files
- Simplify main documentation files with links to detailed docs

## Changes

### New Files
- `docs/architecture.md` — Package structure, AI agent (LangGraph), ingestion pipeline, infrastructure (SST)
- `docs/commands.md` — Full CLI commands reference
- `docs/deployment.md` — Production deployment guide
- `docs/conventions.md` — Formatting, testing, and technical conventions

### Modified Files
- `README.md` — Simplified to focus on features, local dev setup, and contributing. Architecture/commands/deployment sections replaced with links to docs/
- `CLAUDE.md` — Restructured with Workflow emphasized at top (git worktrees, PRs, issue tracking). Detailed content moved to docs/ with links

## Test plan

- [x] All markdown files formatted with Prettier
- [x] Links in README.md and CLAUDE.md point to valid docs/ files
- [x] No content lost during consolidation

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)