### PR TITLE
chore: Remove obsolete ingestion_status PostgreSQL table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 25.3 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 25.9 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -132,10 +132,10 @@ Slack integration is under development. See [#7](https://github.com/rosinbum/uso
 See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
-**Tracked build time:** 25.3 hours
+**Tracked build time:** 25.9 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-11T16:07:06.817Z
+- Last updated: 2026-02-11T17:26:15.319Z
 <!-- HOURS:END -->
 
 ## License

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -21,4 +21,4 @@ npx prettier --check .                   # Check entire repo
 - **Scripts needing AWS resources**: Wrap with `sst shell --` in package.json (e.g., `"ingest": "sst shell -- tsx src/scripts/ingest.ts"`). This injects SST Resource bindings. Don't add `process.env.SOME_CONFIG` fallbacks—use SST Resources only.
 - **DynamoDB GSI keys cannot be null**: When using a Global Secondary Index, omit the attribute entirely rather than setting it to `null`. This creates a sparse index where items without the attribute aren't indexed.
 - **Path resolution in scripts**: Scripts in `packages/*/src/scripts/` need 4 levels up (`../../../../`) to reach repo root.
-- **Database**: PostgreSQL with pgvector. Schema includes `document_chunks` (embeddings with HNSW index), `conversations`, `messages`, `feedback`, `ingestion_status`. Migrations run through the API package.
+- **Database**: PostgreSQL with pgvector. Schema includes `document_chunks` (embeddings with HNSW index), `conversations`, `messages`, `feedback`. Ingestion tracking lives in DynamoDB. Migrations run through the API package.

--- a/packages/ingestion/src/scripts/seed-db.ts
+++ b/packages/ingestion/src/scripts/seed-db.ts
@@ -40,12 +40,11 @@ async function initDatabase(pool: Pool): Promise<void> {
 }
 
 /**
- * Remove all rows from `document_chunks` and `ingestion_status`.
+ * Remove all rows from `document_chunks`.
  */
 async function clearDocuments(pool: Pool): Promise<void> {
   await pool.query("DELETE FROM document_chunks");
-  await pool.query("DELETE FROM ingestion_status");
-  logger.info("Cleared document_chunks and ingestion_status tables");
+  logger.info("Cleared document_chunks table");
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/init-db.sql
+++ b/scripts/init-db.sql
@@ -62,19 +62,3 @@ CREATE TABLE IF NOT EXISTS feedback (
   comment TEXT,
   created_at TIMESTAMPTZ DEFAULT NOW()
 );
-
--- Ingestion status table
-CREATE TABLE IF NOT EXISTS ingestion_status (
-  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  source_id TEXT NOT NULL,
-  source_url TEXT NOT NULL,
-  content_hash TEXT,
-  status TEXT NOT NULL CHECK (status IN ('pending', 'ingesting', 'completed', 'failed')),
-  chunks_count INTEGER DEFAULT 0,
-  error_message TEXT,
-  started_at TIMESTAMPTZ,
-  completed_at TIMESTAMPTZ,
-  created_at TIMESTAMPTZ DEFAULT NOW()
-);
-
-CREATE INDEX IF NOT EXISTS idx_ingestion_source ON ingestion_status (source_id);


### PR DESCRIPTION
Closes #85

## Summary

- Remove `ingestion_status` table definition and index from `scripts/init-db.sql`
- Remove `DELETE FROM ingestion_status` from `clearDocuments()` in `seed-db.ts`
- Update `docs/conventions.md` to reflect that ingestion tracking lives in DynamoDB

Ingestion tracking was migrated to the DynamoDB `IngestionLog` entity in #80/#81. These are the leftover references to the old PostgreSQL table.

## Test plan

- [x] `pnpm --filter @usopc/ingestion test` — all tests pass (2 pre-existing failures in `ingest.test.ts` unrelated to this change)
- [x] `grep -r ingestion_status` returns no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)