### PR TITLE
fix: Pre-populate source edit form with existing values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 33.8 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 34.1 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -133,10 +133,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 33.8 hours
+**Tracked build time:** 34.1 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-12T18:03:03.577Z
+- Last updated: 2026-02-12T18:37:37.126Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/web/app/admin/sources/[id]/edit/EditSourceClient.tsx
+++ b/apps/web/app/admin/sources/[id]/edit/EditSourceClient.tsx
@@ -74,24 +74,23 @@ export function EditSourceClient({ id }: { id: string }) {
     fetchSource();
   }, [fetchSource]);
 
-  // Build form initial values from loaded source
-  useEffect(() => {
-    if (source) {
-      initialValuesRef.current = {
-        id: source.id,
-        title: source.title,
-        description: source.description,
-        url: source.url,
-        format: source.format,
-        documentType: source.documentType as SourceFormValues["documentType"],
-        topicDomains: source.topicDomains,
-        authorityLevel:
-          source.authorityLevel as SourceFormValues["authorityLevel"],
-        priority: source.priority,
-        ngbId: source.ngbId ?? "",
-      };
-    }
-  }, [source]);
+  // Build form initial values eagerly during render (not in useEffect,
+  // which would run after SourceForm mounts with empty defaults).
+  if (source && !initialValuesRef.current) {
+    initialValuesRef.current = {
+      id: source.id,
+      title: source.title,
+      description: source.description,
+      url: source.url,
+      format: source.format,
+      documentType: source.documentType as SourceFormValues["documentType"],
+      topicDomains: source.topicDomains,
+      authorityLevel:
+        source.authorityLevel as SourceFormValues["authorityLevel"],
+      priority: source.priority,
+      ngbId: source.ngbId ?? "",
+    };
+  }
 
   async function handleSubmit(values: SourceFormValues) {
     if (!initialValuesRef.current) return;


### PR DESCRIPTION
## Summary

- Fixes source edit form showing empty fields instead of existing values by moving `initialValuesRef` assignment from `useEffect` to eager render-time computation
- The `useEffect` ran *after* `SourceForm` mounted, so `useState` hooks initialized with empty defaults before the ref was populated

Closes #107

## Test plan

- [x] `pnpm --filter @usopc/web typecheck` passes
- [x] `pnpm --filter @usopc/web test components/sources` — existing tests pass (1 pre-existing date formatting failure unrelated to this change)
- [x] Manual: navigate to `/admin/sources/<id>/edit` and verify all fields are pre-populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)