### PR TITLE
fix: Classifier incorrectly asks for clarification on sport+competition queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 29.2 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 29.6 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -133,10 +133,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 29.2 hours
+**Tracked build time:** 29.6 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-11T21:58:06.767Z
+- Last updated: 2026-02-11T22:23:56.579Z
 <!-- HOURS:END -->
 
 ## License

--- a/packages/core/src/agent/nodes/classifier.test.ts
+++ b/packages/core/src/agent/nodes/classifier.test.ts
@@ -292,6 +292,32 @@ describe("classifierNode", () => {
     expect(result.needsClarification).toBe(false);
   });
 
+  it("does not request clarification when sport and competition are specified", async () => {
+    mockInvoke.mockResolvedValueOnce(
+      classifierResponse({
+        topicDomain: "team_selection",
+        detectedNgbIds: ["usa_triathlon"],
+        queryIntent: "procedural",
+        hasTimeConstraint: false,
+        shouldEscalate: false,
+        needsClarification: false,
+      }),
+    );
+
+    const state = makeState({
+      messages: [
+        new HumanMessage(
+          "I'm a triathlete competing in the world series races, how will selection work?",
+        ),
+      ],
+    });
+    const result = await classifierNode(state);
+
+    expect(result.needsClarification).toBe(false);
+    expect(result.topicDomain).toBe("team_selection");
+    expect(result.detectedNgbIds).toEqual(["usa_triathlon"]);
+  });
+
   describe("conversation context", () => {
     it("uses conversation history to resolve follow-up questions", async () => {
       // First exchange about swimming team selection

--- a/packages/core/src/prompts/classifier.ts
+++ b/packages/core/src/prompts/classifier.ts
@@ -45,19 +45,24 @@ A brief explanation of why escalation is recommended.
 
 ### needsClarification (required)
 Boolean. True if the query is too ambiguous to answer accurately. Set this to true when:
-- The query mentions "selection" without specifying which team (Olympic, Paralympic, World Championships, etc.)
+- The query mentions "selection" without specifying which team or competition (e.g., Olympic Games, Paralympic Games, World Championships, World Cup, World Series, Grand Prix, Pan American Games, Continental Championships, etc.)
 - Multiple NGBs could apply and it's unclear which one (e.g., "swimming" could be USA Swimming or US Paralympics Swimming)
 - The timeframe is ambiguous (e.g., "upcoming games" without specifying which)
 - The query is too vague to retrieve relevant documents (e.g., "What are the rules?")
 - The sport or competition is not specified when it would significantly affect the answer
 
-Important: Do NOT set needsClarification to true for questions that are clear but simply broad or general. Only set it to true when the ambiguity would lead to a potentially incorrect or irrelevant answer.
+Important: Do NOT set needsClarification to true when:
+- The question is clear but simply broad or general
+- The user specifies both a sport AND a named competition or series (e.g., "triathlon world series", "swimming world championships", "track and field Grand Prix") — this is specific enough to retrieve relevant documents
+- The competition name is any recognizable event, not only the Olympics or World Championships
+
+Only set needsClarification to true when the ambiguity would lead to a potentially incorrect or irrelevant answer.
 
 ### clarificationQuestion (required if needsClarification is true)
 A brief, specific question to ask the user that will resolve the ambiguity. Keep it under 50 words. Examples:
 - "Which sport are you asking about?"
 - "Are you asking about Olympic or Paralympic selection?"
-- "Which competition's selection procedures are you interested in (Olympics, World Championships, etc.)?"
+- "Which competition's selection procedures are you interested in (e.g., Olympics, World Championships, World Cup, World Series)?"
 
 ## Output Format
 


### PR DESCRIPTION
## Summary

- Broadened the `needsClarification` prompt guidance in the classifier to recognize World Series, World Cup, Grand Prix, Pan American Games, Continental Championships, and other named competitions — not just Olympics/Worlds
- Added explicit "Do NOT set needsClarification" rules: when the user specifies both a sport AND a named competition (e.g., "triathlon world series"), route straight to retrieval
- Updated clarification question examples to include broader competition types
- Added test case verifying the classifier does not request clarification for "triathlon world series" queries

## Test plan

- [x] `pnpm --filter @usopc/core test agent/nodes/classifier` — 25 tests pass
- [x] `pnpm --filter @usopc/core test prompts/classifier` — 10 tests pass
- [x] `pnpm --filter @usopc/core typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)