### PR TITLE
feat: Unified seed command for full local dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 25.9 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 26.1 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -132,10 +132,10 @@ Slack integration is under development. See [#7](https://github.com/rosinbum/uso
 See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
-**Tracked build time:** 25.9 hours
+**Tracked build time:** 26.1 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-11T17:30:12.267Z
+- Last updated: 2026-02-11T18:13:47.427Z
 <!-- HOURS:END -->
 
 ## License

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -43,9 +43,15 @@ All ingestion scripts require SST context (secrets and resources).
 ```bash
 pnpm ingest                        # Run document ingestion
 pnpm ingest -- --source <id>       # Ingest single source
-pnpm seed                          # Seed Postgres database
+pnpm seed                          # Full local setup (PG + DynamoDB + optional ingest)
+pnpm seed -- --skip-ingest         # PG + DynamoDB only (skip document ingestion)
+pnpm seed -- --force               # Overwrite existing DynamoDB items + re-ingest all
+pnpm seed -- --dry-run             # Preview DynamoDB changes, skip ingestion
+pnpm seed:pg                       # Seed Postgres only (schema + ingestion)
+pnpm seed:pg -- --init-only        # Postgres schema init only
 pnpm seed:dynamodb                 # Seed DynamoDB source configs from JSON
-pnpm seed:dynamodb -- --dry-run    # Preview migration
+pnpm seed:dynamodb -- --dry-run    # Preview DynamoDB changes
+pnpm seed:dynamodb -- --force      # Overwrite existing DynamoDB items
 ```
 
 ## Source Management

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "db:migrate": "pnpm --filter @usopc/api db:migrate",
     "ingest": "pnpm --filter @usopc/ingestion ingest",
     "seed": "pnpm --filter @usopc/ingestion seed",
+    "seed:pg": "pnpm --filter @usopc/ingestion seed:pg",
     "seed:dynamodb": "pnpm --filter @usopc/ingestion seed:dynamodb",
     "sources": "pnpm --filter @usopc/ingestion sources"
   },

--- a/packages/ingestion/package.json
+++ b/packages/ingestion/package.json
@@ -10,7 +10,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "ingest": "sst shell -- tsx src/scripts/ingest.ts",
-    "seed": "tsx src/scripts/seed-db.ts",
+    "seed": "sst shell -- tsx src/scripts/seed.ts",
+    "seed:pg": "sst shell -- tsx src/scripts/seed-db.ts",
     "seed:dynamodb": "sst shell -- tsx src/scripts/seed-dynamodb.ts",
     "sources": "sst shell -- tsx src/scripts/sources-cli.ts",
     "clean": "rm -rf dist"

