### PR TITLE
fix: Backfill denormalized document_chunks columns from JSONB metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@ Slack integration is under development. See [#7](https://github.com/rosinbum/uso
 See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
-**Tracked build time:** 16.2 hours
+**Tracked build time:** 16.9 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-05T12:13:35.424Z
+- Last updated: 2026-02-05T13:03:25.780Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/api/src/db/sources.ts
+++ b/apps/api/src/db/sources.ts
@@ -59,16 +59,13 @@ interface StatsRow {
   last_ingested_at: Date | null;
 }
 
-// LangChain's PGVectorStore stores metadata in a JSONB column but does not
-// populate the denormalized text columns. COALESCE reads metadata first, then
-// falls back to the column (for when the ingestion pipeline is fixed).
 const COL = {
-  source_url: "COALESCE(metadata->>'source_url', source_url)",
-  document_title: "COALESCE(metadata->>'document_title', document_title)",
-  document_type: "COALESCE(metadata->>'document_type', document_type)",
-  ngb_id: "COALESCE(metadata->>'ngb_id', ngb_id)",
-  topic_domain: "COALESCE(metadata->>'topic_domain', topic_domain)",
-  authority_level: "COALESCE(metadata->>'authority_level', authority_level)",
+  source_url: "source_url",
+  document_title: "document_title",
+  document_type: "document_type",
+  ngb_id: "ngb_id",
+  topic_domain: "topic_domain",
+  authority_level: "authority_level",
 } as const;
 
 /**

--- a/apps/web/app/api/sources/route.ts
+++ b/apps/web/app/api/sources/route.ts
@@ -23,16 +23,13 @@ interface StatsRow {
   last_ingested_at: Date | null;
 }
 
-// LangChain's PGVectorStore stores metadata in a JSONB column but does not
-// populate the denormalized text columns. COALESCE reads metadata first, then
-// falls back to the column (for when the ingestion pipeline is fixed).
 const COL = {
-  source_url: "COALESCE(metadata->>'source_url', source_url)",
-  document_title: "COALESCE(metadata->>'document_title', document_title)",
-  document_type: "COALESCE(metadata->>'document_type', document_type)",
-  ngb_id: "COALESCE(metadata->>'ngb_id', ngb_id)",
-  topic_domain: "COALESCE(metadata->>'topic_domain', topic_domain)",
-  authority_level: "COALESCE(metadata->>'authority_level', authority_level)",
+  source_url: "source_url",
+  document_title: "document_title",
+  document_type: "document_type",
+  ngb_id: "ngb_id",
+  topic_domain: "topic_domain",
+  authority_level: "authority_level",
 } as const;
 
 export async function GET(request: Request) {


### PR DESCRIPTION
## Summary

- Add `backfillDenormalizedColumns()` to the ingestion pipeline that runs an UPDATE after `addDocuments()` to populate `source_url`, `document_title`, `document_type`, `ngb_id`, `topic_domain`, `authority_level`, and `section_title` from the JSONB `metadata` column
- Remove `COALESCE(metadata->>'field', column)` workarounds from `apps/api/src/db/sources.ts` and `apps/web/app/api/sources/route.ts`, replacing with direct column references
- The backfill query only targets rows where `source_url IS NULL AND metadata->>'source_url' IS NOT NULL`, so it also fixes existing data on first run

## Test plan

- [x] New tests for `backfillDenormalizedColumns` (connects, runs UPDATE, closes client; returns 0 when nothing to update; closes client on error)
- [x] `ingestSource` test verifies backfill runs after embedding
- [x] Updated `sources.test.ts` to assert direct column queries (no COALESCE)
- [x] All existing tests pass across ingestion, API, and web packages
- [x] Typecheck passes for all three packages

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)