### PR TITLE
fix: Sync hours in README header with time-tracking hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 15 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 17.3 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -132,19 +132,12 @@ Slack integration is under development. See [#7](https://github.com/rosinbum/uso
 See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
-**Tracked build time:** 17.1 hours
+**Tracked build time:** 17.3 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-05T13:12:01.665Z
+- Last updated: 2026-02-05T13:24:30.133Z
 <!-- HOURS:END -->
 
 ## License
 
 Proprietary. All rights reserved.
-
-<!-- HOURS:START -->
-**Tracked build time:** 16.7 hours
-
-- Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-05T12:42:48.083Z
-<!-- HOURS:END -->

--- a/scripts/update-hours.mjs
+++ b/scripts/update-hours.mjs
@@ -10,7 +10,10 @@ const IDLE_CUTOFF_MIN = Number(process.env.IDLE_CUTOFF_MIN ?? 10);
 const MAX_GAP_MS = IDLE_CUTOFF_MIN * 60 * 1000;
 
 function gitCommonDir(root) {
-  const out = execSync("git rev-parse --git-common-dir", { cwd: root, encoding: "utf8" }).trim();
+  const out = execSync("git rev-parse --git-common-dir", {
+    cwd: root,
+    encoding: "utf8",
+  }).trim();
   if (path.isAbsolute(out)) return out;
   return path.join(root, out);
 }
@@ -52,7 +55,9 @@ function updateReadme(readme, replacement) {
   const endIdx = readme.indexOf(end);
 
   if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) {
-    return readme.trimEnd() + "\n\n" + start + "\n" + replacement + "\n" + end + "\n";
+    return (
+      readme.trimEnd() + "\n\n" + start + "\n" + replacement + "\n" + end + "\n"
+    );
   }
 
   const before = readme.slice(0, startIdx + start.length);
@@ -61,7 +66,9 @@ function updateReadme(readme, replacement) {
 }
 
 function main() {
-  const eventsJsonl = fs.existsSync(eventsPath) ? fs.readFileSync(eventsPath, "utf8") : "";
+  const eventsJsonl = fs.existsSync(eventsPath)
+    ? fs.readFileSync(eventsPath, "utf8")
+    : "";
   const events = parseEvents(eventsJsonl);
 
   const activeMs = computeActiveMs(events);
@@ -76,8 +83,15 @@ function main() {
     `- Last updated: ${now}`,
   ].join("\n");
 
-  const readme = fs.existsSync(readmePath) ? fs.readFileSync(readmePath, "utf8") : "";
-  fs.writeFileSync(readmePath, updateReadme(readme, snippet), "utf8");
+  let readme = fs.existsSync(readmePath)
+    ? fs.readFileSync(readmePath, "utf8")
+    : "";
+  readme = updateReadme(readme, snippet);
+  readme = readme.replace(
+    /approximately \d+(\.\d+)? hours/,
+    `approximately ${pretty} hours`,
+  );
+  fs.writeFileSync(readmePath, readme, "utf8");
 
   console.log(`Updated README with ${pretty} hours.`);
 }


### PR DESCRIPTION
Closes #63

## Summary

- **`scripts/update-hours.mjs`**: Added a regex replacement step so the hook also updates the "approximately X hours" text in the WIP notice at the top of the README
- **`README.md`**: Removed the duplicate `<!-- HOURS:START -->` block that was orphaned at the bottom of the file

## Test plan

- [x] Ran `node scripts/update-hours.mjs` — WIP header and HOURS block both show the same value
- [x] Confirmed only one `<!-- HOURS:START -->` block exists in README
- [x] Pre-commit hook fired successfully during commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)