### PR TITLE
chore: Update SST from 3.17.38 to 3.18.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 48.4 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 49.1 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 48.4 hours
+**Tracked build time:** 49.1 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-16T01:12:00.250Z
+- Last updated: 2026-02-16T02:00:16.212Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@types/pg": "^8.11.11",
-    "sst": "3.17.38",
+    "sst": "3.18.1",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
     "vitest": "^2.1.8"

--- a/apps/slack/package.json
+++ b/apps/slack/package.json
@@ -21,7 +21,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
-    "sst": "3.17.38",
+    "sst": "3.18.1",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
     "vitest": "^2.1.8"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,7 +39,7 @@
     "@vitejs/plugin-react": "^4.3.4",
     "jsdom": "^26.0.0",
     "postcss": "^8.4.49",
-    "sst": "3.17.38",
+    "sst": "3.18.1",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.3",
     "vitest": "^2.1.9"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/node": "^22.10.5",
     "prettier": "^3.4.2",
-    "sst": "3.17.38",
+    "sst": "3.18.1",
     "typescript": "^5.7.3",
     "vitest": "^2.1.8"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "@types/pg": "^8.11.10",
-    "sst": "3.17.38",
+    "sst": "3.18.1",
     "typescript": "^5.7.3",
     "vitest": "^2.1.8"
   }

