### PR TITLE
fix: Move @types/pg to shared deps for transitive type resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 17.7 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 17.8 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -132,10 +132,10 @@ Slack integration is under development. See [#7](https://github.com/rosinbum/uso
 See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
-**Tracked build time:** 17.7 hours
+**Tracked build time:** 17.8 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-05T13:49:29.723Z
+- Last updated: 2026-02-05T14:00:35.463Z
 <!-- HOURS:END -->
 
 ## License

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -12,11 +12,11 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@types/pg": "^8.11.11",
     "pg": "^8.14.1",
     "zod": "^3.24.1"
   },
   "devDependencies": {
-    "@types/pg": "^8.11.11",
     "sst": "3.17.38",
     "typescript": "^5.7.3",
     "vitest": "^2.1.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,6 +298,9 @@ importers:
 
   packages/shared:
     dependencies:
+      '@types/pg':
+        specifier: ^8.11.11
+        version: 8.16.0
       pg:
         specifier: ^8.14.1
         version: 8.18.0
@@ -305,9 +308,6 @@ importers:
         specifier: ^3.24.1
         version: 3.25.76
     devDependencies:
-      '@types/pg':
-        specifier: ^8.11.11
-        version: 8.16.0
       sst:
         specifier: 3.17.38
         version: 3.17.38


### PR DESCRIPTION
Closes #67

## Summary

- Move `@types/pg` from `devDependencies` to `dependencies` in `packages/shared`
- `getPool()` returns `pg.Pool` as its public API surface, so consumers need the type declarations to resolve `Pool.query<R>()` method signatures
- Fixes `Cannot find module 'pg'` and cascading `Parameter 'row' implicitly has an 'any' type` errors in `apps/web` typecheck

## Test plan

- [x] `pnpm typecheck` passes for all 6 packages (shared, core, web, api, ingestion, slack)
- [x] `pnpm test` passes all 678 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)