### PR TITLE
fix: Create IngestionLog entries during seed ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 27.5 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 28.3 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -133,10 +133,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 27.5 hours
+**Tracked build time:** 28.3 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-11T19:41:39.474Z
+- Last updated: 2026-02-11T20:44:48.228Z
 <!-- HOURS:END -->
 
 ## License

--- a/packages/ingestion/src/scripts/seed.test.ts
+++ b/packages/ingestion/src/scripts/seed.test.ts
@@ -29,7 +29,29 @@ vi.mock("./seed-dynamodb.js", () => ({
 }));
 
 vi.mock("../pipeline.js", () => ({
-  ingestAll: vi.fn(async () => []),
+  ingestSource: vi.fn(async () => ({
+    sourceId: "test",
+    status: "completed",
+    chunksCount: 0,
+  })),
+}));
+
+vi.mock("../db.js", () => ({
+  upsertIngestionStatus: vi.fn(async () => {}),
+}));
+
+vi.mock("../entities/index.js", () => ({
+  createIngestionLogEntity: vi.fn(() => ({})),
+  createSourceConfigEntity: vi.fn(() => ({
+    markSuccess: vi.fn(async () => {}),
+    markFailure: vi.fn(async () => {}),
+  })),
+}));
+
+vi.mock("../loaders/fetchWithRetry.js", () => ({
+  fetchWithRetry: vi.fn(async () => ({
+    text: async () => "mock content",
+  })),
 }));
 
 // Import after mocks


### PR DESCRIPTION
## Summary
- The seed script called `ingestAll()` which only writes to PostgreSQL, never creating DynamoDB IngestionLog entries or updating `SourceConfig.lastIngestedAt`
- Replaced with a per-source loop using `ingestSource()` that mirrors the production cron/worker path — calling `upsertIngestionStatus()` before/after each source and `markSuccess()`/`markFailure()` on the SourceConfigEntity
- Computes content hash via `fetchWithRetry` + SHA-256, same as the cron handler

## Test plan
- [x] Existing `parseArgs` tests updated and passing (7/7)
- [x] Run `pnpm seed` and confirm IngestionLog entities appear in DynamoDB
- [x] Verify SourceConfig entities have `lastIngestedAt` populated
- [x] Check `/admin/sources` shows ingestion timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)