### PR TITLE
fix: NGB-filtered retrieval + standardize metadata keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 30.2 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 31.4 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -133,10 +133,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 30.2 hours
+**Tracked build time:** 31.4 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-11T23:09:49.614Z
+- Last updated: 2026-02-12T14:27:21.442Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/api/src/db/sources.ts
+++ b/apps/api/src/db/sources.ts
@@ -150,14 +150,14 @@ export async function listUniqueDocuments(
       ${COL.ngb_id} as ngb_id,
       ${COL.topic_domain} as topic_domain,
       ${COL.authority_level} as authority_level,
-      metadata->>'effective_date' as effective_date,
+      metadata->>'effectiveDate' as effective_date,
       MIN(ingested_at) as ingested_at,
       COUNT(*) as chunk_count
     FROM document_chunks
     ${whereClause}
     GROUP BY ${COL.source_url}, ${COL.document_title}, ${COL.document_type},
              ${COL.ngb_id}, ${COL.topic_domain}, ${COL.authority_level},
-             metadata->>'effective_date'
+             metadata->>'effectiveDate'
     ORDER BY ingested_at DESC
     LIMIT $${paramIndex} OFFSET $${paramIndex + 1}
   `;

--- a/apps/web/app/api/sources/route.ts
+++ b/apps/web/app/api/sources/route.ts
@@ -24,12 +24,12 @@ interface StatsRow {
 }
 
 const COL = {
-  source_url: "COALESCE(source_url, metadata->>'source_url')",
-  document_title: "COALESCE(document_title, metadata->>'document_title')",
-  document_type: "COALESCE(document_type, metadata->>'document_type')",
-  ngb_id: "COALESCE(ngb_id, metadata->>'ngb_id')",
-  topic_domain: "COALESCE(topic_domain, metadata->>'topic_domain')",
-  authority_level: "COALESCE(authority_level, metadata->>'authority_level')",
+  source_url: "COALESCE(source_url, metadata->>'sourceUrl')",
+  document_title: "COALESCE(document_title, metadata->>'documentTitle')",
+  document_type: "COALESCE(document_type, metadata->>'documentType')",
+  ngb_id: "COALESCE(ngb_id, metadata->>'ngbId')",
+  topic_domain: "COALESCE(topic_domain, metadata->>'topicDomain')",
+  authority_level: "COALESCE(authority_level, metadata->>'authorityLevel')",
 } as const;
 
 export async function GET(request: Request) {
@@ -128,7 +128,7 @@ async function handleList(url: URL) {
       SELECT 1 FROM document_chunks ${whereClause}
       GROUP BY ${COL.source_url}, ${COL.document_title}, ${COL.document_type},
                ${COL.ngb_id}, ${COL.topic_domain}, ${COL.authority_level},
-               metadata->>'effective_date'
+               metadata->>'effectiveDate'
     ) sub`,
     values,
   );
