### PR TITLE
fix: Restore explanatory comments in retriever node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 34.9 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 35.3 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -133,10 +133,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 34.9 hours
+**Tracked build time:** 35.3 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-13T02:48:44.631Z
+- Last updated: 2026-02-13T03:15:42.328Z
 <!-- HOURS:END -->
 
 ## License


### PR DESCRIPTION
## Summary

- Restore inline comments that were inadvertently dropped during the tracing refactor in #110
- Reattach the `createRetrieverNode` JSDoc to the function (was orphaned above the `SearchResult` type alias)
- Restore comments explaining: cosine distance sorting, composite scoring logic, authority boost subtraction, circuit breaker usage, and content deduplication

No logic changes — comments only.

## Test plan

- [x] `pnpm --filter @usopc/core test nodes/retriever` — 21 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)