### PR TITLE
feat: Generate per-NGB selection procedure prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 33.7 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 33.8 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -133,10 +133,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 33.7 hours
+**Tracked build time:** 33.8 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-12T17:58:01.063Z
+- Last updated: 2026-02-12T18:03:03.577Z
 <!-- HOURS:END -->
 
 ## License

--- a/scripts/generate-selection-prompt.mjs
+++ b/scripts/generate-selection-prompt.mjs
@@ -2,61 +2,172 @@
 import { readFileSync } from "node:fs";
 
 const NGB_MAP = new Map([
-  ["usa-archery", { name: "USA Archery", website: "https://www.usarchery.org" }],
-  ["usa-badminton", { name: "USA Badminton", website: "https://www.usabadminton.org" }],
-  ["usa-basketball", { name: "USA Basketball", website: "https://www.usab.com" }],
-  ["usa-biathlon", { name: "USA Biathlon", website: "https://www.teamusa.org/us-biathlon" }],
-  ["usa-bobsled-skeleton", { name: "USA Bobsled & Skeleton", website: "https://www.bobsledskeleton.org" }],
+  [
+    "usa-archery",
+    { name: "USA Archery", website: "https://www.usarchery.org" },
+  ],
+  [
+    "usa-badminton",
+    { name: "USA Badminton", website: "https://www.usabadminton.org" },
+  ],
+  [
+    "usa-basketball",
+    { name: "USA Basketball", website: "https://www.usab.com" },
+  ],
+  [
+    "usa-biathlon",
+    { name: "USA Biathlon", website: "https://www.teamusa.org/us-biathlon" },
+  ],
+  [
+    "usa-bobsled-skeleton",
+    {
+      name: "USA Bobsled & Skeleton",
+      website: "https://www.bobsledskeleton.org",
+    },
+  ],
   ["usa-boxing", { name: "USA Boxing", website: "https://www.usaboxing.org" }],
-  ["usa-canoe-kayak", { name: "USA Canoe/Kayak", website: "https://www.usacanoekayak.org" }],
-  ["usa-climbing", { name: "USA Climbing", website: "https://www.usaclimbing.org" }],
-  ["usa-cricket", { name: "USA Cricket", website: "https://www.usacricket.org" }],
-  ["usa-curling", { name: "USA Curling", website: "https://www.usacurling.org" }],
-  ["usa-cycling", { name: "USA Cycling", website: "https://www.usacycling.org" }],
+  [
+    "usa-canoe-kayak",
+    { name: "USA Canoe/Kayak", website: "https://www.usacanoekayak.org" },
+  ],
+  [
+    "usa-climbing",
+    { name: "USA Climbing", website: "https://www.usaclimbing.org" },
+  ],
+  [
+    "usa-cricket",
+    { name: "USA Cricket", website: "https://www.usacricket.org" },
+  ],
+  [
+    "usa-curling",
+    { name: "USA Curling", website: "https://www.usacurling.org" },
+  ],
+  [
+    "usa-cycling",
+    { name: "USA Cycling", website: "https://www.usacycling.org" },
+  ],
   ["usa-diving", { name: "USA Diving", website: "https://www.usadiving.org" }],
   ["us-equestrian", { name: "US Equestrian", website: "https://www.usef.org" }],
   ["us-fencing", { name: "US Fencing", website: "https://www.usafencing.org" }],
-  ["us-field-hockey", { name: "US Field Hockey", website: "https://www.usfieldhockey.com" }],
-  ["us-figure-skating", { name: "US Figure Skating", website: "https://www.usfigureskating.org" }],
-  ["usa-flag-football", { name: "USA Flag Football", website: "https://www.usaflagfootball.org" }],
+  [
+    "us-field-hockey",
+    { name: "US Field Hockey", website: "https://www.usfieldhockey.com" },
+  ],
+  [
+    "us-figure-skating",
+    { name: "US Figure Skating", website: "https://www.usfigureskating.org" },
+  ],
+  [
+    "usa-flag-football",
+    { name: "USA Flag Football", website: "https://www.usaflagfootball.org" },
+  ],
   ["usa-golf", { name: "USA Golf", website: "https://www.usagolf.org" }],
   ["usa-gymnastics", { name: "USA Gymnastics", website: "https://usagym.org" }],
   ["usa-hockey", { name: "USA Hockey", website: "https://www.usahockey.com" }],
   ["usa-judo", { name: "USA Judo", website: "https://www.usajudo.com" }],
-  ["usa-karate", { name: "USA Karate", website: "https://www.teamusa.org/usa-karate" }],
-  ["usa-lacrosse", { name: "USA Lacrosse", website: "https://www.usalacrosse.com" }],
+  [
+    "usa-karate",
+    { name: "USA Karate", website: "https://www.teamusa.org/usa-karate" },
+  ],
+  [
+    "usa-lacrosse",
+    { name: "USA Lacrosse", website: "https://www.usalacrosse.com" },
+  ],
   ["usa-luge", { name: "USA Luge", website: "https://www.usaluge.org" }],
-  ["usa-modern-pentathlon", { name: "USA Modern Pentathlon", website: "https://www.usapentathlon.org" }],
+  [
+    "usa-modern-pentathlon",
+    { name: "USA Modern Pentathlon", website: "https://www.usapentathlon.org" },
+  ],
   ["us-rowing", { name: "US Rowing", website: "https://www.usrowing.org" }],
   ["us-rugby", { name: "US Rugby", website: "https://www.usa.rugby" }],
   ["us-sailing", { name: "US Sailing", website: "https://www.ussailing.org" }],
-  ["us-shooting", { name: "US Shooting", website: "https://www.usashooting.org" }],
-  ["us-ski-snowboard", { name: "US Ski & Snowboard", website: "https://www.usskiandsnowboard.org" }],
+  [
+    "us-shooting",
+    { name: "US Shooting", website: "https://www.usashooting.org" },
+  ],
+  [
+    "us-ski-snowboard",
+    {
+      name: "US Ski & Snowboard",
+      website: "https://www.usskiandsnowboard.org",
+    },
+  ],
   ["us-soccer", { name: "US Soccer", website: "https://www.ussoccer.com" }],
-  ["usa-softball", { name: "USA Softball", website: "https://www.usasoftball.com" }],
-  ["us-speedskating", { name: "US Speedskating", website: "https://www.usspeedskating.org" }],
+  [
+    "usa-softball",
+    { name: "USA Softball", website: "https://www.usasoftball.com" },
+  ],
+  [
+    "us-speedskating",
+    { name: "US Speedskating", website: "https://www.usspeedskating.org" },
+  ],
   ["us-squash", { name: "US Squash", website: "https://www.ussquash.org" }],
-  ["usa-surfing", { name: "USA Surfing", website: "https://www.usasurfing.org" }],
-  ["usa-swimming", { name: "USA Swimming", website: "https://www.usaswimming.org" }],
-  ["usa-table-tennis", { name: "USA Table Tennis", website: "https://www.usatt.org" }],
-  ["usa-taekwondo", { name: "USA Taekwondo", website: "https://www.usa-taekwondo.us" }],
-  ["usa-team-handball", { name: "USA Team Handball", website: "https://www.usateamhandball.org" }],
+  [
+    "usa-surfing",
+    { name: "USA Surfing", website: "https://www.usasurfing.org" },
+  ],
+  [
+    "usa-swimming",
+    { name: "USA Swimming", website: "https://www.usaswimming.org" },
+  ],
+  [
+    "usa-table-tennis",
+    { name: "USA Table Tennis", website: "https://www.usatt.org" },
+  ],
+  [
+    "usa-taekwondo",
+    { name: "USA Taekwondo", website: "https://www.usa-taekwondo.us" },
+  ],
+  [
+    "usa-team-handball",
+    { name: "USA Team Handball", website: "https://www.usateamhandball.org" },
+  ],
   ["usa-tennis", { name: "USA Tennis", website: "https://www.usta.com" }],
-  ["usa-track-field", { name: "USA Track & Field", website: "https://www.usatf.org" }],
-  ["usa-triathlon", { name: "USA Triathlon", website: "https://www.usatriathlon.org" }],
-  ["usa-volleyball", { name: "USA Volleyball", website: "https://www.usavolleyball.org" }],
-  ["usa-water-polo", { name: "USA Water Polo", website: "https://www.usawaterpolo.org" }],
-  ["usa-weightlifting", { name: "USA Weightlifting", website: "https://www.usaweightlifting.org" }],
-  ["usa-wrestling", { name: "USA Wrestling", website: "https://www.usawrestling.org" }],
-  ["usopc-skateboarding", { name: "Skateboarding (USOPC-managed)", website: "https://www.teamusa.org/usa-skateboarding" }],
-  ["usopc-breaking", { name: "Breaking (USOPC-managed)", website: "https://www.teamusa.org/usa-breaking" }],
+  [
+    "usa-track-field",
+    { name: "USA Track & Field", website: "https://www.usatf.org" },
+  ],
+  [
+    "usa-triathlon",
+    { name: "USA Triathlon", website: "https://www.usatriathlon.org" },
+  ],
+  [
+    "usa-volleyball",
+    { name: "USA Volleyball", website: "https://www.usavolleyball.org" },
+  ],
+  [
+    "usa-water-polo",
+    { name: "USA Water Polo", website: "https://www.usawaterpolo.org" },
+  ],
+  [
+    "usa-weightlifting",
+    { name: "USA Weightlifting", website: "https://www.usaweightlifting.org" },
+  ],
+  [
+    "usa-wrestling",
+    { name: "USA Wrestling", website: "https://www.usawrestling.org" },
+  ],
+  [
+    "usopc-skateboarding",
+    {
+      name: "Skateboarding (USOPC-managed)",
+      website: "https://www.teamusa.org/usa-skateboarding",
+    },
+  ],
+  [
+    "usopc-breaking",
+    {
+      name: "Breaking (USOPC-managed)",
+      website: "https://www.teamusa.org/usa-breaking",
+    },
+  ],
 ]);
 
 const arg = process.argv[2];
 
 if (!arg) {
   console.error("Usage: node scripts/generate-selection-prompt.mjs <ngb-id>");
-  console.error('       node scripts/generate-selection-prompt.mjs --list');
+  console.error("       node scripts/generate-selection-prompt.mjs --list");
   process.exit(1);
 }
 