@@ -147,14 +147,14 @@ async function handleList(url: URL) {
       ${COL.ngb_id} as ngb_id,
       ${COL.topic_domain} as topic_domain,
       ${COL.authority_level} as authority_level,
-      metadata->>'effective_date' as effective_date,
+      metadata->>'effectiveDate' as effective_date,
       MIN(ingested_at) as ingested_at,
       COUNT(*) as chunk_count
     FROM document_chunks
     ${whereClause}
     GROUP BY ${COL.source_url}, ${COL.document_title}, ${COL.document_type},
              ${COL.ngb_id}, ${COL.topic_domain}, ${COL.authority_level},
-             metadata->>'effective_date'
+             metadata->>'effectiveDate'
     ORDER BY ingested_at DESC
     LIMIT $${paramIndex} OFFSET $${paramIndex + 1}
     `,

--- a/packages/core/src/prompts/classifier.ts
+++ b/packages/core/src/prompts/classifier.ts
@@ -18,7 +18,7 @@ One of the following values:
 
 ### detectedNgbIds (required)
 An array of NGB or sport organization identifiers mentioned or implied in the query. \
-Use standard abbreviations when possible (e.g., "usa_swimming", "us_ski_snowboard", "usa_track_field"). \
+Use standard abbreviations when possible (e.g., "usa-swimming", "us-ski-snowboard", "usa-track-field"). \
 Return an empty array if no specific NGB is mentioned or can be inferred from the sport name.
 
 ### queryIntent (required)
@@ -70,7 +70,7 @@ Return ONLY valid JSON with no additional text, markdown formatting, or explanat
 
 {
   "topicDomain": "dispute_resolution",
-  "detectedNgbIds": ["usa_swimming"],
+  "detectedNgbIds": ["usa-swimming"],
   "queryIntent": "procedural",
   "hasTimeConstraint": true,
   "shouldEscalate": false,

--- a/packages/core/src/rag/reranker.test.ts
+++ b/packages/core/src/rag/reranker.test.ts
@@ -16,18 +16,18 @@ describe("rerank", () => {
 
   it("boosts documents matching an NGB ID", () => {
     const docs = [
-      makeDoc({ ngb_id: "other" }, "other"),
-      makeDoc({ ngb_id: "usa_swimming" }, "match"),
+      makeDoc({ ngbId: "other" }, "other"),
+      makeDoc({ ngbId: "usa-swimming" }, "match"),
     ];
 
-    const result = rerank(docs, { ngbIds: ["usa_swimming"] });
+    const result = rerank(docs, { ngbIds: ["usa-swimming"] });
     expect(result[0].pageContent).toBe("match");
   });
 
   it("boosts documents matching the topic domain", () => {
     const docs = [
-      makeDoc({ topic_domain: "governance" }, "governance"),
-      makeDoc({ topic_domain: "safesport" }, "safesport"),
+      makeDoc({ topicDomain: "governance" }, "governance"),
+      makeDoc({ topicDomain: "safesport" }, "safesport"),
     ];
 
     const result = rerank(docs, { topicDomain: "safesport" });
@@ -36,8 +36,8 @@ describe("rerank", () => {
 
   it("boosts high-priority document types", () => {
     const docs = [
-      makeDoc({ document_type: "faq" }, "faq"),
-      makeDoc({ document_type: "bylaws" }, "bylaws"),
+      makeDoc({ documentType: "faq" }, "faq"),
+      makeDoc({ documentType: "bylaws" }, "bylaws"),
     ];
 
     const result = rerank(docs);
@@ -52,8 +52,8 @@ describe("rerank", () => {
     old.setFullYear(old.getFullYear() - 5);
 
     const docs = [
-      makeDoc({ effective_date: old.toISOString() }, "old"),
-      makeDoc({ effective_date: recent.toISOString() }, "recent"),
+      makeDoc({ effectiveDate: old.toISOString() }, "old"),
+      makeDoc({ effectiveDate: recent.toISOString() }, "recent"),
     ];
 
     const result = rerank(docs);
@@ -77,20 +77,20 @@ describe("rerank", () => {
     recent.setMonth(recent.getMonth() - 1);
 
     const docs = [
-      makeDoc({ document_type: "faq" }, "low"),
+      makeDoc({ documentType: "faq" }, "low"),
       makeDoc(
         {
-          ngb_id: "usa_swimming",
-          topic_domain: "team_selection",
-          document_type: "selection_procedures",
-          effective_date: recent.toISOString(),
+          ngbId: "usa-swimming",
+          topicDomain: "team_selection",
+          documentType: "selection_procedures",
+          effectiveDate: recent.toISOString(),
         },
         "high",
       ),
     ];
 
     const result = rerank(docs, {
-      ngbIds: ["usa_swimming"],
+      ngbIds: ["usa-swimming"],
       topicDomain: "team_selection",
     });
     expect(result[0].pageContent).toBe("high");
@@ -99,9 +99,9 @@ describe("rerank", () => {
   describe("authority level boosting", () => {
     it("boosts documents with higher authority levels", () => {
       const docs = [
-        makeDoc({ authority_level: "educational_guidance" }, "faq"),
-        makeDoc({ authority_level: "usopc_policy_procedure" }, "policy"),
-        makeDoc({ authority_level: "law" }, "law"),
+        makeDoc({ authorityLevel: "educational_guidance" }, "faq"),
+        makeDoc({ authorityLevel: "usopc_policy_procedure" }, "policy"),
+        makeDoc({ authorityLevel: "law" }, "law"),
       ];
 
       const result = rerank(docs);
@@ -114,16 +114,16 @@ describe("rerank", () => {
     it("stacks authority boost with NGB match boost", () => {
       const docs = [
         makeDoc(
-          { ngb_id: "usa_swimming", authority_level: "ngb_policy_procedure" },
+          { ngbId: "usa-swimming", authorityLevel: "ngb_policy_procedure" },
           "ngb-match-low-auth",
         ),
         makeDoc(
-          { ngb_id: "usa_gymnastics", authority_level: "law" },
+          { ngbId: "usa-gymnastics", authorityLevel: "law" },
           "no-match-high-auth",
         ),
       ];
 
-      const result = rerank(docs, { ngbIds: ["usa_swimming"] });
+      const result = rerank(docs, { ngbIds: ["usa-swimming"] });
       // Both have boosts - NGB match + low authority vs no match + high authority
       // The exact order depends on boost values
       expect(result).toHaveLength(2);
@@ -132,7 +132,7 @@ describe("rerank", () => {
     it("handles documents without authority level", () => {
       const docs = [
         makeDoc({}, "no-authority"),
-        makeDoc({ authority_level: "usopc_governance" }, "has-authority"),
+        makeDoc({ authorityLevel: "usopc_governance" }, "has-authority"),
       ];
 
       const result = rerank(docs);

--- a/packages/core/src/rag/reranker.ts
+++ b/packages/core/src/rag/reranker.ts
@@ -21,16 +21,16 @@ export function rerank(
     let score = 0;
 
     // Metadata match bonuses
-    if (ngbIds?.includes(doc.metadata.ngb_id)) {
+    if (ngbIds?.includes(doc.metadata.ngbId)) {
       score += 0.2;
     }
-    if (topicDomain && doc.metadata.topic_domain === topicDomain) {
+    if (topicDomain && doc.metadata.topicDomain === topicDomain) {
       score += 0.15;
     }
 
     // Recency bonus (documents from last year get a small boost)
-    if (doc.metadata.effective_date) {
-      const effectiveDate = new Date(doc.metadata.effective_date);
+    if (doc.metadata.effectiveDate) {
+      const effectiveDate = new Date(doc.metadata.effectiveDate);
       const oneYearAgo = new Date();
       oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
       if (effectiveDate > oneYearAgo) {
@@ -41,16 +41,16 @@ export function rerank(
     // Priority boost for high-priority document types
     if (
       ["bylaws", "legislation", "selection_procedures"].includes(
-        doc.metadata.document_type,
+        doc.metadata.documentType,
       )
     ) {
       score += 0.1;
     }
 
     // Authority level boost (higher authority = larger boost)
-    if (doc.metadata.authority_level) {
+    if (doc.metadata.authorityLevel) {
       const authorityIndex = AUTHORITY_LEVELS.indexOf(
-        doc.metadata.authority_level as AuthorityLevel,
+        doc.metadata.authorityLevel as AuthorityLevel,
       );
       if (authorityIndex !== -1) {
         // Higher index = lower authority = less boost

--- a/packages/core/src/rag/retriever.test.ts
+++ b/packages/core/src/rag/retriever.test.ts
@@ -75,13 +75,13 @@ describe("retrieve", () => {
       ]);
 
       await retrieve(mockVectorStore as unknown as PGVectorStore, "query", {
-        ngbIds: ["usa_swimming", "us_rowing"],
+        ngbIds: ["usa-swimming", "us-rowing"],
       });
 
       expect(mockVectorStore.similaritySearchWithScore).toHaveBeenCalledWith(
         "query",
         5,
-        { ngb_id: { $in: ["usa_swimming", "us_rowing"] } },
+        { ngbId: { $in: ["usa-swimming", "us-rowing"] } },
       );
     });
 
@@ -113,7 +113,7 @@ describe("retrieve", () => {
       expect(mockVectorStore.similaritySearchWithScore).toHaveBeenCalledWith(
         "query",
         5,
-        { topic_domain: "team_selection" },
+        { topicDomain: "team_selection" },
       );
     });
   });
@@ -125,7 +125,7 @@ describe("retrieve", () => {
       ]);
 
       await retrieve(mockVectorStore as unknown as PGVectorStore, "query", {
-        ngbIds: ["usa_swimming"],
+        ngbIds: ["usa-swimming"],
         topicDomain: "eligibility",
       });
 
@@ -133,8 +133,8 @@ describe("retrieve", () => {
         "query",
         5,
         {
-          ngb_id: { $in: ["usa_swimming"] },
-          topic_domain: "eligibility",
+          ngbId: { $in: ["usa-swimming"] },
+          topicDomain: "eligibility",
         },
       );
     });
@@ -156,7 +156,7 @@ describe("retrieve", () => {
       const result = await retrieve(
         mockVectorStore as unknown as PGVectorStore,
         "query",
-        { ngbIds: ["usa_swimming"], confidenceThreshold: 0.5 },
+        { ngbIds: ["usa-swimming"], confidenceThreshold: 0.5 },
       );
 
       // Should have called twice - narrow then broad
@@ -175,7 +175,7 @@ describe("retrieve", () => {
         .mockResolvedValueOnce([[createDoc("2", "Broad"), 0.8]]);
 
       await retrieve(mockVectorStore as unknown as PGVectorStore, "query", {
-        ngbIds: ["usa_swimming"],
+        ngbIds: ["usa-swimming"],
         topicDomain: "safesport",
         confidenceThreshold: 0.5,
       });
@@ -183,7 +183,7 @@ describe("retrieve", () => {
       // Second call should have only topic filter
       expect(
         mockVectorStore.similaritySearchWithScore.mock.calls[1][2],
-      ).toEqual({ topic_domain: "safesport" });
+      ).toEqual({ topicDomain: "safesport" });
     });
 
     it("should merge narrow and broad results with deduplication", async () => {
@@ -233,7 +233,7 @@ describe("retrieve", () => {
       ]);
 
       await retrieve(mockVectorStore as unknown as PGVectorStore, "query", {
-        ngbIds: ["usa_swimming"],
+        ngbIds: ["usa-swimming"],
         confidenceThreshold: 0.5,
       });
 

--- a/packages/core/src/rag/retriever.ts
+++ b/packages/core/src/rag/retriever.ts
@@ -28,10 +28,10 @@ export async function retrieve(
   // Stage 1: Narrow search with filters
   let filter: Record<string, any> = {};
   if (ngbIds && ngbIds.length > 0) {
-    filter.ngb_id = { $in: ngbIds };
+    filter.ngbId = { $in: ngbIds };
   }
   if (topicDomain) {
-    filter.topic_domain = topicDomain;
+    filter.topicDomain = topicDomain;
   }
 
   const narrowResults = await vectorStore.similaritySearchWithScore(
@@ -55,7 +55,7 @@ export async function retrieve(
     // Remove NGB filter but keep topic if present
     const broadFilter: Record<string, any> = {};
     if (topicDomain) {
-      broadFilter.topic_domain = topicDomain;
+      broadFilter.topicDomain = topicDomain;
     }
 
     const broadResults = await vectorStore.similaritySearchWithScore(

--- a/packages/core/src/tools/fetchDocumentSection.test.ts
+++ b/packages/core/src/tools/fetchDocumentSection.test.ts
@@ -33,7 +33,7 @@ describe("createFetchDocumentSectionTool", () => {
             document_title: "Test Document",
             section_title: null,
             source_url: "https://example.com/doc",
-            ngb_id: "usa_swimming",
+            ngb_id: "usa-swimming",
             topic_domain: "team_selection",
             effective_date: "2024-01-01",
             chunk_index: 0,
@@ -44,7 +44,7 @@ describe("createFetchDocumentSectionTool", () => {
       await tool.invoke({ documentId: "doc-123" });
 
       expect(mockPool.query).toHaveBeenCalledWith(
-        expect.stringContaining("metadata->>'source_id' = $1"),
+        expect.stringContaining("metadata->>'sourceId' = $1"),
         ["doc-123"],
       );
     });
@@ -57,7 +57,7 @@ describe("createFetchDocumentSectionTool", () => {
             document_title: "Selection Procedures",
             section_title: null,
             source_url: "https://usopc.org/selection",
-            ngb_id: "usa_swimming",
+            ngb_id: "usa-swimming",
             topic_domain: "team_selection",
             effective_date: "2024-01-01",
             chunk_index: 0,
@@ -69,7 +69,7 @@ describe("createFetchDocumentSectionTool", () => {
 
       expect(result).toContain("Document: Selection Procedures");
       expect(result).toContain("Source: https://usopc.org/selection");
-      expect(result).toContain("NGB: usa_swimming");
+      expect(result).toContain("NGB: usa-swimming");
       expect(result).toContain("Topic: team_selection");
       expect(result).toContain("Effective Date: 2024-01-01");
       expect(result).toContain("Chunks: 1");
@@ -100,7 +100,7 @@ describe("createFetchDocumentSectionTool", () => {
       });
 
       expect(mockPool.query).toHaveBeenCalledWith(
-        expect.stringContaining("metadata->>'section_title' ILIKE $2"),
+        expect.stringContaining("metadata->>'sectionTitle' ILIKE $2"),
         ["doc-456", "%Eligibility%"],
       );
     });
@@ -275,7 +275,7 @@ describe("createFetchDocumentSectionTool", () => {
             document_title: "Complete Document",
             section_title: "Full Section",
             source_url: "https://full.example.com",
-            ngb_id: "full_ngb",
+            ngb_id: "full-ngb",
             topic_domain: "governance",
             effective_date: "2025-06-15",
             chunk_index: 0,
@@ -291,7 +291,7 @@ describe("createFetchDocumentSectionTool", () => {
       expect(result).toContain("Document: Complete Document");
       expect(result).toContain("Section: Full Section");
       expect(result).toContain("Source: https://full.example.com");
-      expect(result).toContain("NGB: full_ngb");
+      expect(result).toContain("NGB: full-ngb");
       expect(result).toContain("Topic: governance");
       expect(result).toContain("Effective Date: 2025-06-15");
     });

--- a/packages/core/src/tools/fetchDocumentSection.ts
+++ b/packages/core/src/tools/fetchDocumentSection.ts
@@ -47,33 +47,33 @@ export function createFetchDocumentSectionTool(pool: Pool) {
           query = `
             SELECT
               content,
-              metadata->>'document_title' AS document_title,
-              metadata->>'section_title' AS section_title,
-              metadata->>'source_url' AS source_url,
-              metadata->>'ngb_id' AS ngb_id,
-              metadata->>'topic_domain' AS topic_domain,
-              metadata->>'effective_date' AS effective_date,
-              metadata->>'chunk_index' AS chunk_index
+              metadata->>'documentTitle' AS document_title,
+              metadata->>'sectionTitle' AS section_title,
+              metadata->>'sourceUrl' AS source_url,
+              metadata->>'ngbId' AS ngb_id,
+              metadata->>'topicDomain' AS topic_domain,
+              metadata->>'effectiveDate' AS effective_date,
+              metadata->>'chunkIndex' AS chunk_index
             FROM document_chunks
-            WHERE metadata->>'source_id' = $1
-              AND metadata->>'section_title' ILIKE $2
-            ORDER BY (metadata->>'chunk_index')::int ASC
+            WHERE metadata->>'sourceId' = $1
+              AND metadata->>'sectionTitle' ILIKE $2
+            ORDER BY (metadata->>'chunkIndex')::int ASC
           `;
           params = [documentId, `%${sectionTitle}%`];
         } else {
           query = `
             SELECT
               content,
-              metadata->>'document_title' AS document_title,
-              metadata->>'section_title' AS section_title,
-              metadata->>'source_url' AS source_url,
-              metadata->>'ngb_id' AS ngb_id,
-              metadata->>'topic_domain' AS topic_domain,
-              metadata->>'effective_date' AS effective_date,
-              metadata->>'chunk_index' AS chunk_index
+              metadata->>'documentTitle' AS document_title,
+              metadata->>'sectionTitle' AS section_title,
+              metadata->>'sourceUrl' AS source_url,
+              metadata->>'ngbId' AS ngb_id,
+              metadata->>'topicDomain' AS topic_domain,
+              metadata->>'effectiveDate' AS effective_date,
+              metadata->>'chunkIndex' AS chunk_index
             FROM document_chunks
-            WHERE metadata->>'source_id' = $1
-            ORDER BY (metadata->>'chunk_index')::int ASC
+            WHERE metadata->>'sourceId' = $1
+            ORDER BY (metadata->>'chunkIndex')::int ASC
           `;
           params = [documentId];
         }

--- a/packages/core/src/tools/searchKnowledgeBase.test.ts
+++ b/packages/core/src/tools/searchKnowledgeBase.test.ts
@@ -45,7 +45,7 @@ describe("createSearchKnowledgeBaseTool", () => {
         [
           createMockDocument("Test content", {
             documentTitle: "Test Doc",
-            ngbId: "usa_swimming",
+            ngbId: "usa-swimming",
           }),
           0.85,
         ],
@@ -66,7 +66,7 @@ describe("createSearchKnowledgeBaseTool", () => {
           createMockDocument("Content about selection criteria", {
             documentTitle: "Selection Procedures",
             sectionTitle: "Criteria",
-            ngbId: "usa_swimming",
+            ngbId: "usa-swimming",
             topicDomain: "team_selection",
             sourceUrl: "https://example.com/doc",
             effectiveDate: "2024-01-01",
@@ -80,7 +80,7 @@ describe("createSearchKnowledgeBaseTool", () => {
       expect(result).toContain("Result 1 (score: 0.876)");
       expect(result).toContain("Document: Selection Procedures");
       expect(result).toContain("Section: Criteria");
-      expect(result).toContain("NGB: usa_swimming");
+      expect(result).toContain("NGB: usa-swimming");
       expect(result).toContain("Topic: team_selection");
       expect(result).toContain("Source: https://example.com/doc");
       expect(result).toContain("Effective Date: 2024-01-01");
@@ -94,13 +94,13 @@ describe("createSearchKnowledgeBaseTool", () => {
 
       await tool.invoke({
         query: "eligibility requirements",
-        ngbIds: ["usa_swimming", "us_rowing"],
+        ngbIds: ["usa-swimming", "us-rowing"],
       });
 
       expect(mockVectorStore.similaritySearchWithScore).toHaveBeenCalledWith(
         "eligibility requirements",
         expect.any(Number),
-        { ngb_id: { $in: ["usa_swimming", "us_rowing"] } },
+        { ngbId: { $in: ["usa-swimming", "us-rowing"] } },
       );
     });
 
@@ -109,7 +109,7 @@ describe("createSearchKnowledgeBaseTool", () => {
 
       await tool.invoke({
         query: "team selection",
-        ngbIds: ["usa_swimming"],
+        ngbIds: ["usa-swimming"],
       });
 
       // With filter, should use narrowFilterTopK (typically 5)
@@ -130,7 +130,7 @@ describe("createSearchKnowledgeBaseTool", () => {
       expect(mockVectorStore.similaritySearchWithScore).toHaveBeenCalledWith(
         "how to file a complaint",
         expect.any(Number),
-        { topic_domain: "safesport" },
+        { topicDomain: "safesport" },
       );
     });
   });
@@ -141,7 +141,7 @@ describe("createSearchKnowledgeBaseTool", () => {
 
       await tool.invoke({
         query: "anti-doping rules",
-        ngbIds: ["usa_track_field"],
+        ngbIds: ["usa-track-field"],
         topicDomain: "anti_doping",
       });
 
@@ -149,8 +149,8 @@ describe("createSearchKnowledgeBaseTool", () => {
         "anti-doping rules",
         expect.any(Number),
         {
-          ngb_id: { $in: ["usa_track_field"] },
-          topic_domain: "anti_doping",
+          ngbId: { $in: ["usa-track-field"] },
+          topicDomain: "anti_doping",
         },
       );
     });

--- a/packages/core/src/tools/searchKnowledgeBase.ts
+++ b/packages/core/src/tools/searchKnowledgeBase.ts
@@ -15,7 +15,7 @@ const searchKnowledgeBaseSchema = z.object({
     .array(z.string())
     .optional()
     .describe(
-      "Optional list of NGB identifiers to narrow the search (e.g. ['usa_swimming', 'us_rowing']).",
+      "Optional list of NGB identifiers to narrow the search (e.g. ['usa-swimming', 'us-rowing']).",
     ),
   topicDomain: z
     .string()
@@ -50,13 +50,12 @@ export function createSearchKnowledgeBaseTool(vectorStore: PGVectorStore) {
         const k = topK ?? RETRIEVAL_CONFIG.narrowFilterTopK;
 
         // Build metadata filter if NGB or topic domain constraints are provided
-        // Uses snake_case field names and $in operator to match pgvector schema
         const filter: Record<string, unknown> = {};
         if (ngbIds && ngbIds.length > 0) {
-          filter.ngb_id = { $in: ngbIds };
+          filter.ngbId = { $in: ngbIds };
         }
         if (topicDomain) {
-          filter.topic_domain = topicDomain;
+          filter.topicDomain = topicDomain;
         }
 
         const hasFilter = Object.keys(filter).length > 0;

--- a/packages/ingestion/src/pipeline.ts
+++ b/packages/ingestion/src/pipeline.ts
@@ -177,15 +177,15 @@ export async function backfillDenormalizedColumns(
     const result = await client.query(`
       UPDATE document_chunks
       SET
-        source_url      = metadata->>'source_url',
-        document_title  = metadata->>'document_title',
-        document_type   = metadata->>'document_type',
-        ngb_id          = metadata->>'ngb_id',
-        topic_domain    = metadata->>'topic_domain',
-        authority_level  = metadata->>'authority_level',
-        section_title   = metadata->>'section_title'
+        source_url      = metadata->>'sourceUrl',
+        document_title  = metadata->>'documentTitle',
+        document_type   = metadata->>'documentType',
+        ngb_id          = metadata->>'ngbId',
+        topic_domain    = metadata->>'topicDomain',
+        authority_level  = metadata->>'authorityLevel',
+        section_title   = metadata->>'sectionTitle'
       WHERE source_url IS NULL
-        AND metadata->>'source_url' IS NOT NULL
+        AND metadata->>'sourceUrl' IS NOT NULL
     `);
     return result.rowCount ?? 0;
   } finally {

--- a/packages/ingestion/src/transformers/metadataEnricher.test.ts
+++ b/packages/ingestion/src/transformers/metadataEnricher.test.ts
@@ -31,8 +31,8 @@ describe("enrichMetadata", () => {
 
     const enriched = enrichMetadata(chunks, sourceWithAuthority);
 
-    expect(enriched[0].metadata.authority_level).toBe("usopc_governance");
-    expect(enriched[1].metadata.authority_level).toBe("usopc_governance");
+    expect(enriched[0].metadata.authorityLevel).toBe("usopc_governance");
+    expect(enriched[1].metadata.authorityLevel).toBe("usopc_governance");
   });
 
   it("does not include authority_level when not present in source", () => {
@@ -40,7 +40,7 @@ describe("enrichMetadata", () => {
 
     const enriched = enrichMetadata(chunks, baseSource);
 
-    expect(enriched[0].metadata.authority_level).toBeUndefined();
+    expect(enriched[0].metadata.authorityLevel).toBeUndefined();
   });
 
   it("preserves existing metadata fields", () => {
@@ -52,18 +52,18 @@ describe("enrichMetadata", () => {
 
     const enriched = enrichMetadata(chunks, sourceWithAuthority);
 
-    expect(enriched[0].metadata.ngb_id).toBe("usa-swimming");
-    expect(enriched[0].metadata.topic_domain).toBe("governance");
-    expect(enriched[0].metadata.topic_domains).toEqual([
+    expect(enriched[0].metadata.ngbId).toBe("usa-swimming");
+    expect(enriched[0].metadata.topicDomain).toBe("governance");
+    expect(enriched[0].metadata.topicDomains).toEqual([
       "governance",
       "athlete_rights",
     ]);
-    expect(enriched[0].metadata.document_type).toBe("policy");
-    expect(enriched[0].metadata.source_url).toBe("https://example.com/doc.pdf");
-    expect(enriched[0].metadata.document_title).toBe("Test Document");
-    expect(enriched[0].metadata.source_id).toBe("test-source");
-    expect(enriched[0].metadata.chunk_index).toBe(0);
-    expect(enriched[0].metadata.ingested_at).toBeDefined();
+    expect(enriched[0].metadata.documentType).toBe("policy");
+    expect(enriched[0].metadata.sourceUrl).toBe("https://example.com/doc.pdf");
+    expect(enriched[0].metadata.documentTitle).toBe("Test Document");
+    expect(enriched[0].metadata.sourceId).toBe("test-source");
+    expect(enriched[0].metadata.chunkIndex).toBe(0);
+    expect(enriched[0].metadata.ingestedAt).toBeDefined();
   });
 
   it("preserves original chunk metadata", () => {
@@ -89,8 +89,8 @@ describe("enrichMetadata", () => {
 
     const enriched = enrichMetadata(chunks, sourceWithAuthority);
 
-    expect(enriched[0].metadata.chunk_index).toBe(0);
-    expect(enriched[1].metadata.chunk_index).toBe(1);
-    expect(enriched[2].metadata.chunk_index).toBe(2);
+    expect(enriched[0].metadata.chunkIndex).toBe(0);
+    expect(enriched[1].metadata.chunkIndex).toBe(1);
+    expect(enriched[2].metadata.chunkIndex).toBe(2);
   });
 });

--- a/packages/ingestion/src/transformers/metadataEnricher.ts
+++ b/packages/ingestion/src/transformers/metadataEnricher.ts
@@ -14,16 +14,16 @@ export function enrichMetadata(
     ...chunk,
     metadata: {
       ...chunk.metadata,
-      ngb_id: source.ngbId,
-      topic_domain: source.topicDomains[0], // primary domain
-      topic_domains: source.topicDomains,
-      document_type: source.documentType,
-      source_url: source.url,
-      document_title: source.title,
-      source_id: source.id,
-      chunk_index: index,
-      ingested_at: new Date().toISOString(),
-      authority_level: source.authorityLevel,
+      ngbId: source.ngbId,
+      topicDomain: source.topicDomains[0], // primary domain
+      topicDomains: source.topicDomains,
+      documentType: source.documentType,
+      sourceUrl: source.url,
+      documentTitle: source.title,
+      sourceId: source.id,
+      chunkIndex: index,
+      ingestedAt: new Date().toISOString(),
+      authorityLevel: source.authorityLevel,
     },
   }));
 }


### PR DESCRIPTION
## Summary

Fixes #99. NGB-based retrieval filtering has never worked due to three bugs:

- **JSONB key mismatch**: Ingestion wrote snake_case (`ngb_id`, `topic_domain`), retriever filtered with camelCase (`ngbId`, `topicDomain`) — filters never matched
- **NGB ID format mismatch**: Classifier output underscored IDs (`usa_swimming`), source data uses hyphens (`usa-swimming`)
- **Broadening drops all filters**: Phase 2 broadening ran with no filter, losing NGB context

Additionally, synthesizer and citationBuilder read `undefined` metadata because they expected camelCase keys on snake_case JSONB data.

### Changes

**Ingestion** — write camelCase JSONB keys (`ngbId`, `topicDomain`, `documentType`, etc.)

**SQL queries** — read camelCase keys in backfill, fetchDocumentSection, sources API, and COALESCE fallbacks

**RAG modules** — `reranker.ts` and `retriever.ts` read camelCase metadata properties and filter with camelCase keys

**Agent retriever** — fix `authority_level` → `authorityLevel` read, add `buildBroadFilter()` with `$or` for NGB + universal docs (ngbId: null)

**Classifier prompt** — NGB ID examples from underscores to hyphens

**searchKnowledgeBase** — filter keys + description NGB IDs to camelCase/hyphens

### Files already correct (no changes needed)

`types/agent.ts`, `synthesizer.ts`, `citationBuilder.ts`, `buildFilter()`, `sport-organizations.json`, `data/sources/*.json`

## Test plan

- [x] `pnpm --filter @usopc/core test` — 434 tests pass
- [x] `pnpm --filter @usopc/ingestion test` — 130 tests pass
- [x] `pnpm --filter @usopc/core typecheck` — clean
- [x] `pnpm --filter @usopc/ingestion typecheck` — clean
- [ ] After deploy + reingest: verify in LangSmith that NGB-filtered retrieval returns relevant docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)