### PR TITLE
feat: Add local dev default for DATABASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 24.4 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 25.3 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -132,10 +132,10 @@ Slack integration is under development. See [#7](https://github.com/rosinbum/uso
 See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
-**Tracked build time:** 24.4 hours
+**Tracked build time:** 25.3 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-11T15:11:18.805Z
+- Last updated: 2026-02-11T16:07:06.817Z
 <!-- HOURS:END -->
 
 ## License

--- a/packages/shared/src/env.test.ts
+++ b/packages/shared/src/env.test.ts
@@ -139,13 +139,39 @@ describe("getDatabaseUrl", () => {
     expect(url).toContain("p%40ss%3Aword%2F123");
   });
 
-  it("throws when neither DATABASE_URL nor SST Resource is available", () => {
+  it("throws when neither DATABASE_URL nor SST Resource is available in production", () => {
     delete process.env.DATABASE_URL;
+    process.env.NODE_ENV = "production";
     // mockResource.Database is not set, so accessing it will throw
 
     expect(() => getDatabaseUrl()).toThrow(
       "DATABASE_URL is not set and SST Database resource is not available",
     );
+  });
+
+  it("returns local dev default when in development mode and no other source", () => {
+    delete process.env.DATABASE_URL;
+    process.env.NODE_ENV = "development";
+
+    expect(getDatabaseUrl()).toBe(
+      "postgresql://postgres:postgres@localhost:5432/usopc_athlete_support",
+    );
+  });
+
+  it("returns local dev default when NODE_ENV is unset and no other source", () => {
+    delete process.env.DATABASE_URL;
+    delete process.env.NODE_ENV;
+
+    expect(getDatabaseUrl()).toBe(
+      "postgresql://postgres:postgres@localhost:5432/usopc_athlete_support",
+    );
+  });
+
+  it("prefers DATABASE_URL over local dev default", () => {
+    process.env.DATABASE_URL = "postgresql://custom:5433/other";
+    process.env.NODE_ENV = "development";
+
+    expect(getDatabaseUrl()).toBe("postgresql://custom:5433/other");
   });
 
   it("prefers DATABASE_URL over SST Resource", () => {

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -27,6 +27,9 @@ export function getOptionalEnv(
   return value;
 }
 
+const LOCAL_DEV_DATABASE_URL =
+  "postgresql://postgres:postgres@localhost:5432/usopc_athlete_support";
+
 /**
  * Returns the database connection URL.
  *
@@ -34,7 +37,8 @@ export function getOptionalEnv(
  *   1. `DATABASE_URL` environment variable (set directly or via .env)
  *   2. SST Resource binding (`Resource.Database` with `host`, `port`,
  *      `username`, `password`, `database` fields).
- *   3. Throws if neither source is available.
+ *   3. In development mode, falls back to the standard local Docker URL.
+ *   4. Throws if neither source is available.
  */
 export function getDatabaseUrl(): string {
   const directUrl = process.env.DATABASE_URL;
@@ -48,6 +52,9 @@ export function getDatabaseUrl(): string {
       .Database;
     return `postgresql://${encodeURIComponent(db.username)}:${encodeURIComponent(db.password)}@${db.host}:${db.port}/${db.database}`;
   } catch {
+    if (isDevelopment()) {
+      return LOCAL_DEV_DATABASE_URL;
+    }
     throw new Error(
       "DATABASE_URL is not set and SST Database resource is not available. " +
         "Provide DATABASE_URL or deploy with SST resource bindings.",


### PR DESCRIPTION
## Summary

- `getDatabaseUrl()` now falls back to the standard local Docker Postgres URL (`postgresql://postgres:postgres@localhost:5432/usopc_athlete_support`) when in development mode and neither `DATABASE_URL` nor SST Resource is available
- Removes the need to manually export `DATABASE_URL` before running CLI scripts like `pnpm seed` or `pnpm ingest` locally

Closes #82

## Changes

- **`packages/shared/src/env.ts`** — Add `LOCAL_DEV_DATABASE_URL` constant; return it from `getDatabaseUrl()` catch block when `isDevelopment()` is true
- **`packages/shared/src/env.test.ts`** — Add 3 new tests (dev default with `NODE_ENV=development`, dev default with `NODE_ENV` unset, `DATABASE_URL` precedence over default); update existing throw test to explicitly set `NODE_ENV=production`

## Test plan

- [x] `pnpm --filter @usopc/shared test` — 202 tests pass
- [x] `pnpm --filter @usopc/shared typecheck` — clean
- [x] Manual: run `pnpm seed -- --init-only` without setting `DATABASE_URL` — should connect to local Docker Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)