### PR TITLE
feat: Migrate DynamoDB to One Table design with dynamodb-onetable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 24.0 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 24.4 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -132,10 +132,10 @@ Slack integration is under development. See [#7](https://github.com/rosinbum/uso
 See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
-**Tracked build time:** 24.0 hours
+**Tracked build time:** 24.4 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-10T23:48:34.389Z
+- Last updated: 2026-02-11T15:11:18.805Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/web/lib/source-config.ts
+++ b/apps/web/lib/source-config.ts
@@ -1,14 +1,12 @@
 import { Resource } from "sst";
-import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
-import { SourceConfigEntity } from "@usopc/shared";
+import { createAppTable, SourceConfigEntity } from "@usopc/shared";
 
 /**
  * Factory to create a SourceConfigEntity using the SST-linked table name.
  */
 export function createSourceConfigEntity(): SourceConfigEntity {
-  const tableName = (Resource as unknown as { SourceConfigs: { name: string } })
-    .SourceConfigs.name;
-  const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
-  return new SourceConfigEntity(tableName, client);
+  const tableName = (Resource as unknown as { AppTable: { name: string } })
+    .AppTable.name;
+  const table = createAppTable(tableName);
+  return new SourceConfigEntity(table);
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,7 +14,6 @@
     "@ai-sdk/anthropic": "^1.1.6",
     "@aws-sdk/client-dynamodb": "^3.981.0",
     "@aws-sdk/client-sqs": "^3.981.0",
-    "@aws-sdk/lib-dynamodb": "^3.981.0",
     "@usopc/core": "workspace:*",
     "@usopc/shared": "workspace:*",
     "ai": "^4.1.2",

--- a/packages/core/src/agent/nodes/classifier.ts
+++ b/packages/core/src/agent/nodes/classifier.ts
@@ -1,7 +1,7 @@
 import { ChatAnthropic } from "@langchain/anthropic";
 import { HumanMessage } from "@langchain/core/messages";
 import { logger, CircuitBreakerError } from "@usopc/shared";
-import { MODEL_CONFIG } from "../../config/index.js";
+import { getModelConfig } from "../../config/index.js";
 import { buildClassifierPromptWithHistory } from "../../prompts/index.js";
 import {
   invokeAnthropic,
@@ -169,10 +169,11 @@ export async function classifierNode(
     };
   }
 
+  const config = await getModelConfig();
   const model = new ChatAnthropic({
-    model: MODEL_CONFIG.classifier.model,
-    temperature: MODEL_CONFIG.classifier.temperature,
-    maxTokens: MODEL_CONFIG.classifier.maxTokens,
+    model: config.classifier.model,
+    temperature: config.classifier.temperature,
+    maxTokens: config.classifier.maxTokens,
   });
 
   const prompt = buildClassifierPromptWithHistory(

--- a/packages/core/src/agent/nodes/escalate.ts
+++ b/packages/core/src/agent/nodes/escalate.ts
@@ -1,9 +1,5 @@
-import { ChatAnthropic } from "@langchain/anthropic";
-import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { logger } from "@usopc/shared";
-import { MODEL_CONFIG } from "../../config/index.js";
 import {
-  SYSTEM_PROMPT,
   getEscalationTargets,
   buildEscalation,
   type EscalationTarget,

--- a/packages/core/src/agent/nodes/synthesizer.ts
+++ b/packages/core/src/agent/nodes/synthesizer.ts
@@ -1,7 +1,7 @@
 import { ChatAnthropic } from "@langchain/anthropic";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { logger, CircuitBreakerError } from "@usopc/shared";
-import { MODEL_CONFIG } from "../../config/index.js";
+import { getModelConfig } from "../../config/index.js";
 import { SYSTEM_PROMPT, buildSynthesizerPrompt } from "../../prompts/index.js";
 import {
   invokeAnthropic,
@@ -171,10 +171,11 @@ export async function synthesizerNode(
     conversationContext,
   );
 
+  const config = await getModelConfig();
   const model = new ChatAnthropic({
-    model: MODEL_CONFIG.agent.model,
-    temperature: MODEL_CONFIG.agent.temperature,
-    maxTokens: MODEL_CONFIG.agent.maxTokens,
+    model: config.agent.model,
+    temperature: config.agent.temperature,
+    maxTokens: config.agent.maxTokens,
   });
 
   try {

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,4 +1,9 @@
-export { MODEL_CONFIG } from "./models.js";
+export {
+  MODEL_CONFIG,
+  getModelConfig,
+  initModelConfig,
+  type ModelConfig,
+} from "./models.js";
 export {
   RETRIEVAL_CONFIG,
   RATE_LIMIT,

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -1,3 +1,5 @@
+import type { AgentModelEntity, AgentModelConfig } from "@usopc/shared";
+
 export const MODEL_CONFIG = {
   agent: {
     model: "claude-sonnet-4-20250514",
@@ -14,3 +16,64 @@ export const MODEL_CONFIG = {
     dimensions: 1536,
   },
 } as const;
+
+export type ModelConfig = typeof MODEL_CONFIG;
+
+let cachedConfig: ModelConfig | null = null;
+let cacheTimestamp = 0;
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+let entityRef: AgentModelEntity | null = null;
+
+export function initModelConfig(entity: AgentModelEntity): void {
+  entityRef = entity;
+  cachedConfig = null;
+  cacheTimestamp = 0;
+}
+
+export async function getModelConfig(): Promise<ModelConfig> {
+  const now = Date.now();
+  if (cachedConfig && now - cacheTimestamp < CACHE_TTL_MS) {
+    return cachedConfig;
+  }
+
+  if (!entityRef) {
+    // Not initialized (dev/local mode) — use hardcoded defaults
+    return MODEL_CONFIG;
+  }
+
+  try {
+    const configs = await entityRef.getAll();
+    const configMap = new Map<string, AgentModelConfig>(
+      configs.map((c) => [c.id, c]),
+    );
+
+    const agent = configMap.get("agent");
+    const classifier = configMap.get("classifier");
+    const embeddings = configMap.get("embeddings");
+
+    cachedConfig = {
+      agent: {
+        model: agent?.model ?? MODEL_CONFIG.agent.model,
+        temperature: agent?.temperature ?? MODEL_CONFIG.agent.temperature,
+        maxTokens: agent?.maxTokens ?? MODEL_CONFIG.agent.maxTokens,
+      },
+      classifier: {
+        model: classifier?.model ?? MODEL_CONFIG.classifier.model,
+        temperature:
+          classifier?.temperature ?? MODEL_CONFIG.classifier.temperature,
+        maxTokens: classifier?.maxTokens ?? MODEL_CONFIG.classifier.maxTokens,
+      },
+      embeddings: {
+        model: embeddings?.model ?? MODEL_CONFIG.embeddings.model,
+        dimensions:
+          embeddings?.dimensions ?? MODEL_CONFIG.embeddings.dimensions,
+      },
+    } as unknown as ModelConfig;
+
+    cacheTimestamp = now;
+    return cachedConfig;
+  } catch {
+    // DynamoDB unavailable — use fallback defaults
+    return MODEL_CONFIG;
+  }
+}

--- a/packages/core/src/knowledge/index.ts
+++ b/packages/core/src/knowledge/index.ts
@@ -10,6 +10,7 @@ export {
   getDeadlineById,
 } from "./deadlines.js";
 export {
+  initSportOrgRegistry,
   loadSportOrganizations,
   clearSportOrgCache,
   findSportOrg,

--- a/packages/core/src/prompts/index.ts
+++ b/packages/core/src/prompts/index.ts
@@ -18,3 +18,4 @@ export {
   buildEscalationPrompt,
   type EscalationTarget,
 } from "./escalation.js";
+export { initPromptLoader, loadPrompt } from "./loader.js";

--- a/packages/core/src/prompts/loader.ts
+++ b/packages/core/src/prompts/loader.ts
@@ -1,0 +1,41 @@
+import type { PromptEntity } from "@usopc/shared";
+
+let entityRef: PromptEntity | null = null;
+
+const promptCache = new Map<string, { content: string; timestamp: number }>();
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+export function initPromptLoader(entity: PromptEntity): void {
+  entityRef = entity;
+  promptCache.clear();
+}
+
+/**
+ * Load a prompt by name from DynamoDB with TTL cache.
+ * Falls back to the provided default if DynamoDB is unavailable.
+ */
+export async function loadPrompt(
+  name: string,
+  fallback: string,
+): Promise<string> {
+  const now = Date.now();
+  const cached = promptCache.get(name);
+  if (cached && now - cached.timestamp < CACHE_TTL_MS) {
+    return cached.content;
+  }
+
+  if (!entityRef) {
+    return fallback;
+  }
+
+  try {
+    const prompt = await entityRef.get(name);
+    if (prompt) {
+      promptCache.set(name, { content: prompt.content, timestamp: now });
+      return prompt.content;
+    }
+    return fallback;
+  } catch {
+    return fallback;
+  }
+}

--- a/packages/core/src/services/embeddingsService.ts
+++ b/packages/core/src/services/embeddingsService.ts
@@ -36,11 +36,15 @@ const embeddingsCircuit = new CircuitBreaker({
 export class ProtectedOpenAIEmbeddings {
   private readonly embeddings: OpenAIEmbeddings;
 
-  constructor(apiKey?: string) {
+  constructor(
+    apiKey?: string,
+    embeddingsConfig?: { model: string; dimensions: number },
+  ) {
+    const config = embeddingsConfig ?? MODEL_CONFIG.embeddings;
     this.embeddings = new OpenAIEmbeddings({
       openAIApiKey: apiKey ?? process.env.OPENAI_API_KEY,
-      modelName: MODEL_CONFIG.embeddings.model,
-      dimensions: MODEL_CONFIG.embeddings.dimensions,
+      modelName: config.model,
+      dimensions: config.dimensions,
     });
   }
 
@@ -83,8 +87,9 @@ export class ProtectedOpenAIEmbeddings {
  */
 export function createProtectedEmbeddings(
   apiKey?: string,
+  embeddingsConfig?: { model: string; dimensions: number },
 ): ProtectedOpenAIEmbeddings {
-  return new ProtectedOpenAIEmbeddings(apiKey);
+  return new ProtectedOpenAIEmbeddings(apiKey, embeddingsConfig);
 }
 
 /**

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -1,6 +1,7 @@
 import type { StructuredToolInterface } from "@langchain/core/tools";
 import type { PGVectorStore } from "@langchain/community/vectorstores/pgvector";
 import type { Pool } from "pg";
+import type { SportOrgEntity } from "@usopc/shared";
 
 import { createSearchKnowledgeBaseTool } from "./searchKnowledgeBase.js";
 import { createWebSearchTool, type WebSearchToolOptions } from "./webSearch.js";
@@ -30,6 +31,8 @@ export interface ToolDependencies {
   pool: Pool;
   /** Optional Tavily API key. Falls back to TAVILY_API_KEY env var. */
   tavilyApiKey?: string;
+  /** SportOrgEntity instance for DynamoDB sport organization lookups. */
+  sportOrgEntity: SportOrgEntity;
 }
 
 /**
@@ -44,6 +47,7 @@ export interface ToolDependencies {
  *   vectorStore,
  *   pool,
  *   tavilyApiKey: process.env.TAVILY_API_KEY,
+ *   sportOrgEntity,
  * });
  * ```
  */
@@ -51,7 +55,7 @@ export function getAllTools(deps: ToolDependencies): StructuredToolInterface[] {
   return [
     createSearchKnowledgeBaseTool(deps.vectorStore),
     createWebSearchTool({ apiKey: deps.tavilyApiKey }),
-    createLookupSportOrgTool(),
+    createLookupSportOrgTool(deps.sportOrgEntity),
     createCalculateDeadlineTool(),
     createLookupContactTool(),
     createFetchDocumentSectionTool(deps.pool),

--- a/packages/core/src/types/sport-org.ts
+++ b/packages/core/src/types/sport-org.ts
@@ -1,21 +1,7 @@
-export type OlympicProgram = "summer" | "winter" | "pan_american";
-export type OrgStatus = "active" | "decertified";
-export type OrgType = "ngb" | "usopc_managed";
-
-export interface SportOrganization {
-  id: string;
-  type: OrgType;
-  officialName: string;
-  abbreviation?: string;
-  sports: string[];
-  olympicProgram: OlympicProgram | null;
-  paralympicManaged: boolean;
-  websiteUrl: string;
-  bylawsUrl?: string;
-  selectionProceduresUrl?: string;
-  internationalFederation?: string;
-  aliases: string[];
-  keywords: string[];
-  status: OrgStatus;
-  effectiveDate: string;
-}
+// Re-export from @usopc/shared — type definitions moved to shared package
+export type {
+  OlympicProgram,
+  OrgStatus,
+  OrgType,
+  SportOrganization,
+} from "@usopc/shared/src/types/sport-org.js";

--- a/packages/ingestion/package.json
+++ b/packages/ingestion/package.json
@@ -19,7 +19,6 @@
     "@aws-sdk/client-dynamodb": "^3.981.0",
     "@aws-sdk/client-s3": "^3.981.0",
     "@aws-sdk/client-sqs": "^3.981.0",
-    "@aws-sdk/lib-dynamodb": "^3.981.0",
     "@langchain/community": "^0.3.22",
     "@langchain/core": "^0.3.28",
     "@langchain/openai": "^0.3.17",

--- a/packages/ingestion/src/entities/index.ts
+++ b/packages/ingestion/src/entities/index.ts
@@ -1,12 +1,13 @@
 import { Resource } from "sst";
-import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import { DynamoDBDocumentClient } from "@aws-sdk/lib-dynamodb";
 import {
+  createAppTable,
   SourceConfigEntity,
   type SourceConfig,
   type CreateSourceInput,
   type MarkSuccessOptions,
-} from "./SourceConfigEntity.js";
+  IngestionLogEntity,
+  type IngestionLog,
+} from "@usopc/shared";
 
 export {
   SourceConfigEntity,
@@ -15,16 +16,18 @@ export {
   type MarkSuccessOptions,
 };
 
+export { IngestionLogEntity, type IngestionLog };
+
 /**
- * Get the SourceConfigs table name from SST Resource.
+ * Get the AppTable name from SST Resource.
  */
-export function getSourceConfigTableName(): string {
+export function getAppTableName(): string {
   try {
-    return (Resource as unknown as { SourceConfigs: { name: string } })
-      .SourceConfigs.name;
+    return (Resource as unknown as { AppTable: { name: string } }).AppTable
+      .name;
   } catch {
     throw new Error(
-      "SST Resource SourceConfigs not available. Run with 'sst shell' or deploy with SST.",
+      "SST Resource AppTable not available. Run with 'sst shell' or deploy with SST.",
     );
   }
 }
@@ -33,7 +36,14 @@ export function getSourceConfigTableName(): string {
  * Factory function to create a SourceConfigEntity with SST integration.
  */
 export function createSourceConfigEntity(): SourceConfigEntity {
-  const tableName = getSourceConfigTableName();
-  const client = DynamoDBDocumentClient.from(new DynamoDBClient({}));
-  return new SourceConfigEntity(tableName, client);
+  const table = createAppTable(getAppTableName());
+  return new SourceConfigEntity(table);
+}
+
+/**
+ * Factory function to create an IngestionLogEntity with SST integration.
+ */
+export function createIngestionLogEntity(): IngestionLogEntity {
+  const table = createAppTable(getAppTableName());
+  return new IngestionLogEntity(table);
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.981.0",
-    "@aws-sdk/lib-dynamodb": "^3.981.0",
+    "dynamodb-onetable": "^2.7",
     "pg": "^8.14.1",
     "zod": "^3.24.1"
   },

--- a/packages/shared/src/entities/AgentModelEntity.test.ts
+++ b/packages/shared/src/entities/AgentModelEntity.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../logger.js", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(),
+  }),
+}));
+
+// Create mock model methods
+const mockCreate = vi.fn();
+const mockGet = vi.fn();
+const mockFind = vi.fn();
+const mockScan = vi.fn();
+const mockUpdate = vi.fn();
+const mockRemove = vi.fn();
+
+const mockModel = {
+  create: mockCreate,
+  get: mockGet,
+  find: mockFind,
+  scan: mockScan,
+  update: mockUpdate,
+  remove: mockRemove,
+};
+
+// Mock Table that returns our mock model
+const mockTable = {
+  getModel: vi.fn(() => mockModel),
+} as unknown;
+
+// Import after mocks
+import { AgentModelEntity, type AgentModelConfig } from "./AgentModelEntity.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function internalItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "agent",
+    role: "Primary reasoning agent",
+    model: "claude-sonnet-4-20250514",
+    temperature: 0.1,
+    maxTokens: 4096,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AgentModelEntity", () => {
+  let entity: AgentModelEntity;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    entity = new AgentModelEntity(mockTable as never);
+  });
+
+  describe("get", () => {
+    it("returns null for a missing item", async () => {
+      mockGet.mockResolvedValueOnce(undefined);
+
+      const result = await entity.get("nonexistent");
+
+      expect(result).toBeNull();
+      expect(mockGet).toHaveBeenCalledWith({ id: "nonexistent" });
+    });
+
+    it("converts internal item to external shape", async () => {
+      mockGet.mockResolvedValueOnce(internalItem());
+
+      const result = await entity.get("agent");
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe("agent");
+      expect(result!.role).toBe("Primary reasoning agent");
+      expect(result!.model).toBe("claude-sonnet-4-20250514");
+      expect(result!.temperature).toBe(0.1);
+      expect(result!.maxTokens).toBe(4096);
+      expect(result!.createdAt).toBe("2024-01-01T00:00:00.000Z");
+      expect(result!.updatedAt).toBe("2024-01-01T00:00:00.000Z");
+    });
+
+    it("handles embeddings config with dimensions", async () => {
+      mockGet.mockResolvedValueOnce(
+        internalItem({
+          id: "embeddings",
+          role: "Text embeddings",
+          model: "text-embedding-3-small",
+          temperature: undefined,
+          maxTokens: undefined,
+          dimensions: 1536,
+        }),
+      );
+
+      const result = await entity.get("embeddings");
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe("embeddings");
+      expect(result!.dimensions).toBe(1536);
+      expect(result!.temperature).toBeUndefined();
+      expect(result!.maxTokens).toBeUndefined();
+    });
+  });
+
+  describe("upsert", () => {
+    it("creates a new item when it does not exist", async () => {
+      const created = internalItem({
+        createdAt: "2024-01-15T12:00:00.000Z",
+        updatedAt: "2024-01-15T12:00:00.000Z",
+      });
+      mockCreate.mockResolvedValueOnce(created);
+
+      const config: AgentModelConfig = {
+        id: "agent",
+        role: "Primary reasoning agent",
+        model: "claude-sonnet-4-20250514",
+        temperature: 0.1,
+        maxTokens: 4096,
+      };
+
+      const result = await entity.upsert(config);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "agent",
+          role: "Primary reasoning agent",
+          model: "claude-sonnet-4-20250514",
+          temperature: 0.1,
+          maxTokens: 4096,
+          createdAt: "2024-01-15T12:00:00.000Z",
+          updatedAt: "2024-01-15T12:00:00.000Z",
+        }),
+        { exists: null },
+      );
+
+      expect(result.id).toBe("agent");
+      expect(result.model).toBe("claude-sonnet-4-20250514");
+    });
+
+    it("falls back to update when item already exists", async () => {
+      mockCreate.mockRejectedValueOnce(new Error("Conditional check failed"));
+      mockUpdate.mockResolvedValueOnce(
+        internalItem({
+          model: "claude-sonnet-4-20250514",
+          updatedAt: "2024-01-15T12:00:00.000Z",
+        }),
+      );
+
+      const config: AgentModelConfig = {
+        id: "agent",
+        role: "Primary reasoning agent",
+        model: "claude-sonnet-4-20250514",
+        temperature: 0.1,
+        maxTokens: 4096,
+      };
+
+      const result = await entity.upsert(config);
+
+      expect(mockCreate).toHaveBeenCalled();
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "agent",
+          model: "claude-sonnet-4-20250514",
+          updatedAt: "2024-01-15T12:00:00.000Z",
+        }),
+      );
+      expect(result.model).toBe("claude-sonnet-4-20250514");
+    });
+
+    it("preserves existing createdAt when provided", async () => {
+      const created = internalItem({
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-15T12:00:00.000Z",
+      });
+      mockCreate.mockResolvedValueOnce(created);
+
+      const config: AgentModelConfig = {
+        id: "agent",
+        role: "Primary reasoning agent",
+        model: "claude-sonnet-4-20250514",
+        createdAt: "2024-01-01T00:00:00.000Z",
+      };
+
+      await entity.upsert(config);
+
+      const createArg = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+      expect(createArg.createdAt).toBe("2024-01-01T00:00:00.000Z");
+    });
+
+    it("includes dimensions for embeddings config", async () => {
+      const created = internalItem({
+        id: "embeddings",
+        role: "Text embeddings",
+        model: "text-embedding-3-small",
+        dimensions: 1536,
+      });
+      mockCreate.mockResolvedValueOnce(created);
+
+      const config: AgentModelConfig = {
+        id: "embeddings",
+        role: "Text embeddings",
+        model: "text-embedding-3-small",
+        dimensions: 1536,
+      };
+
+      const result = await entity.upsert(config);
+
+      const createArg = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+      expect(createArg.dimensions).toBe(1536);
+      expect(result.dimensions).toBe(1536);
+    });
+  });
+
+  describe("getAll", () => {
+    it("returns all agent model configs via model.scan", async () => {
+      mockScan.mockResolvedValueOnce([
+        internalItem({ id: "agent" }),
+        internalItem({ id: "classifier", model: "claude-haiku-4-5-20251001" }),
+        internalItem({
+          id: "embeddings",
+          model: "text-embedding-3-small",
+          dimensions: 1536,
+        }),
+      ]);
+
+      const results = await entity.getAll();
+
+      expect(results).toHaveLength(3);
+      expect(results[0].id).toBe("agent");
+      expect(results[1].id).toBe("classifier");
+      expect(results[1].model).toBe("claude-haiku-4-5-20251001");
+      expect(results[2].id).toBe("embeddings");
+      expect(results[2].dimensions).toBe(1536);
+    });
+
+    it("returns empty array when no configs exist", async () => {
+      mockScan.mockResolvedValueOnce([]);
+
+      const results = await entity.getAll();
+
+      expect(results).toEqual([]);
+    });
+  });
+});

--- a/packages/shared/src/entities/AgentModelEntity.ts
+++ b/packages/shared/src/entities/AgentModelEntity.ts
@@ -1,0 +1,81 @@
+import { Table } from "dynamodb-onetable";
+import { createLogger } from "../index.js";
+import type { AppTableSchema } from "./schema.js";
+
+const logger = createLogger({ service: "agent-model-entity" });
+
+export interface AgentModelConfig {
+  id: string; // "agent" | "classifier" | "embeddings"
+  role: string; // description of what this model does
+  model: string; // model name (e.g., "claude-sonnet-4-20250514")
+  temperature?: number;
+  maxTokens?: number;
+  dimensions?: number; // for embeddings only
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export class AgentModelEntity {
+  private model;
+  private table: Table<typeof AppTableSchema>;
+
+  constructor(table: Table<typeof AppTableSchema>) {
+    this.table = table;
+    this.model = table.getModel("AgentModel");
+  }
+
+  private toExternal(item: Record<string, unknown>): AgentModelConfig {
+    return {
+      id: item.id as string,
+      role: item.role as string,
+      model: item.model as string,
+      temperature: item.temperature as number | undefined,
+      maxTokens: item.maxTokens as number | undefined,
+      dimensions: item.dimensions as number | undefined,
+      createdAt: item.createdAt as string | undefined,
+      updatedAt: item.updatedAt as string | undefined,
+    };
+  }
+
+  async get(id: string): Promise<AgentModelConfig | null> {
+    const item = await this.model.get({ id } as never);
+    if (!item) return null;
+    return this.toExternal(item as unknown as Record<string, unknown>);
+  }
+
+  async upsert(config: AgentModelConfig): Promise<AgentModelConfig> {
+    const now = new Date().toISOString();
+    const item: Record<string, unknown> = {
+      id: config.id,
+      role: config.role,
+      model: config.model,
+      updatedAt: now,
+    };
+    if (config.temperature !== undefined) item.temperature = config.temperature;
+    if (config.maxTokens !== undefined) item.maxTokens = config.maxTokens;
+    if (config.dimensions !== undefined) item.dimensions = config.dimensions;
+    if (!config.createdAt) item.createdAt = now;
+    else item.createdAt = config.createdAt;
+
+    logger.info(`Upserting agent model config: ${config.id}`, {
+      modelId: config.id,
+    });
+
+    // Use create with {exists: null} to avoid overwrite, fallback to update
+    try {
+      const result = await this.model.create(item as never, { exists: null });
+      return this.toExternal(result as unknown as Record<string, unknown>);
+    } catch {
+      // Item already exists, update it
+      const result = await this.model.update(item as never);
+      return this.toExternal(result as unknown as Record<string, unknown>);
+    }
+  }
+
+  async getAll(): Promise<AgentModelConfig[]> {
+    const items = await this.model.scan({} as never);
+    return items.map((item) =>
+      this.toExternal(item as unknown as Record<string, unknown>),
+    );
+  }
+}

--- a/packages/shared/src/entities/IngestionLogEntity.test.ts
+++ b/packages/shared/src/entities/IngestionLogEntity.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../logger.js", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(),
+  }),
+}));
+
+// Create mock model methods
+const mockCreate = vi.fn();
+const mockGet = vi.fn();
+const mockFind = vi.fn();
+const mockScan = vi.fn();
+const mockUpdate = vi.fn();
+const mockRemove = vi.fn();
+
+const mockModel = {
+  create: mockCreate,
+  get: mockGet,
+  find: mockFind,
+  scan: mockScan,
+  update: mockUpdate,
+  remove: mockRemove,
+};
+
+// Mock Table that returns our mock model
+const mockTable = {
+  getModel: vi.fn(() => mockModel),
+} as unknown;
+
+// Import after mocks
+import { IngestionLogEntity, type IngestionLog } from "./IngestionLogEntity.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function internalItem(overrides: Record<string, unknown> = {}) {
+  return {
+    sourceId: "usopc-bylaws",
+    sourceUrl: "https://example.com/bylaws.pdf",
+    status: "in_progress",
+    startedAt: "2024-01-15T12:00:00.000Z",
+    createdAt: "2024-01-15T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("IngestionLogEntity", () => {
+  let entity: IngestionLogEntity;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    entity = new IngestionLogEntity(mockTable as never);
+  });
+
+  describe("create", () => {
+    it("creates a new ingestion log entry and returns external shape", async () => {
+      mockCreate.mockResolvedValueOnce(
+        internalItem({
+          sourceId: "usopc-bylaws",
+          sourceUrl: "https://example.com/bylaws.pdf",
+          status: "in_progress",
+          startedAt: "2024-01-15T12:00:00.000Z",
+          createdAt: "2024-01-15T12:00:00.000Z",
+        }),
+      );
+
+      const result = await entity.create({
+        sourceId: "usopc-bylaws",
+        sourceUrl: "https://example.com/bylaws.pdf",
+        status: "in_progress",
+      });
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sourceId: "usopc-bylaws",
+          sourceUrl: "https://example.com/bylaws.pdf",
+          status: "in_progress",
+          startedAt: "2024-01-15T12:00:00.000Z",
+          createdAt: "2024-01-15T12:00:00.000Z",
+        }),
+      );
+
+      expect(result.sourceId).toBe("usopc-bylaws");
+      expect(result.sourceUrl).toBe("https://example.com/bylaws.pdf");
+      expect(result.status).toBe("in_progress");
+      expect(result.startedAt).toBe("2024-01-15T12:00:00.000Z");
+      expect(result.createdAt).toBe("2024-01-15T12:00:00.000Z");
+    });
+
+    it("includes optional fields when provided", async () => {
+      mockCreate.mockResolvedValueOnce(
+        internalItem({
+          contentHash: "abc123",
+          chunksCount: 5,
+          errorMessage: "some error",
+        }),
+      );
+
+      await entity.create({
+        sourceId: "usopc-bylaws",
+        sourceUrl: "https://example.com/bylaws.pdf",
+        status: "failed",
+        contentHash: "abc123",
+        chunksCount: 5,
+        errorMessage: "some error",
+      });
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          contentHash: "abc123",
+          chunksCount: 5,
+          errorMessage: "some error",
+        }),
+      );
+    });
+
+    it("omits optional fields when not provided", async () => {
+      mockCreate.mockResolvedValueOnce(internalItem());
+
+      await entity.create({
+        sourceId: "usopc-bylaws",
+        sourceUrl: "https://example.com/bylaws.pdf",
+        status: "in_progress",
+      });
+
+      const createArg = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+      expect(createArg.contentHash).toBeUndefined();
+      expect(createArg.chunksCount).toBeUndefined();
+      expect(createArg.errorMessage).toBeUndefined();
+    });
+  });
+
+  describe("getForSource", () => {
+    it("returns logs for a specific source in reverse order", async () => {
+      mockFind.mockResolvedValueOnce([
+        internalItem({ startedAt: "2024-01-15T12:00:00.000Z" }),
+        internalItem({ startedAt: "2024-01-14T12:00:00.000Z" }),
+      ]);
+
+      const results = await entity.getForSource("usopc-bylaws");
+
+      expect(results).toHaveLength(2);
+      expect(mockFind).toHaveBeenCalledWith(
+        { sourceId: "usopc-bylaws" },
+        { reverse: true, limit: 10 },
+      );
+    });
+
+    it("respects custom limit", async () => {
+      mockFind.mockResolvedValueOnce([internalItem()]);
+
+      await entity.getForSource("usopc-bylaws", 5);
+
+      expect(mockFind).toHaveBeenCalledWith(
+        { sourceId: "usopc-bylaws" },
+        { reverse: true, limit: 5 },
+      );
+    });
+
+    it("returns empty array when no logs exist", async () => {
+      mockFind.mockResolvedValueOnce([]);
+
+      const results = await entity.getForSource("nonexistent");
+
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe("getRecent", () => {
+    it("queries gsi1 index for recent logs across all sources", async () => {
+      mockFind.mockResolvedValueOnce([
+        internalItem({ sourceId: "src1" }),
+        internalItem({ sourceId: "src2" }),
+      ]);
+
+      const results = await entity.getRecent();
+
+      expect(results).toHaveLength(2);
+      expect(mockFind).toHaveBeenCalledWith(
+        { gsi1pk: "INGEST" },
+        { index: "gsi1", reverse: true, limit: 20 },
+      );
+    });
+
+    it("respects custom limit", async () => {
+      mockFind.mockResolvedValueOnce([]);
+
+      await entity.getRecent(5);
+
+      expect(mockFind).toHaveBeenCalledWith(
+        { gsi1pk: "INGEST" },
+        { index: "gsi1", reverse: true, limit: 5 },
+      );
+    });
+  });
+
+  describe("updateStatus", () => {
+    it("updates the status of an ingestion log entry", async () => {
+      mockUpdate.mockResolvedValueOnce(internalItem({ status: "completed" }));
+
+      await entity.updateStatus(
+        "usopc-bylaws",
+        "2024-01-15T12:00:00.000Z",
+        "completed",
+      );
+
+      expect(mockUpdate).toHaveBeenCalledWith({
+        sourceId: "usopc-bylaws",
+        startedAt: "2024-01-15T12:00:00.000Z",
+        status: "completed",
+      });
+    });
+
+    it("includes optional fields when provided", async () => {
+      mockUpdate.mockResolvedValueOnce(
+        internalItem({
+          status: "completed",
+          contentHash: "abc123",
+          chunksCount: 10,
+          completedAt: "2024-01-15T13:00:00.000Z",
+        }),
+      );
+
+      await entity.updateStatus(
+        "usopc-bylaws",
+        "2024-01-15T12:00:00.000Z",
+        "completed",
+        {
+          contentHash: "abc123",
+          chunksCount: 10,
+          completedAt: "2024-01-15T13:00:00.000Z",
+        },
+      );
+
+      expect(mockUpdate).toHaveBeenCalledWith({
+        sourceId: "usopc-bylaws",
+        startedAt: "2024-01-15T12:00:00.000Z",
+        status: "completed",
+        contentHash: "abc123",
+        chunksCount: 10,
+        completedAt: "2024-01-15T13:00:00.000Z",
+      });
+    });
+
+    it("includes errorMessage for failed status", async () => {
+      mockUpdate.mockResolvedValueOnce(
+        internalItem({ status: "failed", errorMessage: "Network error" }),
+      );
+
+      await entity.updateStatus(
+        "usopc-bylaws",
+        "2024-01-15T12:00:00.000Z",
+        "failed",
+        { errorMessage: "Network error" },
+      );
+
+      expect(mockUpdate).toHaveBeenCalledWith({
+        sourceId: "usopc-bylaws",
+        startedAt: "2024-01-15T12:00:00.000Z",
+        status: "failed",
+        errorMessage: "Network error",
+      });
+    });
+  });
+
+  describe("getLastContentHash", () => {
+    it("returns content hash from the most recent completed ingestion", async () => {
+      mockFind.mockResolvedValueOnce([
+        internalItem({ status: "failed", contentHash: undefined }),
+        internalItem({ status: "completed", contentHash: "abc123hash" }),
+        internalItem({ status: "completed", contentHash: "older-hash" }),
+      ]);
+
+      const result = await entity.getLastContentHash("usopc-bylaws");
+
+      expect(result).toBe("abc123hash");
+      expect(mockFind).toHaveBeenCalledWith(
+        { sourceId: "usopc-bylaws" },
+        { reverse: true, limit: 20 },
+      );
+    });
+
+    it("returns null when no completed ingestions exist", async () => {
+      mockFind.mockResolvedValueOnce([
+        internalItem({ status: "in_progress" }),
+        internalItem({ status: "failed" }),
+      ]);
+
+      const result = await entity.getLastContentHash("usopc-bylaws");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when no ingestion logs exist", async () => {
+      mockFind.mockResolvedValueOnce([]);
+
+      const result = await entity.getLastContentHash("nonexistent");
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/shared/src/entities/IngestionLogEntity.ts
+++ b/packages/shared/src/entities/IngestionLogEntity.ts
@@ -1,0 +1,146 @@
+import { Table } from "dynamodb-onetable";
+import { createLogger } from "../index.js";
+import type { AppTableSchema } from "./schema.js";
+
+const logger = createLogger({ service: "ingestion-log-entity" });
+
+export interface IngestionLog {
+  sourceId: string;
+  sourceUrl: string;
+  status: "pending" | "in_progress" | "completed" | "failed";
+  contentHash?: string;
+  chunksCount?: number;
+  errorMessage?: string;
+  startedAt: string;
+  completedAt?: string;
+  createdAt: string;
+}
+
+export class IngestionLogEntity {
+  private model;
+  private table: Table<typeof AppTableSchema>;
+
+  constructor(table: Table<typeof AppTableSchema>) {
+    this.table = table;
+    this.model = table.getModel("IngestionLog");
+  }
+
+  private toExternal(item: Record<string, unknown>): IngestionLog {
+    return {
+      sourceId: item.sourceId as string,
+      sourceUrl: item.sourceUrl as string,
+      status: item.status as IngestionLog["status"],
+      contentHash: item.contentHash as string | undefined,
+      chunksCount: item.chunksCount as number | undefined,
+      errorMessage: item.errorMessage as string | undefined,
+      startedAt: item.startedAt as string,
+      completedAt: item.completedAt as string | undefined,
+      createdAt: item.createdAt as string,
+    };
+  }
+
+  /**
+   * Create a new ingestion log entry.
+   */
+  async create(input: {
+    sourceId: string;
+    sourceUrl: string;
+    status: IngestionLog["status"];
+    contentHash?: string;
+    chunksCount?: number;
+    errorMessage?: string;
+  }): Promise<IngestionLog> {
+    const now = new Date().toISOString();
+    const item: Record<string, unknown> = {
+      sourceId: input.sourceId,
+      sourceUrl: input.sourceUrl,
+      status: input.status,
+      startedAt: now,
+      createdAt: now,
+    };
+    if (input.contentHash) item.contentHash = input.contentHash;
+    if (input.chunksCount !== undefined) item.chunksCount = input.chunksCount;
+    if (input.errorMessage) item.errorMessage = input.errorMessage;
+
+    logger.info(`Creating ingestion log for source: ${input.sourceId}`, {
+      sourceId: input.sourceId,
+      status: input.status,
+    });
+
+    const result = await this.model.create(item as never);
+    return this.toExternal(result as unknown as Record<string, unknown>);
+  }
+
+  /**
+   * Get ingestion logs for a specific source, ordered by most recent first.
+   */
+  async getForSource(sourceId: string, limit = 10): Promise<IngestionLog[]> {
+    const items = await this.model.find({ sourceId } as never, {
+      reverse: true,
+      limit,
+    });
+    return items.map((item) =>
+      this.toExternal(item as unknown as Record<string, unknown>),
+    );
+  }
+
+  /**
+   * Get recent ingestion logs across all sources (via gsi1).
+   */
+  async getRecent(limit = 20): Promise<IngestionLog[]> {
+    const items = await this.model.find({ gsi1pk: "INGEST" } as never, {
+      index: "gsi1",
+      reverse: true,
+      limit,
+    });
+    return items.map((item) =>
+      this.toExternal(item as unknown as Record<string, unknown>),
+    );
+  }
+
+  /**
+   * Update the status of an ingestion log entry.
+   */
+  async updateStatus(
+    sourceId: string,
+    startedAt: string,
+    status: IngestionLog["status"],
+    fields?: {
+      contentHash?: string;
+      chunksCount?: number;
+      errorMessage?: string;
+      completedAt?: string;
+    },
+  ): Promise<void> {
+    const props: Record<string, unknown> = {
+      sourceId,
+      startedAt,
+      status,
+    };
+    if (fields?.contentHash) props.contentHash = fields.contentHash;
+    if (fields?.chunksCount !== undefined)
+      props.chunksCount = fields.chunksCount;
+    if (fields?.errorMessage) props.errorMessage = fields.errorMessage;
+    if (fields?.completedAt) props.completedAt = fields.completedAt;
+
+    await this.model.update(props as never);
+  }
+
+  /**
+   * Get the content hash from the most recent completed ingestion for a source.
+   */
+  async getLastContentHash(sourceId: string): Promise<string | null> {
+    const items = await this.model.find({ sourceId } as never, {
+      reverse: true,
+      limit: 20,
+    });
+    // Find the most recent completed entry
+    for (const item of items) {
+      const record = item as unknown as Record<string, unknown>;
+      if (record.status === "completed" && record.contentHash) {
+        return record.contentHash as string;
+      }
+    }
+    return null;
+  }
+}

--- a/packages/shared/src/entities/PromptEntity.test.ts
+++ b/packages/shared/src/entities/PromptEntity.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../logger.js", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(),
+  }),
+}));
+
+// Create mock model methods
+const mockCreate = vi.fn();
+const mockGet = vi.fn();
+const mockFind = vi.fn();
+const mockScan = vi.fn();
+const mockUpdate = vi.fn();
+const mockRemove = vi.fn();
+
+const mockModel = {
+  create: mockCreate,
+  get: mockGet,
+  find: mockFind,
+  scan: mockScan,
+  update: mockUpdate,
+  remove: mockRemove,
+};
+
+// Mock Table that returns our mock model
+const mockTable = {
+  getModel: vi.fn(() => mockModel),
+} as unknown;
+
+// Import after mocks
+import { PromptEntity, type PromptConfig } from "./PromptEntity.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function internalItem(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "classifier",
+    content: "You are a classifier that analyzes user queries...",
+    domain: "classification",
+    version: 1,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PromptEntity", () => {
+  let entity: PromptEntity;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    entity = new PromptEntity(mockTable as never);
+  });
+
+  describe("get", () => {
+    it("returns null for a missing item", async () => {
+      mockGet.mockResolvedValueOnce(undefined);
+
+      const result = await entity.get("nonexistent");
+
+      expect(result).toBeNull();
+      expect(mockGet).toHaveBeenCalledWith({ name: "nonexistent" });
+    });
+
+    it("converts internal item to external shape", async () => {
+      mockGet.mockResolvedValueOnce(internalItem());
+
+      const result = await entity.get("classifier");
+
+      expect(result).not.toBeNull();
+      expect(result!.name).toBe("classifier");
+      expect(result!.content).toBe(
+        "You are a classifier that analyzes user queries...",
+      );
+      expect(result!.domain).toBe("classification");
+      expect(result!.version).toBe(1);
+      expect(result!.createdAt).toBe("2024-01-01T00:00:00.000Z");
+      expect(result!.updatedAt).toBe("2024-01-01T00:00:00.000Z");
+    });
+
+    it("defaults version to 1 when not present", async () => {
+      mockGet.mockResolvedValueOnce(internalItem({ version: undefined }));
+
+      const result = await entity.get("classifier");
+
+      expect(result!.version).toBe(1);
+    });
+
+    it("handles prompt without domain", async () => {
+      mockGet.mockResolvedValueOnce(internalItem({ domain: undefined }));
+
+      const result = await entity.get("classifier");
+
+      expect(result!.domain).toBeUndefined();
+    });
+  });
+
+  describe("upsert", () => {
+    it("creates a new item when it does not exist", async () => {
+      const created = internalItem({
+        createdAt: "2024-01-15T12:00:00.000Z",
+        updatedAt: "2024-01-15T12:00:00.000Z",
+      });
+      mockCreate.mockResolvedValueOnce(created);
+
+      const result = await entity.upsert({
+        name: "classifier",
+        content: "You are a classifier that analyzes user queries...",
+        domain: "classification",
+        version: 1,
+      });
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "classifier",
+          content: "You are a classifier that analyzes user queries...",
+          domain: "classification",
+          version: 1,
+          createdAt: "2024-01-15T12:00:00.000Z",
+          updatedAt: "2024-01-15T12:00:00.000Z",
+        }),
+        { exists: null },
+      );
+
+      expect(result.name).toBe("classifier");
+      expect(result.content).toBe(
+        "You are a classifier that analyzes user queries...",
+      );
+    });
+
+    it("falls back to update when item already exists", async () => {
+      mockCreate.mockRejectedValueOnce(new Error("Conditional check failed"));
+      mockUpdate.mockResolvedValueOnce(
+        internalItem({
+          content: "Updated classifier prompt",
+          version: 2,
+          updatedAt: "2024-01-15T12:00:00.000Z",
+        }),
+      );
+
+      const result = await entity.upsert({
+        name: "classifier",
+        content: "Updated classifier prompt",
+        version: 2,
+      });
+
+      expect(mockCreate).toHaveBeenCalled();
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "classifier",
+          content: "Updated classifier prompt",
+          version: 2,
+          updatedAt: "2024-01-15T12:00:00.000Z",
+        }),
+      );
+
+      // createdAt should NOT be in the update call
+      const updateArg = mockUpdate.mock.calls[0][0] as Record<string, unknown>;
+      expect(updateArg.createdAt).toBeUndefined();
+
+      expect(result.content).toBe("Updated classifier prompt");
+      expect(result.version).toBe(2);
+    });
+
+    it("omits domain when not provided", async () => {
+      mockCreate.mockResolvedValueOnce(internalItem({ domain: undefined }));
+
+      await entity.upsert({
+        name: "system",
+        content: "You are an AI assistant...",
+        version: 1,
+      });
+
+      const createArg = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+      expect(createArg.domain).toBeUndefined();
+    });
+  });
+
+  describe("getAll", () => {
+    it("returns all prompts via model.scan", async () => {
+      mockScan.mockResolvedValueOnce([
+        internalItem({ name: "classifier" }),
+        internalItem({ name: "synthesizer" }),
+        internalItem({ name: "system" }),
+      ]);
+
+      const results = await entity.getAll();
+
+      expect(results).toHaveLength(3);
+      expect(results[0].name).toBe("classifier");
+      expect(results[1].name).toBe("synthesizer");
+      expect(results[2].name).toBe("system");
+    });
+
+    it("returns empty array when no prompts exist", async () => {
+      mockScan.mockResolvedValueOnce([]);
+
+      const results = await entity.getAll();
+
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe("delete", () => {
+    it("removes the item from the table", async () => {
+      mockRemove.mockResolvedValueOnce(undefined);
+
+      await entity.delete("classifier");
+
+      expect(mockRemove).toHaveBeenCalledWith({ name: "classifier" });
+    });
+  });
+});

--- a/packages/shared/src/entities/PromptEntity.ts
+++ b/packages/shared/src/entities/PromptEntity.ts
@@ -1,0 +1,81 @@
+import { Table } from "dynamodb-onetable";
+import { createLogger } from "../index.js";
+import type { AppTableSchema } from "./schema.js";
+
+const logger = createLogger({ service: "prompt-entity" });
+
+export interface PromptConfig {
+  name: string;
+  content: string;
+  domain?: string;
+  version: number;
+  updatedAt?: string;
+  createdAt?: string;
+}
+
+export class PromptEntity {
+  private model;
+  private table: Table<typeof AppTableSchema>;
+
+  constructor(table: Table<typeof AppTableSchema>) {
+    this.table = table;
+    this.model = table.getModel("Prompt");
+  }
+
+  private toExternal(item: Record<string, unknown>): PromptConfig {
+    return {
+      name: item.name as string,
+      content: item.content as string,
+      domain: item.domain as string | undefined,
+      version: (item.version as number) ?? 1,
+      updatedAt: item.updatedAt as string | undefined,
+      createdAt: item.createdAt as string | undefined,
+    };
+  }
+
+  async get(name: string): Promise<PromptConfig | null> {
+    const item = await this.model.get({ name } as never);
+    if (!item) return null;
+    return this.toExternal(item as unknown as Record<string, unknown>);
+  }
+
+  async upsert(
+    config: Omit<PromptConfig, "createdAt" | "updatedAt">,
+  ): Promise<PromptConfig> {
+    const now = new Date().toISOString();
+    const item: Record<string, unknown> = {
+      name: config.name,
+      content: config.content,
+      version: config.version,
+      updatedAt: now,
+      createdAt: now,
+    };
+    if (config.domain) item.domain = config.domain;
+
+    logger.info(`Upserting prompt: ${config.name}`, {
+      promptName: config.name,
+    });
+
+    try {
+      const result = await this.model.create(item as never, { exists: null });
+      return this.toExternal(result as unknown as Record<string, unknown>);
+    } catch {
+      // Already exists — update (don't overwrite original createdAt)
+      delete item.createdAt;
+      const result = await this.model.update(item as never);
+      return this.toExternal(result as unknown as Record<string, unknown>);
+    }
+  }
+
+  async getAll(): Promise<PromptConfig[]> {
+    const items = await this.model.scan({} as never);
+    return items.map((item) =>
+      this.toExternal(item as unknown as Record<string, unknown>),
+    );
+  }
+
+  async delete(name: string): Promise<void> {
+    logger.info(`Deleting prompt: ${name}`, { promptName: name });
+    await this.model.remove({ name } as never);
+  }
+}

--- a/packages/shared/src/entities/SourceConfigEntity.test.ts
+++ b/packages/shared/src/entities/SourceConfigEntity.test.ts
@@ -14,22 +14,27 @@ vi.mock("../logger.js", () => ({
   }),
 }));
 
