### PR TITLE
chore: Auto-approve common tool permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,23 @@
 {
   "permissions": {
-    "additionalDirectories": ["/Users/joelrosinbum/src/usopc-issue-*"]
+    "additionalDirectories": ["/Users/joelrosinbum/src/usopc-issue-*"],
+    "allow": [
+      "Read",
+      "Edit",
+      "Write",
+      "Glob",
+      "Grep",
+      "Bash(pnpm *)",
+      "Bash(npx *)",
+      "Bash(git *)",
+      "Bash(gh *)",
+      "Bash(node *)",
+      "Bash(sleep *)",
+      "Bash(ls *)",
+      "Bash(cp *)",
+      "Bash(rm *)",
+      "Bash(mkdir *)"
+    ]
   },
   "enabledPlugins": {
     "code-simplifier@claude-plugins-official": true,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 49.5 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 49.7 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 49.5 hours
+**Tracked build time:** 49.7 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-16T02:25:53.232Z
+- Last updated: 2026-02-16T02:34:45.180Z
 <!-- HOURS:END -->
 
 ## License


### PR DESCRIPTION
## Summary
- Add `permissions.allow` rules to `.claude/settings.json` for routine file operations, pnpm, git, and gh commands
- Eliminates manual approval prompts in worktrees for common operations

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)