### PR TITLE
feat: Source edit/delete API with vector DB sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 31.4 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 32.7 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -133,10 +133,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 31.4 hours
+**Tracked build time:** 32.7 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-12T14:27:21.442Z
+- Last updated: 2026-02-12T16:02:04.142Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/web/app/api/admin/sources/[id]/route.ts
+++ b/apps/web/app/api/admin/sources/[id]/route.ts
@@ -1,5 +1,14 @@
 import { NextResponse } from "next/server";
+import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
+import { Resource } from "sst";
 import { z } from "zod";
+import {
+  getPool,
+  deleteChunksBySourceId,
+  updateChunkMetadataBySourceId,
+  countChunksBySourceId,
+  type SourceConfig,
+} from "@usopc/shared";
 import { requireAdmin } from "../../../../../lib/admin-api.js";
 import { createSourceConfigEntity } from "../../../../../lib/source-config.js";
 
@@ -9,13 +18,33 @@ import { createSourceConfigEntity } from "../../../../../lib/source-config.js";
 
 const patchSourceSchema = z
   .object({
-    enabled: z.boolean().optional(),
+    title: z.string().min(1).optional(),
+    description: z.string().optional(),
     url: z.string().url("Must be a valid URL").optional(),
+    format: z.enum(["pdf", "html", "text"]).optional(),
+    documentType: z.string().min(1).optional(),
+    topicDomains: z.array(z.string().min(1)).min(1).optional(),
+    ngbId: z.string().nullable().optional(),
+    priority: z.enum(["high", "medium", "low"]).optional(),
+    authorityLevel: z.string().min(1).optional(),
+    enabled: z.boolean().optional(),
   })
   .strict()
   .refine((obj) => Object.keys(obj).length > 0, {
     message: "No valid fields to update",
   });
+
+// Fields that require re-ingestion (content changes)
+const CONTENT_AFFECTING_FIELDS = new Set(["url", "format"]);
+
+// Fields that require chunk metadata updates (no re-ingestion)
+const METADATA_FIELDS = new Set([
+  "title",
+  "documentType",
+  "topicDomains",
+  "ngbId",
+  "authorityLevel",
+]);
 
 // ---------------------------------------------------------------------------
 // GET
@@ -37,7 +66,10 @@ export async function GET(
       return NextResponse.json({ error: "Source not found" }, { status: 404 });
     }
 