-const mockSend = vi.fn();
-vi.mock("@aws-sdk/lib-dynamodb", () => ({
-  DynamoDBDocumentClient: {
-    from: vi.fn(() => ({ send: mockSend })),
-  },
-  PutCommand: vi.fn((input: unknown) => ({ _type: "put", input })),
-  GetCommand: vi.fn((input: unknown) => ({ _type: "get", input })),
-  QueryCommand: vi.fn((input: unknown) => ({ _type: "query", input })),
-  UpdateCommand: vi.fn((input: unknown) => ({ _type: "update", input })),
-  DeleteCommand: vi.fn((input: unknown) => ({ _type: "delete", input })),
-  ScanCommand: vi.fn((input: unknown) => ({ _type: "scan", input })),
-}));
+// Create mock model methods
+const mockCreate = vi.fn();
+const mockGet = vi.fn();
+const mockFind = vi.fn();
+const mockScan = vi.fn();
+const mockUpdate = vi.fn();
+const mockRemove = vi.fn();
 
-vi.mock("@aws-sdk/client-dynamodb", () => ({
-  DynamoDBClient: vi.fn(),
-}));
+const mockModel = {
+  create: mockCreate,
+  get: mockGet,
+  find: mockFind,
+  scan: mockScan,
+  update: mockUpdate,
+  remove: mockRemove,
+};
+
+// Mock Table that returns our mock model
+const mockTable = {
+  getModel: vi.fn(() => mockModel),
+} as unknown;
 
 // Import after mocks
 import {
@@ -37,18 +42,12 @@ import {
   type SourceConfig,
   type CreateSourceInput,
 } from "./SourceConfigEntity.js";
-import {
-  PutCommand,
-  GetCommand,
-  QueryCommand,
-  UpdateCommand,
-  ScanCommand,
-} from "@aws-sdk/lib-dynamodb";
 
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
 
+/** A sample SourceConfig as returned by the public API (external shape). */
 const SAMPLE_SOURCE: SourceConfig = {
   id: "usopc-bylaws",
   title: "USOPC Bylaws",
@@ -70,6 +69,26 @@ const SAMPLE_SOURCE: SourceConfig = {
   createdAt: "2024-01-01T00:00:00.000Z",
   updatedAt: "2024-01-01T00:00:00.000Z",
 };
+
+/** Returns the OneTable-internal representation (string enabled, no nulls). */
+function internalItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "usopc-bylaws",
+    title: "USOPC Bylaws",
+    documentType: "bylaws",
+    topicDomains: ["governance", "athlete_rights"],
+    url: "https://example.com/bylaws.pdf",
+    format: "pdf",
+    priority: "high",
+    description: "Official USOPC bylaws document",
+    authorityLevel: "usopc_governance",
+    enabled: "true",
+    consecutiveFailures: 0,
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
 
 function createSampleInput(): CreateSourceInput {
   return {
@@ -97,36 +116,47 @@ describe("SourceConfigEntity", () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
-    entity = new SourceConfigEntity("test-table");
+    entity = new SourceConfigEntity(mockTable as never);
   });
 
   describe("create", () => {
-    it("generates correct pk/sk and timestamps", async () => {
-      mockSend.mockResolvedValueOnce({});
+    it("calls model.create with internal representation and returns external shape", async () => {
+      mockCreate.mockResolvedValueOnce(
+        internalItem({
+          createdAt: "2024-01-15T12:00:00.000Z",
+          updatedAt: "2024-01-15T12:00:00.000Z",
+        }),
+      );
 
       const input = createSampleInput();
       const result = await entity.create(input);
 
-      expect(PutCommand).toHaveBeenCalledWith(
+      // Verify model.create was called with the internal representation
+      expect(mockCreate).toHaveBeenCalledWith(
         expect.objectContaining({
-          TableName: "test-table",
-          Item: expect.objectContaining({
-            pk: "SOURCE#usopc-bylaws",
-            sk: "CONFIG",
-            id: "usopc-bylaws",
-            createdAt: "2024-01-15T12:00:00.000Z",
-            updatedAt: "2024-01-15T12:00:00.000Z",
-            enabled: "true", // Stored as string for GSI
-            consecutiveFailures: 0,
-          }),
+          id: "usopc-bylaws",
+          enabled: "true", // boolean -> string
+          consecutiveFailures: 0,
+          createdAt: "2024-01-15T12:00:00.000Z",
+          updatedAt: "2024-01-15T12:00:00.000Z",
         }),
+        { exists: null },
       );
+
+      // Null fields should be stripped from the internal call
+      const createArg = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+      expect(createArg.ngbId).toBeUndefined();
+      expect(createArg.lastIngestedAt).toBeUndefined();
+      expect(createArg.lastError).toBeUndefined();
+
+      // Return value should be in external shape
       expect(result.id).toBe("usopc-bylaws");
+      expect(result.enabled).toBe(true); // string -> boolean
       expect(result.createdAt).toBe("2024-01-15T12:00:00.000Z");
     });
 
     it("initializes with default values", async () => {
-      mockSend.mockResolvedValueOnce({});
+      mockCreate.mockResolvedValueOnce(internalItem());
 
       const input = createSampleInput();
       const result = await entity.create(input);
@@ -143,28 +173,16 @@ describe("SourceConfigEntity", () => {
 
   describe("getById", () => {
     it("returns null for missing item", async () => {
-      mockSend.mockResolvedValueOnce({ Item: undefined });
+      mockGet.mockResolvedValueOnce(undefined);
 
       const result = await entity.getById("nonexistent");
 
       expect(result).toBeNull();
-      expect(GetCommand).toHaveBeenCalledWith({
-        TableName: "test-table",
-        Key: {
-          pk: "SOURCE#nonexistent",
-          sk: "CONFIG",
-        },
-      });
+      expect(mockGet).toHaveBeenCalledWith({ id: "nonexistent" });
     });
 
-    it("unmarshalls DynamoDB item correctly", async () => {
-      mockSend.mockResolvedValueOnce({
-        Item: {
-          pk: "SOURCE#usopc-bylaws",
-          sk: "CONFIG",
-          ...SAMPLE_SOURCE,
-        },
-      });
+    it("converts internal item to external shape", async () => {
+      mockGet.mockResolvedValueOnce(internalItem());
 
       const result = await entity.getById("usopc-bylaws");
 
@@ -174,23 +192,17 @@ describe("SourceConfigEntity", () => {
       expect(result!.topicDomains).toEqual(["governance", "athlete_rights"]);
       expect(result!.format).toBe("pdf");
       expect(result!.authorityLevel).toBe("usopc_governance");
+      expect(result!.enabled).toBe(true);
+      expect(result!.ngbId).toBeNull();
     });
   });
 
   describe("getAll", () => {
-    it("returns all sources via Scan", async () => {
-      mockSend.mockResolvedValueOnce({
-        Items: [
-          { pk: "SOURCE#src1", sk: "CONFIG", ...SAMPLE_SOURCE, id: "src1" },
-          {
-            pk: "SOURCE#src2",
-            sk: "CONFIG",
-            ...SAMPLE_SOURCE,
-            id: "src2",
-            enabled: "false",
-          },
-        ],
-      });
+    it("returns all sources via model.scan", async () => {
+      mockScan.mockResolvedValueOnce([
+        internalItem({ id: "src1" }),
+        internalItem({ id: "src2", enabled: "false" }),
+      ]);
 
       const results = await entity.getAll();
 
@@ -200,30 +212,8 @@ describe("SourceConfigEntity", () => {
       expect(results[1].enabled).toBe(false);
     });
 
-    it("paginates when LastEvaluatedKey is present", async () => {
-      mockSend
-        .mockResolvedValueOnce({
-          Items: [
-            { pk: "SOURCE#src1", sk: "CONFIG", ...SAMPLE_SOURCE, id: "src1" },
-          ],
-          LastEvaluatedKey: { pk: "SOURCE#src1", sk: "CONFIG" },
-        })
-        .mockResolvedValueOnce({
-          Items: [
-            { pk: "SOURCE#src2", sk: "CONFIG", ...SAMPLE_SOURCE, id: "src2" },
-          ],
-        });
-
-      const results = await entity.getAll();
-
-      expect(results).toHaveLength(2);
-      expect(results[0].id).toBe("src1");
-      expect(results[1].id).toBe("src2");
-      expect(mockSend).toHaveBeenCalledTimes(2);
-    });
-
     it("returns empty array when no sources exist", async () => {
-      mockSend.mockResolvedValueOnce({ Items: [] });
+      mockScan.mockResolvedValueOnce([]);
 
       const results = await entity.getAll();
 
@@ -232,31 +222,23 @@ describe("SourceConfigEntity", () => {
   });
 
   describe("getAllEnabled", () => {
-    it("filters by enabled=true using GSI", async () => {
-      mockSend.mockResolvedValueOnce({
-        Items: [
-          { pk: "SOURCE#src1", sk: "CONFIG", ...SAMPLE_SOURCE, id: "src1" },
-          { pk: "SOURCE#src2", sk: "CONFIG", ...SAMPLE_SOURCE, id: "src2" },
-        ],
-      });
+    it("queries enabled-priority-index GSI", async () => {
+      mockFind.mockResolvedValueOnce([
+        internalItem({ id: "src1" }),
+        internalItem({ id: "src2" }),
+      ]);
 
       const results = await entity.getAllEnabled();
 
       expect(results).toHaveLength(2);
-      expect(QueryCommand).toHaveBeenCalledWith(
-        expect.objectContaining({
-          TableName: "test-table",
-          IndexName: "enabled-priority-index",
-          KeyConditionExpression: "enabled = :enabled",
-          ExpressionAttributeValues: {
-            ":enabled": "true",
-          },
-        }),
+      expect(mockFind).toHaveBeenCalledWith(
+        { enabled: "true" },
+        { index: "enabled-priority-index" },
       );
     });
 
     it("returns empty array when no enabled sources", async () => {
-      mockSend.mockResolvedValueOnce({ Items: [] });
+      mockFind.mockResolvedValueOnce([]);
 
       const results = await entity.getAllEnabled();
 
@@ -265,65 +247,44 @@ describe("SourceConfigEntity", () => {
   });
 
   describe("getByNgb", () => {
-    it("queries GSI correctly", async () => {
-      mockSend.mockResolvedValueOnce({
-        Items: [
-          {
-            pk: "SOURCE#usa-swimming-rules",
-            sk: "CONFIG",
-            ...SAMPLE_SOURCE,
-            id: "usa-swimming-rules",
-            ngbId: "usa-swimming",
-          },
-        ],
-      });
+    it("queries ngbId-index GSI", async () => {
+      mockFind.mockResolvedValueOnce([
+        internalItem({
+          id: "usa-swimming-rules",
+          ngbId: "usa-swimming",
+        }),
+      ]);
 
       const results = await entity.getByNgb("usa-swimming");
 
       expect(results).toHaveLength(1);
       expect(results[0].ngbId).toBe("usa-swimming");
-      expect(QueryCommand).toHaveBeenCalledWith(
-        expect.objectContaining({
-          TableName: "test-table",
-          IndexName: "ngbId-index",
-          KeyConditionExpression: "ngbId = :ngbId",
-          ExpressionAttributeValues: {
-            ":ngbId": "usa-swimming",
-          },
-        }),
+      expect(mockFind).toHaveBeenCalledWith(
+        { ngbId: "usa-swimming" },
+        { index: "ngbId-index" },
       );
     });
   });
 
   describe("update", () => {
-    it("merges updates and sets updatedAt", async () => {
-      mockSend.mockResolvedValueOnce({
-        Attributes: {
-          pk: "SOURCE#usopc-bylaws",
-          sk: "CONFIG",
-          ...SAMPLE_SOURCE,
+    it("merges updates, sets updatedAt, and converts enabled", async () => {
+      mockUpdate.mockResolvedValueOnce(
+        internalItem({
           url: "https://example.com/new-bylaws.pdf",
           updatedAt: "2024-01-15T12:00:00.000Z",
-        },
-      });
+        }),
+      );
 
       const result = await entity.update("usopc-bylaws", {
         url: "https://example.com/new-bylaws.pdf",
       });
 
       expect(result.url).toBe("https://example.com/new-bylaws.pdf");
-      expect(UpdateCommand).toHaveBeenCalledWith(
+      expect(mockUpdate).toHaveBeenCalledWith(
         expect.objectContaining({
-          TableName: "test-table",
-          Key: {
-            pk: "SOURCE#usopc-bylaws",
-            sk: "CONFIG",
-          },
-          UpdateExpression: expect.stringContaining("SET"),
-          ExpressionAttributeValues: expect.objectContaining({
-            ":updatedAt": "2024-01-15T12:00:00.000Z",
-          }),
-          ReturnValues: "ALL_NEW",
+          id: "usopc-bylaws",
+          url: "https://example.com/new-bylaws.pdf",
+          updatedAt: "2024-01-15T12:00:00.000Z",
         }),
       );
     });
@@ -331,108 +292,102 @@ describe("SourceConfigEntity", () => {
 
   describe("markSuccess", () => {
     it("resets failures, sets hash, timestamp, and S3 info", async () => {
-      mockSend.mockResolvedValueOnce({
-        Attributes: {
-          pk: "SOURCE#usopc-bylaws",
-          sk: "CONFIG",
-          ...SAMPLE_SOURCE,
+      mockUpdate.mockResolvedValueOnce(
+        internalItem({
           lastContentHash: "abc123hash",
           lastIngestedAt: "2024-01-15T12:00:00.000Z",
           consecutiveFailures: 0,
-          lastError: null,
           s3Key: "sources/usopc-bylaws/abc123hash.pdf",
           s3VersionId: "v1",
-        },
-      });
+        }),
+      );
 
       await entity.markSuccess("usopc-bylaws", "abc123hash", {
         s3Key: "sources/usopc-bylaws/abc123hash.pdf",
         s3VersionId: "v1",
       });
 
-      expect(UpdateCommand).toHaveBeenCalledWith(
+      expect(mockUpdate).toHaveBeenCalledWith(
         expect.objectContaining({
-          Key: {
-            pk: "SOURCE#usopc-bylaws",
-            sk: "CONFIG",
-          },
-          ExpressionAttributeValues: expect.objectContaining({
-            ":contentHash": "abc123hash",
-            ":failures": 0,
-            ":lastError": null,
-            ":s3Key": "sources/usopc-bylaws/abc123hash.pdf",
-            ":s3VersionId": "v1",
-          }),
+          id: "usopc-bylaws",
+          lastContentHash: "abc123hash",
+          consecutiveFailures: 0,
+          s3Key: "sources/usopc-bylaws/abc123hash.pdf",
+          s3VersionId: "v1",
         }),
+        { remove: ["lastError"] },
       );
     });
   });
 
   describe("markFailure", () => {
     it("increments failures and sets lastError", async () => {
-      mockSend.mockResolvedValueOnce({
-        Attributes: {
-          pk: "SOURCE#usopc-bylaws",
-          sk: "CONFIG",
-          ...SAMPLE_SOURCE,
+      // First call: get current item
+      mockGet.mockResolvedValueOnce(internalItem({ consecutiveFailures: 2 }));
+      // Second call: update
+      mockUpdate.mockResolvedValueOnce(
+        internalItem({
           consecutiveFailures: 3,
           lastError: "Connection timeout",
-        },
-      });
+        }),
+      );
 
       await entity.markFailure("usopc-bylaws", "Connection timeout");
 
-      expect(UpdateCommand).toHaveBeenCalledWith(
+      expect(mockGet).toHaveBeenCalledWith({ id: "usopc-bylaws" });
+      expect(mockUpdate).toHaveBeenCalledWith(
         expect.objectContaining({
-          UpdateExpression: expect.stringContaining(
-            "consecutiveFailures = consecutiveFailures + :inc",
-          ),
-          ExpressionAttributeValues: expect.objectContaining({
-            ":inc": 1,
-            ":lastError": "Connection timeout",
-          }),
+          id: "usopc-bylaws",
+          consecutiveFailures: 3,
+          lastError: "Connection timeout",
+          updatedAt: "2024-01-15T12:00:00.000Z",
+        }),
+      );
+    });
+
+    it("starts from 0 when item has no failures field", async () => {
+      mockGet.mockResolvedValueOnce(
+        internalItem({ consecutiveFailures: undefined }),
+      );
+      mockUpdate.mockResolvedValueOnce(
+        internalItem({ consecutiveFailures: 1 }),
+      );
+
+      await entity.markFailure("usopc-bylaws", "Some error");
+
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          consecutiveFailures: 1,
         }),
       );
     });
   });
 
   describe("disable", () => {
-    it("sets enabled to false", async () => {
-      mockSend.mockResolvedValueOnce({
-        Attributes: {
-          ...SAMPLE_SOURCE,
-          enabled: false,
-        },
-      });
+    it("calls update with enabled: false", async () => {
+      mockUpdate.mockResolvedValueOnce(internalItem({ enabled: "false" }));
 
       await entity.disable("usopc-bylaws");
 
-      expect(UpdateCommand).toHaveBeenCalledWith(
+      expect(mockUpdate).toHaveBeenCalledWith(
         expect.objectContaining({
-          ExpressionAttributeValues: expect.objectContaining({
-            ":enabled": "false",
-          }),
+          id: "usopc-bylaws",
+          enabled: "false",
         }),
       );
     });
   });
 
   describe("enable", () => {
-    it("sets enabled to true", async () => {
-      mockSend.mockResolvedValueOnce({
-        Attributes: {
-          ...SAMPLE_SOURCE,
-          enabled: true,
-        },
-      });
+    it("calls update with enabled: true", async () => {
+      mockUpdate.mockResolvedValueOnce(internalItem({ enabled: "true" }));
 
       await entity.enable("usopc-bylaws");
 
-      expect(UpdateCommand).toHaveBeenCalledWith(
+      expect(mockUpdate).toHaveBeenCalledWith(
         expect.objectContaining({
-          ExpressionAttributeValues: expect.objectContaining({
-            ":enabled": "true",
-          }),
+          id: "usopc-bylaws",
+          enabled: "true",
         }),
       );
     });
@@ -440,18 +395,11 @@ describe("SourceConfigEntity", () => {
 
   describe("delete", () => {
     it("removes the item from the table", async () => {
-      const { DeleteCommand } = await import("@aws-sdk/lib-dynamodb");
-      mockSend.mockResolvedValueOnce({});
+      mockRemove.mockResolvedValueOnce(undefined);
 
       await entity.delete("usopc-bylaws");
 
-      expect(DeleteCommand).toHaveBeenCalledWith({
-        TableName: "test-table",
-        Key: {
-          pk: "SOURCE#usopc-bylaws",
-          sk: "CONFIG",
-        },
-      });
+      expect(mockRemove).toHaveBeenCalledWith({ id: "usopc-bylaws" });
     });
   });
 });

--- a/packages/shared/src/entities/SportOrgEntity.test.ts
+++ b/packages/shared/src/entities/SportOrgEntity.test.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("../logger.js", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(),
+  }),
+}));
+
+// Create mock model methods
+const mockCreate = vi.fn();
+const mockGet = vi.fn();
+const mockFind = vi.fn();
+const mockScan = vi.fn();
+const mockUpdate = vi.fn();
+const mockRemove = vi.fn();
+
+const mockModel = {
+  create: mockCreate,
+  get: mockGet,
+  find: mockFind,
+  scan: mockScan,
+  update: mockUpdate,
+  remove: mockRemove,
+};
+
+// Mock Table that returns our mock model
+const mockTable = {
+  getModel: vi.fn(() => mockModel),
+} as unknown;
+
+// Import after mocks
+import { SportOrgEntity, type SportOrganization } from "./SportOrgEntity.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** A sample SportOrganization as returned by the public API (external shape). */
+const SAMPLE_ORG: SportOrganization = {
+  id: "usa-swimming",
+  type: "ngb",
+  officialName: "USA Swimming",
+  abbreviation: "USAS",
+  sports: ["Swimming", "Open Water Swimming"],
+  olympicProgram: "summer",
+  paralympicManaged: false,
+  websiteUrl: "https://www.usaswimming.org",
+  bylawsUrl: "https://www.usaswimming.org/bylaws",
+  selectionProceduresUrl: "https://www.usaswimming.org/selection",
+  internationalFederation: "World Aquatics",
+  aliases: ["US Swimming", "USA-S"],
+  keywords: ["pool", "freestyle", "backstroke"],
+  status: "active",
+  effectiveDate: "2024-01-01",
+};
+
+/** Returns the OneTable-internal representation (no nulls, undefined for absent). */
+function internalItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "usa-swimming",
+    type: "ngb",
+    officialName: "USA Swimming",
+    abbreviation: "USAS",
+    sports: ["Swimming", "Open Water Swimming"],
+    olympicProgram: "summer",
+    paralympicManaged: false,
+    websiteUrl: "https://www.usaswimming.org",
+    bylawsUrl: "https://www.usaswimming.org/bylaws",
+    selectionProceduresUrl: "https://www.usaswimming.org/selection",
+    internationalFederation: "World Aquatics",
+    aliases: ["US Swimming", "USA-S"],
+    keywords: ["pool", "freestyle", "backstroke"],
+    status: "active",
+    effectiveDate: "2024-01-01",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SportOrgEntity", () => {
+  let entity: SportOrgEntity;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    entity = new SportOrgEntity(mockTable as never);
+  });
+
+  describe("create", () => {
+    it("calls model.create with internal representation and returns external shape", async () => {
+      mockCreate.mockResolvedValueOnce(
+        internalItem({
+          createdAt: "2024-01-15T12:00:00.000Z",
+          updatedAt: "2024-01-15T12:00:00.000Z",
+        }),
+      );
+
+      const result = await entity.create(SAMPLE_ORG);
+
+      // Verify model.create was called with the internal representation
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "usa-swimming",
+          type: "ngb",
+          officialName: "USA Swimming",
+          createdAt: "2024-01-15T12:00:00.000Z",
+          updatedAt: "2024-01-15T12:00:00.000Z",
+        }),
+        { exists: null },
+      );
+
+      // Return value should be in external shape
+      expect(result.id).toBe("usa-swimming");
+      expect(result.officialName).toBe("USA Swimming");
+      expect(result.type).toBe("ngb");
+    });
+
+    it("strips null olympicProgram from internal representation", async () => {
+      const orgWithNullProgram: SportOrganization = {
+        ...SAMPLE_ORG,
+        olympicProgram: null,
+      };
+
+      mockCreate.mockResolvedValueOnce(internalItem());
+
+      await entity.create(orgWithNullProgram);
+
+      // Null fields should be stripped from the internal call
+      const createArg = mockCreate.mock.calls[0][0] as Record<string, unknown>;
+      expect(createArg.olympicProgram).toBeUndefined();
+    });
+  });
+
+  describe("getById", () => {
+    it("returns null for missing item", async () => {
+      mockGet.mockResolvedValueOnce(undefined);
+
+      const result = await entity.getById("nonexistent");
+
+      expect(result).toBeNull();
+      expect(mockGet).toHaveBeenCalledWith({ id: "nonexistent" });
+    });
+
+    it("converts internal item to external shape", async () => {
+      mockGet.mockResolvedValueOnce(internalItem());
+
+      const result = await entity.getById("usa-swimming");
+
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe("usa-swimming");
+      expect(result!.officialName).toBe("USA Swimming");
+      expect(result!.type).toBe("ngb");
+      expect(result!.sports).toEqual(["Swimming", "Open Water Swimming"]);
+      expect(result!.olympicProgram).toBe("summer");
+      expect(result!.status).toBe("active");
+    });
+
+    it("converts undefined olympicProgram to null", async () => {
+      mockGet.mockResolvedValueOnce(
+        internalItem({ olympicProgram: undefined }),
+      );
+
+      const result = await entity.getById("usa-swimming");
+
+      expect(result!.olympicProgram).toBeNull();
+    });
+
+    it("defaults missing arrays to empty arrays", async () => {
+      mockGet.mockResolvedValueOnce(
+        internalItem({
+          sports: undefined,
+          aliases: undefined,
+          keywords: undefined,
+        }),
+      );
+
+      const result = await entity.getById("usa-swimming");
+
+      expect(result!.sports).toEqual([]);
+      expect(result!.aliases).toEqual([]);
+      expect(result!.keywords).toEqual([]);
+    });
+  });
+
+  describe("getAll", () => {
+    it("returns all organizations via model.scan", async () => {
+      mockScan.mockResolvedValueOnce([
+        internalItem({ id: "usa-swimming" }),
+        internalItem({ id: "usatf", officialName: "USA Track & Field" }),
+      ]);
+
+      const results = await entity.getAll();
+
+      expect(results).toHaveLength(2);
+      expect(results[0].id).toBe("usa-swimming");
+      expect(results[1].id).toBe("usatf");
+    });
+
+    it("returns empty array when no organizations exist", async () => {
+      mockScan.mockResolvedValueOnce([]);
+
+      const results = await entity.getAll();
+
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe("search", () => {
+    const allOrgs = [
+      internalItem({ id: "usa-swimming" }),
+      internalItem({
+        id: "usatf",
+        officialName: "USA Track & Field",
+        abbreviation: "USATF",
+        sports: ["Track and Field", "Cross Country"],
+        aliases: ["US Track"],
+        keywords: ["running", "marathon"],
+      }),
+      internalItem({
+        id: "usss",
+        officialName: "US Ski & Snowboard",
+        abbreviation: "USSS",
+        sports: ["Alpine Skiing", "Snowboarding"],
+        aliases: ["USSA"],
+        keywords: ["ski", "snow"],
+      }),
+    ];
+
+    it("matches by officialName", async () => {
+      mockScan.mockResolvedValueOnce(allOrgs);
+
+      const results = await entity.search("Swimming");
+
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe("usa-swimming");
+    });
+
+    it("matches by abbreviation", async () => {
+      mockScan.mockResolvedValueOnce(allOrgs);
+
+      const results = await entity.search("USATF");
+
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe("usatf");
+    });
+
+    it("matches by sport name", async () => {
+      mockScan.mockResolvedValueOnce(allOrgs);
+
+      const results = await entity.search("Snowboarding");
+
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe("usss");
+    });
+
+    it("matches by alias", async () => {
+      mockScan.mockResolvedValueOnce(allOrgs);
+
+      const results = await entity.search("US Track");
+
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe("usatf");
+    });
+
+    it("matches by keyword", async () => {
+      mockScan.mockResolvedValueOnce(allOrgs);
+
+      const results = await entity.search("marathon");
+
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe("usatf");
+    });
+
+    it("is case-insensitive", async () => {
+      mockScan.mockResolvedValueOnce(allOrgs);
+
+      const results = await entity.search("swimming");
+
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe("usa-swimming");
+    });
+
+    it("returns empty array when nothing matches", async () => {
+      mockScan.mockResolvedValueOnce(allOrgs);
+
+      const results = await entity.search("Nonexistent");
+
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe("update", () => {
+    it("merges updates and sets updatedAt", async () => {
+      mockUpdate.mockResolvedValueOnce(
+        internalItem({
+          officialName: "USA Swimming Inc.",
+          updatedAt: "2024-01-15T12:00:00.000Z",
+        }),
+      );
+
+      const result = await entity.update("usa-swimming", {
+        officialName: "USA Swimming Inc.",
+      });
+
+      expect(result.officialName).toBe("USA Swimming Inc.");
+      expect(mockUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "usa-swimming",
+          officialName: "USA Swimming Inc.",
+          updatedAt: "2024-01-15T12:00:00.000Z",
+        }),
+      );
+    });
+
+    it("strips null values in updates", async () => {
+      mockUpdate.mockResolvedValueOnce(internalItem());
+
+      await entity.update("usa-swimming", {
+        olympicProgram: null,
+      });
+
+      const updateArg = mockUpdate.mock.calls[0][0] as Record<string, unknown>;
+      expect(updateArg.olympicProgram).toBeUndefined();
+    });
+  });
+
+  describe("delete", () => {
+    it("removes the item from the table", async () => {
+      mockRemove.mockResolvedValueOnce(undefined);
+
+      await entity.delete("usa-swimming");
+
+      expect(mockRemove).toHaveBeenCalledWith({ id: "usa-swimming" });
+    });
+  });
+});

--- a/packages/shared/src/entities/SportOrgEntity.ts
+++ b/packages/shared/src/entities/SportOrgEntity.ts
@@ -1,0 +1,170 @@
+import { Table } from "dynamodb-onetable";
+import { createLogger } from "../index.js";
+import type { AppTableSchema } from "./schema.js";
+
+const logger = createLogger({ service: "sport-org-entity" });
+
+// Re-export the types from shared
+export type {
+  OlympicProgram,
+  OrgStatus,
+  OrgType,
+  SportOrganization,
+} from "../types/sport-org.js";
+import type { SportOrganization, OlympicProgram } from "../types/sport-org.js";
+
+// ---------------------------------------------------------------------------
+// SportOrgEntity — backed by dynamodb-onetable
+// ---------------------------------------------------------------------------
+
+/**
+ * Entity class for managing sport organizations in DynamoDB
+ * using the OneTable single-table pattern.
+ *
+ * Table structure:
+ * - PK: SPORTORG#{id}
+ * - SK: PROFILE
+ */
+export class SportOrgEntity {
+  private model;
+  private table: Table<typeof AppTableSchema>;
+
+  constructor(table: Table<typeof AppTableSchema>) {
+    this.table = table;
+    this.model = table.getModel("SportOrganization");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Marshalling
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Convert a OneTable item (undefined for absent optional fields) to the
+   * external API shape (null for olympicProgram when absent, defaults for arrays).
+   */
+  private toExternal(item: Record<string, unknown>): SportOrganization {
+    return {
+      id: item.id as string,
+      type: item.type as SportOrganization["type"],
+      officialName: item.officialName as string,
+      abbreviation: item.abbreviation as string | undefined,
+      sports: (item.sports as string[]) ?? [],
+      olympicProgram: (item.olympicProgram as OlympicProgram) ?? null,
+      paralympicManaged: (item.paralympicManaged as boolean) ?? false,
+      websiteUrl: item.websiteUrl as string,
+      bylawsUrl: item.bylawsUrl as string | undefined,
+      selectionProceduresUrl: item.selectionProceduresUrl as string | undefined,
+      internationalFederation: item.internationalFederation as
+        | string
+        | undefined,
+      aliases: (item.aliases as string[]) ?? [],
+      keywords: (item.keywords as string[]) ?? [],
+      status: item.status as SportOrganization["status"],
+      effectiveDate: item.effectiveDate as string,
+    };
+  }
+
+  /**
+   * Convert external SportOrganization input to OneTable-compatible properties.
+   * - null olympicProgram -> removed (OneTable omits undefined fields when nulls: false)
+   * - undefined optional fields -> removed
+   */
+  private toInternal(
+    config: Partial<SportOrganization>,
+  ): Record<string, unknown> {
+    const item: Record<string, unknown> = { ...config };
+    // Remove null values — OneTable uses undefined/omission for absent fields
+    for (const key of Object.keys(item)) {
+      if (item[key] === null || item[key] === undefined) {
+        delete item[key];
+      }
+    }
+    return item;
+  }
+
+  // ---------------------------------------------------------------------------
+  // CRUD operations
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Create a new sport organization.
+   */
+  async create(input: SportOrganization): Promise<SportOrganization> {
+    const now = new Date().toISOString();
+
+    logger.info(`Creating sport organization: ${input.id}`, {
+      orgId: input.id,
+    });
+
+    const internal = this.toInternal(input);
+    internal.createdAt = now;
+    internal.updatedAt = now;
+
+    await this.model.create(internal as never, {
+      exists: null,
+    });
+    return input;
+  }
+
+  /**
+   * Get a sport organization by ID.
+   */
+  async getById(id: string): Promise<SportOrganization | null> {
+    const item = await this.model.get({ id } as never);
+    if (!item) return null;
+    return this.toExternal(item as unknown as Record<string, unknown>);
+  }
+
+  /**
+   * Get all sport organizations.
+   * OneTable handles pagination internally.
+   */
+  async getAll(): Promise<SportOrganization[]> {
+    const items = await this.model.scan({} as never);
+    return items.map((item) =>
+      this.toExternal(item as unknown as Record<string, unknown>),
+    );
+  }
+
+  /**
+   * Search sport organizations by query string.
+   * Gets all orgs and filters in memory (small dataset).
+   * Matches against: officialName, abbreviation, sports, aliases, keywords.
+   * Case-insensitive contains matching.
+   */
+  async search(query: string): Promise<SportOrganization[]> {
+    const orgs = await this.getAll();
+    const q = query.toLowerCase();
+
+    return orgs.filter(
+      (org) =>
+        org.officialName.toLowerCase().includes(q) ||
+        (org.abbreviation && org.abbreviation.toLowerCase().includes(q)) ||
+        org.sports.some((s) => s.toLowerCase().includes(q)) ||
+        org.aliases.some((a) => a.toLowerCase().includes(q)) ||
+        org.keywords.some((k) => k.toLowerCase().includes(q)),
+    );
+  }
+
+  /**
+   * Update a sport organization.
+   */
+  async update(
+    id: string,
+    updates: Partial<Omit<SportOrganization, "id">>,
+  ): Promise<SportOrganization> {
+    const now = new Date().toISOString();
+    const internal = this.toInternal({ ...updates });
+    internal.updatedAt = now;
+    const result = await this.model.update({ id, ...internal } as never);
+    return this.toExternal(result as unknown as Record<string, unknown>);
+  }
+
+  /**
+   * Delete a sport organization.
+   */
+  async delete(id: string): Promise<void> {
+    logger.info(`Deleting sport organization: ${id}`, { orgId: id });
+    await this.model.remove({ id } as never);
+  }
+}

--- a/packages/shared/src/entities/index.ts
+++ b/packages/shared/src/entities/index.ts
@@ -1,6 +1,12 @@
+export { AppTableSchema } from "./schema.js";
+export { createAppTable } from "./table.js";
 export {
   SourceConfigEntity,
   type SourceConfig,
   type CreateSourceInput,
   type MarkSuccessOptions,
 } from "./SourceConfigEntity.js";
+export { SportOrgEntity } from "./SportOrgEntity.js";
+export { AgentModelEntity, type AgentModelConfig } from "./AgentModelEntity.js";
+export { IngestionLogEntity, type IngestionLog } from "./IngestionLogEntity.js";
+export { PromptEntity, type PromptConfig } from "./PromptEntity.js";

--- a/packages/shared/src/entities/schema.ts
+++ b/packages/shared/src/entities/schema.ts
@@ -1,0 +1,125 @@
+/**
+ * OneTable schema defining the DynamoDB single-table structure
+ * and all entity models for the USOPC Athlete Support Agent.
+ *
+ * Phase 1 implements SourceConfig; other models are defined
+ * here for future phases.
+ */
+export const AppTableSchema = {
+  format: "onetable:1.1.0",
+  version: "0.0.1",
+  indexes: {
+    primary: { hash: "pk", sort: "sk" },
+    "ngbId-index": { hash: "ngbId", sort: "pk", project: "all" },
+    "enabled-priority-index": { hash: "enabled", sort: "sk", project: "all" },
+    gsi1: { hash: "gsi1pk", sort: "gsi1sk", project: "all" },
+  },
+  models: {
+    SourceConfig: {
+      pk: { type: String, value: "SOURCE#${id}" },
+      sk: { type: String, value: "CONFIG" },
+      id: { type: String, required: true },
+      title: { type: String, required: true },
+      documentType: { type: String, required: true },
+      topicDomains: { type: Array, items: { type: String } },
+      url: { type: String, required: true },
+      format: {
+        type: String,
+        required: true,
+        enum: ["pdf", "html", "text"] as const,
+      },
+      ngbId: { type: String }, // omitted when null for sparse GSI
+      priority: {
+        type: String,
+        required: true,
+        enum: ["high", "medium", "low"] as const,
+      },
+      description: { type: String, required: true },
+      authorityLevel: { type: String, required: true },
+      enabled: { type: String, required: true }, // "true"/"false" string for GSI
+      lastIngestedAt: { type: String },
+      lastContentHash: { type: String },
+      consecutiveFailures: { type: Number, default: 0 },
+      lastError: { type: String },
+      s3Key: { type: String },
+      s3VersionId: { type: String },
+      createdAt: { type: String },
+      updatedAt: { type: String },
+    },
+    SportOrganization: {
+      pk: { type: String, value: "SPORTORG#${id}" },
+      sk: { type: String, value: "PROFILE" },
+      id: { type: String, required: true },
+      type: {
+        type: String,
+        required: true,
+        enum: ["ngb", "usopc_managed"] as const,
+      },
+      officialName: { type: String, required: true },
+      abbreviation: { type: String },
+      sports: { type: Array, items: { type: String } },
+      olympicProgram: { type: String }, // null -> omitted for sparse
+      paralympicManaged: { type: Boolean, default: false },
+      websiteUrl: { type: String, required: true },
+      bylawsUrl: { type: String },
+      selectionProceduresUrl: { type: String },
+      internationalFederation: { type: String },
+      aliases: { type: Array, items: { type: String }, default: [] },
+      keywords: { type: Array, items: { type: String }, default: [] },
+      status: {
+        type: String,
+        required: true,
+        enum: ["active", "decertified"] as const,
+      },
+      effectiveDate: { type: String, required: true },
+      createdAt: { type: String },
+      updatedAt: { type: String },
+    },
+    AgentModel: {
+      pk: { type: String, value: "AGENT#${id}" },
+      sk: { type: String, value: "CONFIG" },
+      id: { type: String, required: true },
+      role: { type: String, required: true },
+      model: { type: String, required: true },
+      temperature: { type: Number },
+      maxTokens: { type: Number },
+      dimensions: { type: Number },
+      createdAt: { type: String },
+      updatedAt: { type: String },
+    },
+    IngestionLog: {
+      pk: { type: String, value: "SOURCE#${sourceId}" },
+      sk: { type: String, value: "INGEST#${startedAt}" },
+      gsi1pk: { type: String, value: "INGEST" },
+      gsi1sk: { type: String, value: "${startedAt}" },
+      sourceId: { type: String, required: true },
+      sourceUrl: { type: String },
+      status: {
+        type: String,
+        required: true,
+        enum: ["pending", "in_progress", "completed", "failed"] as const,
+      },
+      contentHash: { type: String },
+      chunksCount: { type: Number },
+      errorMessage: { type: String },
+      startedAt: { type: String, required: true },
+      completedAt: { type: String },
+      createdAt: { type: String },
+    },
+    Prompt: {
+      pk: { type: String, value: "PROMPT#${name}" },
+      sk: { type: String, value: "CONFIG" },
+      name: { type: String, required: true },
+      content: { type: String, required: true },
+      domain: { type: String },
+      version: { type: Number, default: 1 },
+      updatedAt: { type: String },
+      createdAt: { type: String },
+    },
+  },
+  params: {
+    timestamps: false,
+    nulls: false,
+    isoDates: false,
+  },
+} as const;

--- a/packages/shared/src/entities/table.ts
+++ b/packages/shared/src/entities/table.ts
@@ -1,0 +1,23 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import Dynamo from "dynamodb-onetable/Dynamo";
+import { Table } from "dynamodb-onetable";
+import { AppTableSchema } from "./schema.js";
+
+/**
+ * Create a OneTable Table instance connected to the AppTable.
+ *
+ * @param tableName - DynamoDB table name (from SST Resource)
+ * @param client - Optional pre-configured DynamoDBClient (useful for testing)
+ */
+export function createAppTable(
+  tableName: string,
+  client?: DynamoDBClient,
+): Table<typeof AppTableSchema> {
+  const dynamoClient = client ?? new DynamoDBClient({});
+  return new Table({
+    name: tableName,
+    client: new Dynamo({ client: dynamoClient }),
+    schema: AppTableSchema,
+    partial: true, // Allow partial updates
+  });
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -57,9 +57,21 @@ export {
   type DocumentType,
 } from "./validation.js";
 
+export { AppTableSchema } from "./entities/index.js";
+export { createAppTable } from "./entities/index.js";
 export {
   SourceConfigEntity,
   type SourceConfig,
   type CreateSourceInput,
   type MarkSuccessOptions,
 } from "./entities/index.js";
+export { SportOrgEntity } from "./entities/index.js";
+export { AgentModelEntity, type AgentModelConfig } from "./entities/index.js";
+export { IngestionLogEntity, type IngestionLog } from "./entities/index.js";
+export { PromptEntity, type PromptConfig } from "./entities/index.js";
+export type {
+  OlympicProgram,
+  OrgStatus,
+  OrgType,
+  SportOrganization,
+} from "./types/sport-org.js";

--- a/packages/shared/src/types/sport-org.ts
+++ b/packages/shared/src/types/sport-org.ts
@@ -1,0 +1,21 @@
+export type OlympicProgram = "summer" | "winter" | "pan_american";
+export type OrgStatus = "active" | "decertified";
+export type OrgType = "ngb" | "usopc_managed";
+
+export interface SportOrganization {
+  id: string;
+  type: OrgType;
+  officialName: string;
+  abbreviation?: string;
+  sports: string[];
+  olympicProgram: OlympicProgram | null;
+  paralympicManaged: boolean;
+  websiteUrl: string;
+  bylawsUrl?: string;
+  selectionProceduresUrl?: string;
+  internationalFederation?: string;
+  aliases: string[];
+  keywords: string[];
+  status: OrgStatus;
+  effectiveDate: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,9 +121,6 @@ importers:
       '@aws-sdk/client-sqs':
         specifier: ^3.981.0
         version: 3.981.0
-      '@aws-sdk/lib-dynamodb':
-        specifier: ^3.981.0
-        version: 3.982.0(@aws-sdk/client-dynamodb@3.982.0)
       '@usopc/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -258,9 +255,6 @@ importers:
       '@aws-sdk/client-sqs':
         specifier: ^3.981.0
         version: 3.981.0
-      '@aws-sdk/lib-dynamodb':
-        specifier: ^3.981.0
-        version: 3.982.0(@aws-sdk/client-dynamodb@3.982.0)
       '@langchain/community':
         specifier: ^0.3.22
         version: 0.3.59(@aws-crypto/sha256-js@5.2.0)(@aws-sdk/client-dynamodb@3.982.0)(@aws-sdk/client-s3@3.982.0)(@aws-sdk/credential-provider-node@3.972.5)(@browserbasehq/sdk@2.6.0)(@browserbasehq/stagehand@1.14.0(@playwright/test@1.58.1)(deepmerge@4.3.1)(dotenv@16.6.1)(openai@4.104.0(ws@8.19.0)(zod@3.25.76))(zod@3.25.76))(@ibm-cloud/watsonx-ai@1.7.7)(@langchain/anthropic@0.3.34(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76)))(zod@3.25.76))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@4.104.0(ws@8.19.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(@smithy/util-utf8@2.3.0)(axios@1.13.4)(cheerio@1.2.0)(fast-xml-parser@5.3.4)(ibm-cloud-sdk-core@5.4.5)(jsdom@26.1.0)(jsonwebtoken@9.0.3)(openai@4.104.0(ws@8.19.0)(zod@3.25.76))(pdf-parse@1.1.4)(pg@8.18.0)(playwright@1.58.1)(weaviate-client@3.11.0)(ws@8.19.0)
@@ -319,9 +313,9 @@ importers:
       '@aws-sdk/client-dynamodb':
         specifier: ^3.981.0
         version: 3.982.0
-      '@aws-sdk/lib-dynamodb':
-        specifier: ^3.981.0
-        version: 3.982.0(@aws-sdk/client-dynamodb@3.982.0)
+      dynamodb-onetable:
+        specifier: ^2.7
+        version: 2.7.7
       pg:
         specifier: ^8.14.1
         version: 8.18.0
@@ -540,12 +534,6 @@ packages:
   '@aws-sdk/endpoint-cache@3.972.2':
     resolution: {integrity: sha512-3L7mwqSLJ6ouZZKtCntoNF0HTYDNs1FDQqkGjoPWXcv1p0gnLotaDmLq1rIDqfu4ucOit0Re3ioLyYDUTpSroA==}
     engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/lib-dynamodb@3.982.0':
-    resolution: {integrity: sha512-7wdaH3OcG7tRWD+9Mm6iN/u/Ccw3Ley/m8nSeTFocBj4fqkJwpa4k3vfS1uLlDqynnn6NIXPSrpuikzE1nlwSA==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@aws-sdk/client-dynamodb': 3.982.0
 
   '@aws-sdk/middleware-bucket-endpoint@3.972.3':
     resolution: {integrity: sha512-fmbgWYirF67YF1GfD7cg5N6HHQ96EyRNx/rDIrTF277/zTWVuPI2qS/ZHgofwR1NZPe/NWvoppflQY01LrbVLg==}
@@ -2814,6 +2802,9 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  custom-metrics@1.1.0:
+    resolution: {integrity: sha512-DUflupebUOtqd8xAhL8blq7PrXdLGoU9h2bE43Dcxob9oNrEn05NwMNZQUwwERuIQD2WCjGj0zyZAbv+RIMVQg==}
+
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
@@ -2903,6 +2894,10 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  dynamodb-onetable@2.7.7:
+    resolution: {integrity: sha512-yugIXk9XO1mnwKyqIuPnIQMg0uXaE6p/dNjEcxVePPnwjaAL+iHxnJ33dv8a//Q1Tug/qbeduaZDpUYjlTyKLw==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
@@ -5427,16 +5422,6 @@ snapshots:
       mnemonist: 0.38.3
       tslib: 2.8.1
 
-  '@aws-sdk/lib-dynamodb@3.982.0(@aws-sdk/client-dynamodb@3.982.0)':
-    dependencies:
-      '@aws-sdk/client-dynamodb': 3.982.0
-      '@aws-sdk/core': 3.973.6
-      '@aws-sdk/util-dynamodb': 3.982.0(@aws-sdk/client-dynamodb@3.982.0)
-      '@smithy/core': 3.22.1
-      '@smithy/smithy-client': 4.11.2
-      '@smithy/types': 4.12.0
-      tslib: 2.8.1
-
   '@aws-sdk/middleware-bucket-endpoint@3.972.3':
     dependencies:
       '@aws-sdk/types': 3.973.1
@@ -7602,6 +7587,13 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  custom-metrics@1.1.0:
+    dependencies:
+      '@aws-sdk/client-dynamodb': 3.982.0
+      '@aws-sdk/util-dynamodb': 3.982.0(@aws-sdk/client-dynamodb@3.982.0)
+    transitivePeerDependencies:
+      - aws-crt
+
   data-urls@5.0.0:
     dependencies:
       whatwg-mimetype: 4.0.0
@@ -7676,6 +7668,14 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  dynamodb-onetable@2.7.7:
+    dependencies:
+      '@aws-sdk/client-dynamodb': 3.982.0
+      '@aws-sdk/util-dynamodb': 3.982.0(@aws-sdk/client-dynamodb@3.982.0)
+      custom-metrics: 1.1.0
+    transitivePeerDependencies:
+      - aws-crt
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:


### PR DESCRIPTION
## Summary

Closes #80

Adopts the **One Table** pattern using `dynamodb-onetable` to formalize entity schemas, replace hand-rolled AWS SDK v3 commands, and add four new runtime-configurable entity types to DynamoDB.

### Infrastructure
- Rename SST resource `SourceConfigs` → `AppTable`, add `gsi1` index for cross-entity time queries
- Link `AppTable` to API Lambda for SportOrganization access

### Entities (packages/shared)
- **SourceConfigEntity** — rewritten to use OneTable Model API; public interface unchanged
- **SportOrgEntity** (new) — CRUD + fuzzy `search(query)` for sport organizations
- **AgentModelEntity** (new) — `get`/`upsert`/`getAll` for runtime model configuration
- **IngestionLogEntity** (new) — replaces Postgres `ingestion_status` table with DynamoDB
- **PromptEntity** (new) — infrastructure for runtime-editable prompt management

### Wiring
- **API router** (`ngbs.ts`): SportOrgEntity replaces static JSON file reads
- **Agent tools** (`lookupSportOrg.ts`): accepts SportOrgEntity parameter instead of file I/O
- **Sport org registry** (`sportOrgRegistry.ts`): entity-backed with TTL cache
- **Model config** (`models.ts`): async `getModelConfig()` with 5-min TTL cache and hardcoded fallback
- **Classifier/synthesizer nodes**: use async model config loading
- **Ingestion worker/cron** (`db.ts`, `worker.ts`, `cron.ts`): IngestionLogEntity replaces Pool-based Postgres calls
- **Prompt loader** (`loader.ts`): TTL-cached async prompt loading (infrastructure only, not yet wired to agent nodes)
- **Seed script**: extended to seed SportOrganizations from `data/sport-organizations.json`

### Dependencies
- Added: `dynamodb-onetable@^2.7` to `@usopc/shared`
- Removed: `@aws-sdk/lib-dynamodb` from shared, ingestion, web

## Test plan

- [x] `pnpm --filter @usopc/shared test` — 199 tests pass (SourceConfig 16, SportOrg 18, AgentModel 9, IngestionLog 14, Prompt 10, + existing)
- [x] `pnpm --filter @usopc/core test` — 432 tests pass
- [x] `pnpm --filter @usopc/api test` — 19 tests pass
- [x] `pnpm --filter @usopc/ingestion test` — passes (2 pre-existing failures in parseArgs unrelated to this PR)
- [x] `pnpm --filter @usopc/web test` — passes (1 pre-existing date formatting failure unrelated to this PR)
- [x] `pnpm typecheck` — all packages clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)