### PR TITLE
feat: Add granular LangSmith tracing to retriever node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 34.1 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 34.9 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -133,10 +133,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 34.1 hours
+**Tracked build time:** 34.9 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-12T18:37:37.126Z
+- Last updated: 2026-02-13T02:48:44.631Z
 <!-- HOURS:END -->
 
 ## License

--- a/packages/core/src/agent/nodeMetrics.test.ts
+++ b/packages/core/src/agent/nodeMetrics.test.ts
@@ -129,6 +129,6 @@ describe("withMetrics", () => {
 
     await wrapped(state);
 
-    expect(node).toHaveBeenCalledWith(state);
+    expect(node).toHaveBeenCalledWith(state, undefined);
   });
 });

--- a/packages/core/src/agent/nodeMetrics.ts
+++ b/packages/core/src/agent/nodeMetrics.ts
@@ -1,3 +1,4 @@
+import type { RunnableConfig } from "@langchain/core/runnables";
 import type { AgentState } from "./state.js";
 
 export interface NodeMetricEntry {
@@ -43,12 +44,21 @@ export const nodeMetrics = new NodeMetricsCollector();
  */
 export function withMetrics(
   nodeName: string,
-  fn: (state: AgentState) => Promise<Partial<AgentState>>,
-): (state: AgentState) => Promise<Partial<AgentState>> {
-  return async (state: AgentState): Promise<Partial<AgentState>> => {
+  fn: (
+    state: AgentState,
+    config?: RunnableConfig,
+  ) => Promise<Partial<AgentState>>,
+): (
+  state: AgentState,
+  config?: RunnableConfig,
+) => Promise<Partial<AgentState>> {
+  return async (
+    state: AgentState,
+    config?: RunnableConfig,
+  ): Promise<Partial<AgentState>> => {
     const start = Date.now();
     try {
-      const result = await fn(state);
+      const result = await fn(state, config);
       nodeMetrics.record(nodeName, Date.now() - start);
       return result;
     } catch (error) {

--- a/packages/core/src/agent/nodes/retriever.test.ts
+++ b/packages/core/src/agent/nodes/retriever.test.ts
@@ -449,6 +449,22 @@ describe("createRetrieverNode", () => {
     );
   });
 
+  it("accepts an optional RunnableConfig as second argument", async () => {
+    const store = makeMockVectorStore([
+      [
+        makeSearchResult("doc1", 0.1, { topicDomain: "team_selection" }),
+        makeSearchResult("doc2", 0.2, { topicDomain: "team_selection" }),
+      ],
+    ]);
+
+    const node = createRetrieverNode(store);
+    const state = makeState({ topicDomain: "team_selection" });
+
+    const result = await node(state, { runName: "test-config" });
+    expect(result.retrievedDocuments).toHaveLength(2);
+    expect(result.retrievalConfidence).toBeGreaterThan(0);
+  });
+
   describe("conversation context", () => {
     it("enriches search query with context from prior messages", async () => {
       const store = makeMockVectorStore([


### PR DESCRIPTION
Closes #109

## Summary

- Wrap each retrieval phase in a `RunnableLambda` to create nested child spans in LangSmith (`retriever:build_query`, `retriever:narrow_search`, `retriever:broad_search`, `retriever:score_and_rank`)
- Forward `RunnableConfig` through `withMetrics` so LangGraph's tracing context reaches the retriever node
- No new dependencies; transparent when tracing is disabled

## Test plan

- [x] `pnpm --filter @usopc/core test nodes/retriever` — 21 tests pass (including new config arg test)
- [x] `pnpm --filter @usopc/core test nodeMetrics` — 9 tests pass
- [x] `pnpm --filter @usopc/core typecheck` — clean
- [x] Deploy with `LANGCHAIN_TRACING_V2=true` and verify child spans appear in LangSmith

🤖 Generated with [Claude Code](https://claude.com/claude-code)