-    return NextResponse.json({ source });
+    const pool = getPool();
+    const chunkCount = await countChunksBySourceId(pool, id);
+
+    return NextResponse.json({ source, chunkCount });
   } catch (error) {
     console.error("Admin source detail error:", error);
     return NextResponse.json(
@@ -68,13 +100,137 @@ export async function PATCH(
       return NextResponse.json({ error: firstError }, { status: 400 });
     }
 
+    // Cast is safe — Zod has validated the values above
+    const data = result.data as Partial<Omit<SourceConfig, "id" | "createdAt">>;
+    const changedKeys = Object.keys(data);
+
+    const hasContentChange = changedKeys.some((k) =>
+      CONTENT_AFFECTING_FIELDS.has(k),
+    );
+    const hasMetadataChange = changedKeys.some((k) => METADATA_FIELDS.has(k));
+
+    const actions: Record<string, unknown> = {};
+    const pool = getPool();
+
+    if (hasContentChange) {
+      // Content-affecting: delete old chunks, update config, trigger re-ingestion
+      const chunksDeleted = await deleteChunksBySourceId(pool, id);
+      actions.chunksDeleted = chunksDeleted;
+
+      // Update the source config in DynamoDB
+      const entity = createSourceConfigEntity();
+      const source = await entity.update(id, data);
+
+      // Trigger re-ingestion via SQS
+      try {
+        const queueUrl = (
+          Resource as unknown as { IngestionQueue: { url: string } }
+        ).IngestionQueue.url;
+
+        const message = {
+          source: {
+            id: source.id,
+            title: source.title,
+            documentType: source.documentType,
+            topicDomains: source.topicDomains,
+            url: source.url,
+            format: source.format,
+            ngbId: source.ngbId,
+            priority: source.priority,
+            description: source.description,
+            authorityLevel: source.authorityLevel,
+          },
+          contentHash: "manual",
+          triggeredAt: new Date().toISOString(),
+        };
+
+        const sqs = new SQSClient({});
+        await sqs.send(
+          new SendMessageCommand({
+            QueueUrl: queueUrl,
+            MessageBody: JSON.stringify(message),
+            MessageGroupId: source.id,
+          }),
+        );
+        actions.reIngestionTriggered = true;
+      } catch {
+        // SQS not available in dev — still proceed with the update
+        actions.reIngestionTriggered = false;
+      }
+
+      return NextResponse.json({ source, actions });
+    }
+
+    if (hasMetadataChange) {
+      // Metadata-only: update chunks in PG, then update DynamoDB
+      const metadataUpdates: Record<string, unknown> = {};
+      if (data.title !== undefined) metadataUpdates.title = data.title;
+      if (data.documentType !== undefined)
+        metadataUpdates.documentType = data.documentType;
+      if (data.topicDomains !== undefined)
+        metadataUpdates.topicDomains = data.topicDomains;
+      if (data.ngbId !== undefined) metadataUpdates.ngbId = data.ngbId;
+      if (data.authorityLevel !== undefined)
+        metadataUpdates.authorityLevel = data.authorityLevel;
+
+      const chunksUpdated = await updateChunkMetadataBySourceId(
+        pool,
+        id,
+        metadataUpdates,
+      );
+      actions.chunksUpdated = chunksUpdated;
+    }
+
+    // Update DynamoDB (covers metadata-only and no-vector-impact fields)
     const entity = createSourceConfigEntity();
-    const source = await entity.update(id, result.data);
-    return NextResponse.json({ source });
+    const source = await entity.update(id, data);
+
+    return NextResponse.json({ source, actions });
   } catch (error) {
     console.error("Admin source update error:", error);
     return NextResponse.json(
       { error: "Failed to update source" },
+      { status: 500 },
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DELETE
+// ---------------------------------------------------------------------------
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const denied = await requireAdmin();
+  if (denied) return denied;
+
+  try {
+    const { id } = await params;
+    const entity = createSourceConfigEntity();
+    const source = await entity.getById(id);
+
+    if (!source) {
+      return NextResponse.json({ error: "Source not found" }, { status: 404 });
+    }
+
+    // Delete chunks from PG first (safer ordering)
+    const pool = getPool();
+    const chunksDeleted = await deleteChunksBySourceId(pool, id);
+
+    // Delete config from DynamoDB
+    await entity.delete(id);
+
+    return NextResponse.json({
+      success: true,
+      sourceId: id,
+      chunksDeleted,
+    });
+  } catch (error) {
+    console.error("Admin source delete error:", error);
+    return NextResponse.json(
+      { error: "Failed to delete source" },
       { status: 500 },
     );
   }

--- a/packages/shared/src/chunks.test.ts
+++ b/packages/shared/src/chunks.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Pool, QueryResult } from "pg";
+import {
+  deleteChunksBySourceId,
+  updateChunkMetadataBySourceId,
+  countChunksBySourceId,
+} from "./chunks.js";
+
+// ---------------------------------------------------------------------------
+// Mock pool
+// ---------------------------------------------------------------------------
+
+function createMockPool(queryResult: Partial<QueryResult> = {}) {
+  return {
+    query: vi.fn().mockResolvedValue({
+      rowCount: 0,
+      rows: [],
+      ...queryResult,
+    }),
+  } as unknown as Pool;
+}
+
+describe("deleteChunksBySourceId", () => {
+  it("deletes chunks and returns row count", async () => {
+    const pool = createMockPool({ rowCount: 5 });
+
+    const count = await deleteChunksBySourceId(pool, "test-source");
+
+    expect(count).toBe(5);
+    expect(pool.query).toHaveBeenCalledWith(
+      `DELETE FROM document_chunks WHERE metadata->>'sourceId' = $1`,
+      ["test-source"],
+    );
+  });
+
+  it("returns 0 when no chunks exist", async () => {
+    const pool = createMockPool({ rowCount: 0 });
+
+    const count = await deleteChunksBySourceId(pool, "missing-source");
+
+    expect(count).toBe(0);
+  });
+
+  it("returns 0 when rowCount is null", async () => {
+    const pool = createMockPool({ rowCount: null });
+
+    const count = await deleteChunksBySourceId(pool, "test-source");
+
+    expect(count).toBe(0);
+  });
+});
+
+describe("updateChunkMetadataBySourceId", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updates title in metadata and column", async () => {
+    const pool = createMockPool({ rowCount: 3 });
+
+    const count = await updateChunkMetadataBySourceId(pool, "src-1", {
+      title: "New Title",
+    });
+
+    expect(count).toBe(3);
+    const call = vi.mocked(pool.query).mock.calls[0];
+    expect(call[0]).toContain("metadata = metadata || $2::jsonb");
+    expect(call[0]).toContain("document_title =");
+    expect(call[1]).toContain("src-1");
+    // jsonb patch should include documentTitle
+    const jsonbPatch = JSON.parse(call[1]![1] as string);
+    expect(jsonbPatch.documentTitle).toBe("New Title");
+  });
+
+  it("updates topicDomains with primary domain", async () => {
+    const pool = createMockPool({ rowCount: 2 });
+
+    await updateChunkMetadataBySourceId(pool, "src-1", {
+      topicDomains: ["governance", "eligibility"],
+    });
+
+    const call = vi.mocked(pool.query).mock.calls[0];
+    const jsonbPatch = JSON.parse(call[1]![1] as string);
+    expect(jsonbPatch.topicDomain).toBe("governance");
+    expect(jsonbPatch.topicDomains).toEqual(["governance", "eligibility"]);
+    expect(call[0]).toContain("topic_domain =");
+  });
+
+  it("updates multiple fields at once", async () => {
+    const pool = createMockPool({ rowCount: 10 });
+
+    await updateChunkMetadataBySourceId(pool, "src-1", {
+      title: "Updated",
+      ngbId: "usa-swimming",
+      authorityLevel: "ngb_policy_procedure",
+    });
+
+    const call = vi.mocked(pool.query).mock.calls[0];
+    expect(call[0]).toContain("document_title =");
+    expect(call[0]).toContain("ngb_id =");
+    expect(call[0]).toContain("authority_level =");
+    const jsonbPatch = JSON.parse(call[1]![1] as string);
+    expect(jsonbPatch.documentTitle).toBe("Updated");
+    expect(jsonbPatch.ngbId).toBe("usa-swimming");
+    expect(jsonbPatch.authorityLevel).toBe("ngb_policy_procedure");
+  });
+
+  it("returns 0 when updates is empty", async () => {
+    const pool = createMockPool();
+
+    const count = await updateChunkMetadataBySourceId(pool, "src-1", {});
+
+    expect(count).toBe(0);
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+
+  it("handles null ngbId", async () => {
+    const pool = createMockPool({ rowCount: 1 });
+
+    await updateChunkMetadataBySourceId(pool, "src-1", {
+      ngbId: null,
+    });
+
+    const call = vi.mocked(pool.query).mock.calls[0];
+    const jsonbPatch = JSON.parse(call[1]![1] as string);
+    expect(jsonbPatch.ngbId).toBeNull();
+  });
+});
+
+describe("countChunksBySourceId", () => {
+  it("returns the count", async () => {
+    const pool = createMockPool({ rows: [{ count: 42 }] });
+
+    const count = await countChunksBySourceId(pool, "src-1");
+
+    expect(count).toBe(42);
+    expect(pool.query).toHaveBeenCalledWith(
+      `SELECT COUNT(*)::int AS count FROM document_chunks WHERE metadata->>'sourceId' = $1`,
+      ["src-1"],
+    );
+  });
+
+  it("returns 0 for empty result", async () => {
+    const pool = createMockPool({ rows: [] });
+
+    const count = await countChunksBySourceId(pool, "missing");
+
+    expect(count).toBe(0);
+  });
+});

--- a/packages/shared/src/chunks.ts
+++ b/packages/shared/src/chunks.ts
@@ -1,0 +1,119 @@
+import type { Pool } from "pg";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ChunkMetadataUpdates {
+  title?: string;
+  documentType?: string;
+  topicDomains?: string[];
+  ngbId?: string | null;
+  authorityLevel?: string;
+}
+
+// ---------------------------------------------------------------------------
+// deleteChunksBySourceId
+// ---------------------------------------------------------------------------
+
+/**
+ * Delete all document_chunks rows whose metadata->>'sourceId' matches.
+ * Returns the number of rows deleted.
+ */
+export async function deleteChunksBySourceId(
+  pool: Pool,
+  sourceId: string,
+): Promise<number> {
+  const result = await pool.query(
+    `DELETE FROM document_chunks WHERE metadata->>'sourceId' = $1`,
+    [sourceId],
+  );
+  return result.rowCount ?? 0;
+}
+
+// ---------------------------------------------------------------------------
+// updateChunkMetadataBySourceId
+// ---------------------------------------------------------------------------
+
+/**
+ * Update chunk metadata and denormalized columns in-place for a given source.
+ *
+ * Maps source config fields to their chunk equivalents:
+ * - title       → metadata.documentTitle + document_title column
+ * - documentType → metadata.documentType + document_type column
+ * - topicDomains → metadata.topicDomain (first), metadata.topicDomains + topic_domain column
+ * - ngbId       → metadata.ngbId + ngb_id column
+ * - authorityLevel → metadata.authorityLevel + authority_level column
+ *
+ * Returns the number of rows updated.
+ */
+export async function updateChunkMetadataBySourceId(
+  pool: Pool,
+  sourceId: string,
+  updates: ChunkMetadataUpdates,
+): Promise<number> {
+  // Build the JSONB patch from the updates
+  const jsonbPatch: Record<string, unknown> = {};
+  const setClauses: string[] = [`metadata = metadata || $2::jsonb`];
+  const params: unknown[] = [sourceId]; // $1 = sourceId, $2 = jsonb patch
+
+  if (updates.title !== undefined) {
+    jsonbPatch.documentTitle = updates.title;
+    setClauses.push(`document_title = $${params.length + 2}`);
+    params.push(updates.title); // will be $3, $4, etc.
+  }
+
+  if (updates.documentType !== undefined) {
+    jsonbPatch.documentType = updates.documentType;
+    setClauses.push(`document_type = $${params.length + 2}`);
+    params.push(updates.documentType);
+  }
+
+  if (updates.topicDomains !== undefined) {
+    jsonbPatch.topicDomain = updates.topicDomains[0] ?? null;
+    jsonbPatch.topicDomains = updates.topicDomains;
+    setClauses.push(`topic_domain = $${params.length + 2}`);
+    params.push(updates.topicDomains[0] ?? null);
+  }
+
+  if (updates.ngbId !== undefined) {
+    jsonbPatch.ngbId = updates.ngbId;
+    setClauses.push(`ngb_id = $${params.length + 2}`);
+    params.push(updates.ngbId);
+  }
+
+  if (updates.authorityLevel !== undefined) {
+    jsonbPatch.authorityLevel = updates.authorityLevel;
+    setClauses.push(`authority_level = $${params.length + 2}`);
+    params.push(updates.authorityLevel);
+  }
+
+  if (Object.keys(jsonbPatch).length === 0) {
+    return 0;
+  }
+
+  // Insert the jsonb patch as $2
+  params.splice(1, 0, JSON.stringify(jsonbPatch));
+
+  const sql = `UPDATE document_chunks SET ${setClauses.join(", ")} WHERE metadata->>'sourceId' = $1`;
+  const result = await pool.query(sql, params);
+  return result.rowCount ?? 0;
+}
+
+// ---------------------------------------------------------------------------
+// countChunksBySourceId
+// ---------------------------------------------------------------------------
+
+/**
+ * Count the number of document_chunks for a given source.
+ */
+export async function countChunksBySourceId(
+  pool: Pool,
+  sourceId: string,
+): Promise<number> {
+  const result = await pool.query(
+    `SELECT COUNT(*)::int AS count FROM document_chunks WHERE metadata->>'sourceId' = $1`,
+    [sourceId],
+  );
+  return result.rows[0]?.count ?? 0;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -37,6 +37,13 @@ export {
 export { getPool, closePool } from "./pool.js";
 
 export {
+  deleteChunksBySourceId,
+  updateChunkMetadataBySourceId,
+  countChunksBySourceId,
+  type ChunkMetadataUpdates,
+} from "./chunks.js";
+
+export {
   paginationSchema,
   type Pagination,
   uuidSchema,

--- a/scripts/init-db.sql
+++ b/scripts/init-db.sql
@@ -30,6 +30,7 @@ CREATE INDEX IF NOT EXISTS idx_chunks_topic_domain ON document_chunks (topic_dom
 CREATE INDEX IF NOT EXISTS idx_chunks_document_type ON document_chunks (document_type);
 CREATE INDEX IF NOT EXISTS idx_chunks_authority_level ON document_chunks (authority_level);
 CREATE INDEX IF NOT EXISTS idx_chunks_metadata ON document_chunks USING gin (metadata);
+CREATE INDEX IF NOT EXISTS idx_chunks_source_id ON document_chunks ((metadata->>'sourceId'));
 
 -- Conversations table
 CREATE TABLE IF NOT EXISTS conversations (


### PR DESCRIPTION
## Summary

Closes #101

- **Shared chunk helpers** (`packages/shared/src/chunks.ts`): `deleteChunksBySourceId`, `updateChunkMetadataBySourceId`, `countChunksBySourceId` — all accept a Pool param for testability
- **Expanded PATCH** (`/api/admin/sources/[id]`): Accepts all editable fields (`title`, `description`, `url`, `format`, `documentType`, `topicDomains`, `ngbId`, `priority`, `authorityLevel`, `enabled`). Classifies changes into content-affecting (delete chunks + re-ingest), metadata-only (update chunks in PG), and no-vector-impact (DynamoDB only)
- **DELETE endpoint**: Removes chunks from PG first, then config from DynamoDB
- **Bulk delete**: Added `"delete"` action to bulk route
- **Chunk count in GET**: Returns `{ source, chunkCount }` for UI display
- **Database index**: Btree functional index on `metadata->>'sourceId'` for fast equality queries

## Test plan

- [x] `pnpm --filter @usopc/shared test chunks` — 10 tests pass
- [x] `pnpm --filter @usopc/web test api/admin/sources` — 48 tests pass
- [x] `pnpm --filter @usopc/shared typecheck` — clean
- [x] `pnpm --filter @usopc/web typecheck` — clean
- [x] Prettier format applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)