--- a/packages/ingestion/src/scripts/seed-dynamodb.ts
+++ b/packages/ingestion/src/scripts/seed-dynamodb.ts
@@ -50,7 +50,7 @@ interface SourceFile {
 // CLI argument parsing
 // ---------------------------------------------------------------------------
 
-interface CliOptions {
+export interface CliOptions {
   dryRun: boolean;
   force: boolean;
 }
@@ -113,7 +113,7 @@ async function loadSourcesFromJson(): Promise<CreateSourceInput[]> {
   return allSources;
 }
 
-async function seedSourceConfigs(options: CliOptions): Promise<void> {
+export async function seedSourceConfigs(options: CliOptions): Promise<void> {
   const sources = await loadSourcesFromJson();
   logger.info(`Loaded ${sources.length} source(s) from JSON files`);
 
@@ -188,7 +188,7 @@ async function loadSportOrgsFromJson(): Promise<SportOrganization[]> {
   return JSON.parse(raw) as SportOrganization[];
 }
 
-async function seedSportOrgs(options: CliOptions): Promise<void> {
+export async function seedSportOrgs(options: CliOptions): Promise<void> {
   const orgs = await loadSportOrgsFromJson();
   logger.info(`Loaded ${orgs.length} sport organization(s) from JSON`);
 
@@ -272,9 +272,16 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((error) => {
-  logger.error(
-    `Fatal error: ${error instanceof Error ? error.message : String(error)}`,
-  );
-  process.exit(1);
-});
+// Only run main() when executed directly (not when imported by tests or orchestrator)
+const isDirectExecution =
+  typeof process.env.VITEST === "undefined" &&
+  typeof process.env.NODE_TEST === "undefined";
+
+if (isDirectExecution) {
+  main().catch((error) => {
+    logger.error(
+      `Fatal error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  });
+}

--- a/packages/ingestion/src/scripts/seed.test.ts
+++ b/packages/ingestion/src/scripts/seed.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@usopc/shared", () => ({
+  getDatabaseUrl: () => "postgresql://localhost/test",
+  getSecretValue: () => "sk-test",
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(),
+  }),
+  isProduction: () => false,
+}));
+
+vi.mock("./seed-db.js", () => ({
+  initDatabase: vi.fn(async () => {}),
+  loadAllSources: vi.fn(async () => []),
+  repoRoot: vi.fn(() => "/fake/root"),
+}));
+
+vi.mock("./seed-dynamodb.js", () => ({
+  seedSourceConfigs: vi.fn(async () => {}),
+  seedSportOrgs: vi.fn(async () => {}),
+}));
+
+vi.mock("../pipeline.js", () => ({
+  ingestAll: vi.fn(async () => []),
+}));
+
+// Import after mocks
+import { parseArgs } from "./seed.js";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("parseArgs", () => {
+  it("defaults to all flags false when no args", () => {
+    const result = parseArgs([]);
+    expect(result.skipIngest).toBe(false);
+    expect(result.force).toBe(false);
+    expect(result.dryRun).toBe(false);
+  });
+
+  it("parses --skip-ingest", () => {
+    const result = parseArgs(["--skip-ingest"]);
+    expect(result.skipIngest).toBe(true);
+    expect(result.force).toBe(false);
+    expect(result.dryRun).toBe(false);
+  });
+
+  it("parses --force", () => {
+    const result = parseArgs(["--force"]);
+    expect(result.force).toBe(true);
+    expect(result.skipIngest).toBe(false);
+    expect(result.dryRun).toBe(false);
+  });
+
+  it("parses --dry-run", () => {
+    const result = parseArgs(["--dry-run"]);
+    expect(result.dryRun).toBe(true);
+    expect(result.force).toBe(false);
+    expect(result.skipIngest).toBe(false);
+  });
+
+  it("parses multiple flags together", () => {
+    const result = parseArgs(["--skip-ingest", "--force"]);
+    expect(result.skipIngest).toBe(true);
+    expect(result.force).toBe(true);
+    expect(result.dryRun).toBe(false);
+  });
+
+  it("parses all flags together", () => {
+    const result = parseArgs(["--dry-run", "--force", "--skip-ingest"]);
+    expect(result.skipIngest).toBe(true);
+    expect(result.force).toBe(true);
+    expect(result.dryRun).toBe(true);
+  });
+
+  it("ignores unknown flags", () => {
+    const result = parseArgs(["--unknown", "--skip-ingest"]);
+    expect(result.skipIngest).toBe(true);
+    expect(result.force).toBe(false);
+    expect(result.dryRun).toBe(false);
+  });
+});

--- a/packages/ingestion/src/scripts/seed.ts
+++ b/packages/ingestion/src/scripts/seed.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env tsx
+/**
+ * Unified seed script — initializes the full local dev environment.
+ *
+ * Sequence:
+ *   1. PG schema init   — runs init-db.sql
+ *   2. DynamoDB seed     — seeds source configs + sport organizations
+ *   3. Document ingest   — optional, requires OPENAI_API_KEY
+ *
+ * Usage:
+ *   pnpm seed                     # full setup (ingest if API key available)
+ *   pnpm seed -- --skip-ingest    # PG + DynamoDB only
+ *   pnpm seed -- --force          # overwrite DynamoDB + re-ingest all
+ *   pnpm seed -- --dry-run        # preview DynamoDB changes, skip ingest
+ *
+ * Requires SST context (run via `pnpm seed` which uses `sst shell`).
+ */
+
+import { Pool } from "pg";
+import { getDatabaseUrl, getSecretValue, createLogger } from "@usopc/shared";
+import { initDatabase, loadAllSources, repoRoot } from "./seed-db.js";
+import {
+  seedSourceConfigs,
+  seedSportOrgs,
+  type CliOptions,
+} from "./seed-dynamodb.js";
+import { ingestAll } from "../pipeline.js";
+
+const logger = createLogger({ service: "seed" });
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+export interface ParsedArgs {
+  skipIngest: boolean;
+  force: boolean;
+  dryRun: boolean;
+}
+
+export function parseArgs(argv: string[] = process.argv.slice(2)): ParsedArgs {
+  let skipIngest = false;
+  let force = false;
+  let dryRun = false;
+
+  for (const arg of argv) {
+    if (arg === "--skip-ingest") {
+      skipIngest = true;
+    } else if (arg === "--force") {
+      force = true;
+    } else if (arg === "--dry-run") {
+      dryRun = true;
+    }
+  }
+
+  return { skipIngest, force, dryRun };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const { skipIngest, force, dryRun } = parseArgs();
+  const databaseUrl = getDatabaseUrl();
+  const pool = new Pool({ connectionString: databaseUrl });
+
+  try {
+    // Step 1: PG schema init
+    logger.info("--- Step 1: PostgreSQL schema init ---");
+    await initDatabase(pool);
+
+    // Step 2: DynamoDB seed
+    logger.info("--- Step 2: DynamoDB seed ---");
+    const dynamoOptions: CliOptions = { dryRun, force };
+    await seedSourceConfigs(dynamoOptions);
+    await seedSportOrgs(dynamoOptions);
+
+    // Step 3: Document ingestion (optional)
+    if (dryRun) {
+      logger.info("--- Step 3: Skipping ingestion (--dry-run) ---");
+    } else if (skipIngest) {
+      logger.info("--- Step 3: Skipping ingestion (--skip-ingest) ---");
+    } else {
+      let openaiApiKey: string | undefined;
+      try {
+        openaiApiKey = getSecretValue("OPENAI_API_KEY", "OpenaiApiKey");
+      } catch {
+        // Key not available — skip gracefully
+      }
+
+      if (!openaiApiKey) {
+        logger.warn(
+          "--- Step 3: Skipping ingestion (OPENAI_API_KEY not found) ---",
+        );
+      } else {
+        logger.info("--- Step 3: Document ingestion ---");
+        const sources = await loadAllSources();
+        logger.info(`Loaded ${sources.length} source configuration(s)`);
+
+        const results = await ingestAll(sources, {
+          databaseUrl,
+          openaiApiKey,
+        });
+
+        const succeeded = results.filter((r) => r.status === "completed");
+        const failed = results.filter((r) => r.status === "failed");
+        const totalChunks = results.reduce((sum, r) => sum + r.chunksCount, 0);
+
+        logger.info(
+          `Ingestion: ${succeeded.length}/${results.length} succeeded, ${totalChunks} total chunks`,
+        );
+
+        if (failed.length > 0) {
+          logger.error("Failed sources:");
+          for (const f of failed) {
+            logger.error(`  - ${f.sourceId}: ${f.error}`);
+          }
+          process.exit(1);
+        }
+      }
+    }
+
+    logger.info("Seed complete.");
+  } finally {
+    await pool.end();
+  }
+}
+
+// Only run main() when executed directly (not when imported by tests)
+const isDirectExecution =
+  typeof process.env.VITEST === "undefined" &&
+  typeof process.env.NODE_TEST === "undefined";
+
+if (isDirectExecution) {
+  main().catch((error) => {
+    logger.error(
+      `Fatal error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
Closes #87

## Summary

- **New unified `pnpm seed`** that orchestrates: PG schema init → DynamoDB seed → optional document ingestion (skips gracefully if `OPENAI_API_KEY` not found)
- **Flags:** `--skip-ingest`, `--force`, `--dry-run`
- **Renamed** old `seed` → `seed:pg` for targeted PG-only usage
- **Added import guards** to `seed-db.ts` and `seed-dynamodb.ts` so they can be imported by the orchestrator without auto-executing `main()`
- **Exported** key functions (`initDatabase`, `loadAllSources`, `repoRoot`, `seedSourceConfigs`, `seedSportOrgs`) for reuse

## Files changed

| File | Change |
|---|---|
| `packages/ingestion/src/scripts/seed.ts` | New unified orchestrator |
| `packages/ingestion/src/scripts/seed.test.ts` | Tests for `parseArgs` |
| `packages/ingestion/src/scripts/seed-db.ts` | Export functions, add import guard |
| `packages/ingestion/src/scripts/seed-dynamodb.ts` | Export functions/types, add import guard |
| `packages/ingestion/package.json` | Rename `seed` → `seed:pg`, add new `seed` |
| `package.json` (root) | Add `seed:pg` passthrough |
| `docs/commands.md` | Updated seed command documentation |

## Test plan

- [x] `seed.test.ts` — 7 tests pass (parseArgs flag combinations)
- [x] `pnpm --filter @usopc/ingestion typecheck` — no errors
- [x] Prettier — all files formatted
- [x] Manual: `pnpm seed -- --skip-ingest` inits PG + seeds DynamoDB
- [x] Manual: `pnpm seed:pg -- --init-only` only inits PG schema
- [x] Manual: `pnpm seed:dynamodb -- --dry-run` previews DynamoDB changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)