### PR TITLE
fix: Resolve unhandled rejection warnings in fetchWithRetry tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,10 @@ Slack integration is under development. See [#7](https://github.com/rosinbum/uso
 See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
-**Tracked build time:** 16.9 hours
+**Tracked build time:** 17.1 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-05T13:03:25.780Z
+- Last updated: 2026-02-05T13:12:01.665Z
 <!-- HOURS:END -->
 
 ## License

--- a/packages/ingestion/src/loaders/fetchWithRetry.test.ts
+++ b/packages/ingestion/src/loaders/fetchWithRetry.test.ts
@@ -114,15 +114,13 @@ describe("fetchWithRetry", () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(400));
 
       const promise = fetchWithRetry("https://example.com/doc.pdf");
-      await vi.runAllTimersAsync();
-
-      try {
-        await promise;
-        expect.fail("Expected promise to reject");
-      } catch (error) {
+      const assertion = expect(promise).rejects.toSatisfy((error: unknown) => {
         expect(error).toBeInstanceOf(FetchWithRetryError);
         expect((error as FetchWithRetryError).message).toContain("400");
-      }
+        return true;
+      });
+      await vi.runAllTimersAsync();
+      await assertion;
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
@@ -130,14 +128,9 @@ describe("fetchWithRetry", () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(401));
 
       const promise = fetchWithRetry("https://example.com/doc.pdf");
+      const assertion = expect(promise).rejects.toThrow(FetchWithRetryError);
       await vi.runAllTimersAsync();
-
-      try {
-        await promise;
-        expect.fail("Expected promise to reject");
-      } catch (error) {
-        expect(error).toBeInstanceOf(FetchWithRetryError);
-      }
+      await assertion;
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
@@ -145,14 +138,9 @@ describe("fetchWithRetry", () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(403));
 
       const promise = fetchWithRetry("https://example.com/doc.pdf");
+      const assertion = expect(promise).rejects.toThrow(FetchWithRetryError);
       await vi.runAllTimersAsync();
-
-      try {
-        await promise;
-        expect.fail("Expected promise to reject");
-      } catch (error) {
-        expect(error).toBeInstanceOf(FetchWithRetryError);
-      }
+      await assertion;
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
@@ -160,14 +148,9 @@ describe("fetchWithRetry", () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(404));
 
       const promise = fetchWithRetry("https://example.com/doc.pdf");
+      const assertion = expect(promise).rejects.toThrow(FetchWithRetryError);
       await vi.runAllTimersAsync();
-
-      try {
-        await promise;
-        expect.fail("Expected promise to reject");
-      } catch (error) {
-        expect(error).toBeInstanceOf(FetchWithRetryError);
-      }
+      await assertion;
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
@@ -183,9 +166,9 @@ describe("fetchWithRetry", () => {
         maxRetries: 3,
         initialDelayMs: 100,
       });
+      const assertion = expect(promise).rejects.toThrow(FetchWithRetryError);
       await vi.runAllTimersAsync();
-
-      await expect(promise).rejects.toThrow(FetchWithRetryError);
+      await assertion;
       // Initial attempt + 3 retries = 4 total calls
       expect(mockFetch).toHaveBeenCalledTimes(4);
     });
@@ -199,9 +182,9 @@ describe("fetchWithRetry", () => {
         maxRetries: 2,
         initialDelayMs: 100,
       });
+      const assertion = expect(promise).rejects.toThrow(FetchWithRetryError);
       await vi.runAllTimersAsync();
-
-      await expect(promise).rejects.toThrow(FetchWithRetryError);
+      await assertion;
       // Initial attempt + 2 retries = 3 total calls
       expect(mockFetch).toHaveBeenCalledTimes(3);
     });
@@ -233,11 +216,11 @@ describe("fetchWithRetry", () => {
         maxRetries: 0,
         initialDelayMs: 100,
       });
+      const assertion = expect(promise).rejects.toThrow(FetchWithRetryError);
 
       // Advance past the timeout
       await vi.advanceTimersByTimeAsync(6000);
-
-      await expect(promise).rejects.toThrow(FetchWithRetryError);
+      await assertion;
     });
 
     it("passes AbortSignal to fetch", async () => {
@@ -418,32 +401,28 @@ describe("fetchWithRetry", () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(404));
 
       const promise = fetchWithRetry("https://example.com/doc.pdf");
-      await vi.runAllTimersAsync();
-
-      try {
-        await promise;
-        expect.fail("Expected promise to reject");
-      } catch (error) {
+      const assertion = expect(promise).rejects.toSatisfy((error: unknown) => {
         expect(error).toBeInstanceOf(FetchWithRetryError);
         expect((error as FetchWithRetryError).message).toContain(
           "https://example.com/doc.pdf",
         );
-      }
+        return true;
+      });
+      await vi.runAllTimersAsync();
+      await assertion;
     });
 
     it("includes HTTP status in error for non-retryable responses", async () => {
       mockFetch.mockResolvedValueOnce(createMockResponse(404));
 
       const promise = fetchWithRetry("https://example.com/doc.pdf");
-      await vi.runAllTimersAsync();
-
-      try {
-        await promise;
-        expect.fail("Expected promise to reject");
-      } catch (error) {
+      const assertion = expect(promise).rejects.toSatisfy((error: unknown) => {
         expect(error).toBeInstanceOf(FetchWithRetryError);
         expect((error as FetchWithRetryError).statusCode).toBe(404);
-      }
+        return true;
+      });
+      await vi.runAllTimersAsync();
+      await assertion;
     });
 
     it("includes attempt count in error after max retries", async () => {
@@ -455,15 +434,13 @@ describe("fetchWithRetry", () => {
         maxRetries: 2,
         initialDelayMs: 100,
       });
-      await vi.runAllTimersAsync();
-
-      try {
-        await promise;
-        expect.fail("Expected promise to reject");
-      } catch (error) {
+      const assertion = expect(promise).rejects.toSatisfy((error: unknown) => {
         expect(error).toBeInstanceOf(FetchWithRetryError);
         expect((error as FetchWithRetryError).attempts).toBe(3);
-      }
+        return true;
+      });
+      await vi.runAllTimersAsync();
+      await assertion;
     });
   });
 });


### PR DESCRIPTION
## Summary

- Register rejection handlers (via `expect().rejects`) **before** advancing fake timers in 10 tests that were producing `PromiseRejectionHandledWarning`
- Convert `try/catch` assertion blocks to `expect().rejects.toThrow()` and `expect().rejects.toSatisfy()` patterns
- The ingestion package test suite now exits cleanly (0 errors)

## Root cause

Tests created a promise, advanced fake timers (triggering the rejection), then attached a handler. Node detected the gap between rejection and handler attachment and reported it as "handled asynchronously."

## Test plan

- [x] All 114 ingestion tests pass
- [x] 0 unhandled rejection errors (previously 10)
- [x] Exit code 0 (previously exit code 1)

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)