--- a/packages/evals/package.json
+++ b/packages/evals/package.json
@@ -35,7 +35,7 @@
     "openevals": "^0.1.4"
   },
   "devDependencies": {
-    "sst": "3.17.38",
+    "sst": "3.18.1",
     "tsx": "^4.19.0",
     "typescript": "^5.7.3",
     "vitest": "^2.1.8"

--- a/packages/ingestion/package.json
+++ b/packages/ingestion/package.json
@@ -38,7 +38,7 @@
     "@smithy/util-stream": "^3.0.0",
     "@types/aws-lambda": "^8.10.160",
     "@types/pg": "^8.11.10",
-    "sst": "3.17.38",
+    "sst": "3.18.1",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
     "vitest": "^2.1.8"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/pg": "^8.11.11",
-    "sst": "3.17.38",
+    "sst": "3.18.1",
     "typescript": "^5.7.3",
     "vitest": "^2.1.8"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ^3.4.2
         version: 3.8.1
       sst:
-        specifier: 3.17.38
-        version: 3.17.38
+        specifier: 3.18.1
+        version: 3.18.1
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -59,8 +59,8 @@ importers:
         specifier: ^8.11.11
         version: 8.16.0
       sst:
-        specifier: 3.17.38
-        version: 3.17.38
+        specifier: 3.18.1
+        version: 3.18.1
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -96,8 +96,8 @@ importers:
         version: 3.25.76
     devDependencies:
       sst:
-        specifier: 3.17.38
-        version: 3.17.38
+        specifier: 3.18.1
+        version: 3.18.1
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -190,8 +190,8 @@ importers:
         specifier: ^8.4.49
         version: 8.5.6
       sst:
-        specifier: 3.17.38
-        version: 3.17.38
+        specifier: 3.18.1
+        version: 3.18.1
       tailwindcss:
         specifier: ^4.0.0
         version: 4.1.18
@@ -239,8 +239,8 @@ importers:
         specifier: ^8.11.10
         version: 8.16.0
       sst:
-        specifier: 3.17.38
-        version: 3.17.38
+        specifier: 3.18.1
+        version: 3.18.1
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -270,8 +270,8 @@ importers:
         version: 0.1.4(@langchain/anthropic@0.3.34(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(zod@3.25.76))(@langchain/core@0.3.80(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.4)(cheerio@1.2.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))(typescript@5.9.3)(ws@8.19.0)(zod@3.25.76)
     devDependencies:
       sst:
-        specifier: 3.17.38
-        version: 3.17.38
+        specifier: 3.18.1
+        version: 3.18.1
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -340,8 +340,8 @@ importers:
         specifier: ^8.11.10
         version: 8.16.0
       sst:
-        specifier: 3.17.38
-        version: 3.17.38
+        specifier: 3.18.1
+        version: 3.18.1
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
@@ -371,8 +371,8 @@ importers:
         specifier: ^8.11.11
         version: 8.16.0
       sst:
-        specifier: 3.17.38
-        version: 3.17.38
+        specifier: 3.18.1
+        version: 3.18.1
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -4370,48 +4370,48 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
-  sst-darwin-arm64@3.17.38:
-    resolution: {integrity: sha512-2qEu/jRRBGQbMzkJKy4cypX+LdjInKtn1VrPHeggHD0/DsXLUBVdj/WyYb9ZxbsZEUcA9xZDR2+FBZ7lQzaDcw==}
+  sst-darwin-arm64@3.18.1:
+    resolution: {integrity: sha512-D9MNSiJTQ8dLNCBcHvw5Ii3w1T53+SeFZjYs4i8qK4XQP3krERpIYYMQ8QPMbynhlFY6Y+hhuJb9n/AMVlLivw==}
     cpu: [arm64]
     os: [darwin]
 
-  sst-darwin-x64@3.17.38:
-    resolution: {integrity: sha512-um13cWbRK5rfsYuLxS97gaSkFVd6jCzI+k6wlpJaOcJ5IZiH5UdFIz+ZE/7iCfNTEiwDT+RMw2nGL9a+07Vtww==}
+  sst-darwin-x64@3.18.1:
+    resolution: {integrity: sha512-TNwpk4ePW/UHa97sn+fjaRCk/LEYC4rsFQHjNnTYc3BnImBSjmxTKUgR7El1x2myKIucRIWvPd21ZZC2HWpwuA==}
     cpu: [x64]
     os: [darwin]
 
-  sst-linux-arm64@3.17.38:
-    resolution: {integrity: sha512-gMxYJmpytntqZOf9SZfMnj+v6E0vZ8dAT5XnaKQhETSwuN6WH/OWHgx4bnp7bMQfdvm1uYNB+p7GRopIRRPePQ==}
+  sst-linux-arm64@3.18.1:
+    resolution: {integrity: sha512-tzp7EbpYg4juYlIPg69wf3oOpxnmNIFcUKmx8d76NVNS9fMCHsxyOAMaB0HFbDmr1v7OKFAU9bHz5yEeFwFkMA==}
     cpu: [arm64]
     os: [linux]
 
-  sst-linux-x64@3.17.38:
-    resolution: {integrity: sha512-vwzfHhCugRTWevoA2qcl339yQhc8+vVdAqA11Qcats7LvaM6KxN9SqY00SfHPZxmm2odnefDg8z4b3Qvdo2NAw==}
+  sst-linux-x64@3.18.1:
+    resolution: {integrity: sha512-GGyDJijKiBaAqL+S5BZ+KDjJ3IaaPlTjWJqX5uyKaE5/TDX+tLYzQXUk82akTTv1d3QkYrWmEYQrKcL0GeoMOQ==}
     cpu: [x64]
     os: [linux]
 
-  sst-linux-x86@3.17.38:
-    resolution: {integrity: sha512-rxG2YsN2XnykCvJ1ZquZIXbEOWIdLdcJ1ir9hcqb31cLrH0z2EN5F/IsioH9mLRVJnbmY3JewNk+C9mMB2a8zA==}
+  sst-linux-x86@3.18.1:
+    resolution: {integrity: sha512-JQ3CwLIsWXPWfl4KdYv+JkaCu5Y3Hqu72j/SIfMjImNmUtwJ+qK5nwjA20CAUVK/2nu3n2lolrmbfyvUBu43fw==}
     cpu: [x86]
     os: [linux]
 
-  sst-win32-arm64@3.17.38:
-    resolution: {integrity: sha512-aPTaLqJ4bEEfQwaxnteFXHAePw4Po1Be0tsdTuNUPDhhyv1CV5xSl4nppb4q/Qn1dGxaU6L4zCzZkshWskGIOg==}
+  sst-win32-arm64@3.18.1:
+    resolution: {integrity: sha512-TgdsGdPw26vZCnq4/xsCr9boBzFcJWzH3yHA/RspuYHRcHwCh2+pZJR9GkAUMwUjWNRaHuBKUKUiIQJkHlzXiA==}
     cpu: [arm64]
     os: [win32]
 
-  sst-win32-x64@3.17.38:
-    resolution: {integrity: sha512-X2kx6MOK1tZ0JhMqDisB60fJCOSxot5q7NPFMna5hj7cgJaQfj0NAgQqGJkLEB8iVWyxi6e5o1oJLg+vH452HQ==}
+  sst-win32-x64@3.18.1:
+    resolution: {integrity: sha512-c7+0nbXzbjcrZxxWJGePXSBLqIJN4+E+jCmDmCTdfnpA+bEhdxFyX5aDtT27ldr/mi3kVGkD3P9kdHpGNz2V4A==}
     cpu: [x64]
     os: [win32]
 
-  sst-win32-x86@3.17.38:
-    resolution: {integrity: sha512-W5PxA4uhpXMzWNT0/sMrmU27fn1DCaReGwVwJGEZapu9GKTix41uaP+pyd9fwjiAHVILIdxqe7+BkZfH+mvzbg==}
+  sst-win32-x86@3.18.1:
+    resolution: {integrity: sha512-/8jyHod8n3YN5ZXkRR5/WFmPXBdrV9GgepRyg95Cm0GQbeyr3XzT45IkMmhAsPEPjXXSJM7p6Dg5aHWeXfBdOA==}
     cpu: [x86]
     os: [win32]
 
-  sst@3.17.38:
-    resolution: {integrity: sha512-AshCCzogYVVTgLV7SBQ2hkmctAI0QV4pJmHwsyrX1ruSCvH18ccGgX/kux6/AFfaKrT7GmuVuQ2Zsz25GPXEiA==}
+  sst@3.18.1:
+    resolution: {integrity: sha512-UUyRq5WVR5Cd73TeGgcgI4BDhaIvyGfA/PpCr+qA0yly6r29r5qHJlUEGaKzmIPOpJUALSoG0blYpWhoZ9xowA==}
     hasBin: true
 
   stackback@0.0.2:
@@ -9528,31 +9528,31 @@ snapshots:
 
   split2@4.2.0: {}
 
-  sst-darwin-arm64@3.17.38:
+  sst-darwin-arm64@3.18.1:
     optional: true
 
-  sst-darwin-x64@3.17.38:
+  sst-darwin-x64@3.18.1:
     optional: true
 
-  sst-linux-arm64@3.17.38:
+  sst-linux-arm64@3.18.1:
     optional: true
 
-  sst-linux-x64@3.17.38:
+  sst-linux-x64@3.18.1:
     optional: true
 
-  sst-linux-x86@3.17.38:
+  sst-linux-x86@3.18.1:
     optional: true
 
-  sst-win32-arm64@3.17.38:
+  sst-win32-arm64@3.18.1:
     optional: true
 
-  sst-win32-x64@3.17.38:
+  sst-win32-x64@3.18.1:
     optional: true
 
-  sst-win32-x86@3.17.38:
+  sst-win32-x86@3.18.1:
     optional: true
 
-  sst@3.17.38:
+  sst@3.18.1:
     dependencies:
       aws-sdk: 2.1692.0
       aws4fetch: 1.0.18
@@ -9560,14 +9560,14 @@ snapshots:
       opencontrol: 0.0.6
       openid-client: 5.6.4
     optionalDependencies:
-      sst-darwin-arm64: 3.17.38
-      sst-darwin-x64: 3.17.38
-      sst-linux-arm64: 3.17.38
-      sst-linux-x64: 3.17.38
-      sst-linux-x86: 3.17.38
-      sst-win32-arm64: 3.17.38
-      sst-win32-x64: 3.17.38
-      sst-win32-x86: 3.17.38
+      sst-darwin-arm64: 3.18.1
+      sst-darwin-x64: 3.18.1
+      sst-linux-arm64: 3.18.1
+      sst-linux-x64: 3.18.1
+      sst-linux-x86: 3.18.1
+      sst-win32-arm64: 3.18.1
+      sst-win32-x64: 3.18.1
+      sst-win32-x86: 3.18.1
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
## Summary

- Update `sst` from `3.17.38` to `3.18.1` across all 8 workspace `package.json` files and lockfile
- No breaking changes — includes stability fixes (duplicate lambda permissions, ECR image deletion, function env on redeploy) and minor features (`--exclude` CLI flag, NextJS lambda role transformation)

## Test plan

- [x] `pnpm install` succeeds
- [x] `pnpm typecheck` passes (all packages except pre-existing untracked files)
- [x] `pnpm test` passes (all packages except pre-existing untracked files)
- [ ] Verify `sst dev` starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)