@@ -100,7 +211,9 @@ try {
         /(?<=Do not include documents with these IDs — they are already in the system:\n\n)- `.+?`(\n- `.+?`)*/,
         bulletList,
       );
-      console.error(`(Using live skip list: ${ids.length} source IDs from dev server)`);
+      console.error(
+        `(Using live skip list: ${ids.length} source IDs from dev server)`,
+      );
     }
   } else {
     console.error("(Dev server returned non-OK; using static skip list)");


### PR DESCRIPTION
## Summary

- Adds `scripts/generate-selection-prompt.mjs` — a zero-dependency Node script that automates placeholder substitution in `docs/prompts/02-selection-procedures.md` for each NGB
- Embeds the 48-NGB lookup table, optionally fetches live source IDs from the dev server for the skip list, prints filled prompt to stdout

### Usage

```bash
node scripts/generate-selection-prompt.mjs usa-swimming          # filled prompt → stdout
node scripts/generate-selection-prompt.mjs usa-swimming | pbcopy # copy to clipboard
node scripts/generate-selection-prompt.mjs --list                # list all NGB IDs
```

## Test plan

- [x] `node scripts/generate-selection-prompt.mjs --list` prints all 48 NGB IDs
- [x] `node scripts/generate-selection-prompt.mjs usa-swimming` outputs prompt with correct substitutions
- [x] `node scripts/generate-selection-prompt.mjs bad-id` shows error and suggests `--list`
- [x] Without dev server running, uses static skip list and prints note to stderr

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)