### PR TITLE
fix: Harden ingestion CLI to tolerate individual source failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 30.1 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 30.2 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -133,10 +133,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 30.1 hours
+**Tracked build time:** 30.2 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-11T23:04:42.918Z
+- Last updated: 2026-02-11T23:09:49.614Z
 <!-- HOURS:END -->
 
 ## License


### PR DESCRIPTION
## Summary

- Don't `process.exit(1)` on partial failures in bulk mode — failed sources are already logged and tracked in DynamoDB, so the run exits 0. Fatal/unexpected errors still exit non-zero via the outer `.catch()`.
- Skip sources with permanent HTTP errors (4xx) during `--resume` hash check instead of falling through to a doomed re-ingestion attempt (eliminates the double-fetch pattern visible in logs).
- Change `logger.error` → `logger.warn` for partial failures since these are expected/tolerable.

Closes #97

## Test plan

- [x] `pnpm --filter @usopc/ingestion test scripts/ingest` — all 7 existing parseArgs tests pass
- [x] `pnpm --filter @usopc/ingestion typecheck` — no new type errors (pre-existing `IngestionQueue` binding errors unrelated)
- [ ] Run `pnpm --filter @usopc/ingestion ingest` manually — should complete with exit 0, logging failed sources as warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)