### PR TITLE
fix: Close vector store connections to prevent pool exhaustion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 53.6 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 53.8 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 53.6 hours
+**Tracked build time:** 53.8 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-16T14:58:38.211Z
+- Last updated: 2026-02-16T15:08:50.608Z
 <!-- HOURS:END -->
 
 ## License

--- a/packages/core/src/rag/vectorStore.test.ts
+++ b/packages/core/src/rag/vectorStore.test.ts
@@ -56,9 +56,9 @@ describe("createVectorStore", () => {
       expect(mockInitialize).toHaveBeenCalledWith(
         mockEmbeddings,
         expect.objectContaining({
-          postgresConnectionOptions: {
+          postgresConnectionOptions: expect.objectContaining({
             connectionString: "postgresql://custom:5432/db",
-          },
+          }),
         }),
       );
     });
@@ -71,9 +71,9 @@ describe("createVectorStore", () => {
       expect(mockInitialize).toHaveBeenCalledWith(
         mockEmbeddings,
         expect.objectContaining({
-          postgresConnectionOptions: {
+          postgresConnectionOptions: expect.objectContaining({
             connectionString: "postgresql://env:5432/envdb",
-          },
+          }),
         }),
       );
     });
@@ -94,9 +94,9 @@ describe("createVectorStore", () => {
       expect(mockInitialize).toHaveBeenCalledWith(
         mockEmbeddings,
         expect.objectContaining({
-          postgresConnectionOptions: {
+          postgresConnectionOptions: expect.objectContaining({
             connectionString: "postgresql://explicit:5432/explicitdb",
-          },
+          }),
         }),
       );
     });
@@ -188,6 +188,25 @@ describe("createVectorStore", () => {
           columns: {
             vectorColumnName: "my_embedding",
           },
+        }),
+      );
+    });
+  });
+
+  describe("pool configuration", () => {
+    it("should limit pool size and set timeouts", async () => {
+      await createVectorStore(mockEmbeddings, {
+        connectionString: "postgresql://test",
+      });
+
+      expect(mockInitialize).toHaveBeenCalledWith(
+        mockEmbeddings,
+        expect.objectContaining({
+          postgresConnectionOptions: expect.objectContaining({
+            max: 5,
+            idleTimeoutMillis: 30_000,
+            connectionTimeoutMillis: 5_000,
+          }),
         }),
       );
     });

--- a/packages/core/src/rag/vectorStore.ts
+++ b/packages/core/src/rag/vectorStore.ts
@@ -37,6 +37,9 @@ export async function createVectorStore(
 
   const pgConfig: PoolConfig = {
     connectionString,
+    max: 5,
+    idleTimeoutMillis: 30_000,
+    connectionTimeoutMillis: 5_000,
   };
 
   return await PGVectorStore.initialize(embeddings, {

--- a/packages/evals/src/helpers/multiTurnPipeline.ts
+++ b/packages/evals/src/helpers/multiTurnPipeline.ts
@@ -54,46 +54,50 @@ export async function runMultiTurnPipeline(
 
   const baseMessages = toBaseMessages(messages);
 
-  const output = await runner.invoke({
-    messages: baseMessages,
-    userSport: opts?.userSport,
-    conversationId: opts?.conversationId,
-  });
-
-  const trajectory = nodeMetrics.getAll().map((entry) => entry.name);
-
-  return {
-    state: {
+  try {
+    const output = await runner.invoke({
       messages: baseMessages,
-      answer: output.answer,
-      citations: output.citations,
-      escalation: output.escalation,
-      // These fields aren't directly available from AgentOutput,
-      // so we set sensible defaults. Full state is available through
-      // the graph's stream mode if needed.
-      topicDomain: undefined,
-      detectedNgbIds: [],
-      queryIntent: undefined,
-      retrievedDocuments: [],
-      webSearchResults: [],
-      retrievalConfidence: 0,
-      disclaimerRequired: true,
-      hasTimeConstraint: false,
-      conversationId: opts?.conversationId,
-      conversationSummary: undefined,
       userSport: opts?.userSport,
-      needsClarification: false,
-      clarificationQuestion: undefined,
-      escalationReason: undefined,
-      retrievalStatus: "success",
-      emotionalState: "neutral",
-      qualityCheckResult: undefined,
-      qualityRetryCount: 0,
-      expansionAttempted: false,
-      reformulatedQueries: [],
-      isComplexQuery: false,
-      subQueries: [],
-    },
-    trajectory,
-  };
+      conversationId: opts?.conversationId,
+    });
+
+    const trajectory = nodeMetrics.getAll().map((entry) => entry.name);
+
+    return {
+      state: {
+        messages: baseMessages,
+        answer: output.answer,
+        citations: output.citations,
+        escalation: output.escalation,
+        // These fields aren't directly available from AgentOutput,
+        // so we set sensible defaults. Full state is available through
+        // the graph's stream mode if needed.
+        topicDomain: undefined,
+        detectedNgbIds: [],
+        queryIntent: undefined,
+        retrievedDocuments: [],
+        webSearchResults: [],
+        retrievalConfidence: 0,
+        disclaimerRequired: true,
+        hasTimeConstraint: false,
+        conversationId: opts?.conversationId,
+        conversationSummary: undefined,
+        userSport: opts?.userSport,
+        needsClarification: false,
+        clarificationQuestion: undefined,
+        escalationReason: undefined,
+        retrievalStatus: "success",
+        emotionalState: "neutral",
+        qualityCheckResult: undefined,
+        qualityRetryCount: 0,
+        expansionAttempted: false,
+        reformulatedQueries: [],
+        isComplexQuery: false,
+        subQueries: [],
+      },
+      trajectory,
+    };
+  } finally {
+    await runner.close();
+  }
 }

--- a/packages/evals/src/helpers/pipeline.ts
+++ b/packages/evals/src/helpers/pipeline.ts
@@ -32,47 +32,51 @@ export async function runPipeline(userMessage: string): Promise<{
     tavilyApiKey: process.env.TAVILY_API_KEY,
   });
 
-  const output = await runner.invoke({
-    messages: [new HumanMessage(userMessage)],
-  });
-
-  // Extract trajectory from the metrics collector
-  const trajectory = nodeMetrics.getAll().map((entry) => entry.name);
-
-  return {
-    state: {
+  try {
+    const output = await runner.invoke({
       messages: [new HumanMessage(userMessage)],
-      answer: output.answer,
-      citations: output.citations,
-      escalation: output.escalation,
-      // These fields aren't directly available from AgentOutput,
-      // so we set sensible defaults. Full state is available through
-      // the graph's stream mode if needed.
-      topicDomain: undefined,
-      detectedNgbIds: [],
-      queryIntent: undefined,
-      retrievedDocuments: [],
-      webSearchResults: [],
-      retrievalConfidence: 0,
-      disclaimerRequired: true,
-      hasTimeConstraint: false,
-      conversationId: undefined,
-      conversationSummary: undefined,
-      userSport: undefined,
-      needsClarification: false,
-      clarificationQuestion: undefined,
-      escalationReason: undefined,
-      retrievalStatus: "success",
-      emotionalState: "neutral",
-      qualityCheckResult: undefined,
-      qualityRetryCount: 0,
-      expansionAttempted: false,
-      reformulatedQueries: [],
-      isComplexQuery: false,
-      subQueries: [],
-    },
-    trajectory,
-  };
+    });
+
+    // Extract trajectory from the metrics collector
+    const trajectory = nodeMetrics.getAll().map((entry) => entry.name);
+
+    return {
+      state: {
+        messages: [new HumanMessage(userMessage)],
+        answer: output.answer,
+        citations: output.citations,
+        escalation: output.escalation,
+        // These fields aren't directly available from AgentOutput,
+        // so we set sensible defaults. Full state is available through
+        // the graph's stream mode if needed.
+        topicDomain: undefined,
+        detectedNgbIds: [],
+        queryIntent: undefined,
+        retrievedDocuments: [],
+        webSearchResults: [],
+        retrievalConfidence: 0,
+        disclaimerRequired: true,
+        hasTimeConstraint: false,
+        conversationId: undefined,
+        conversationSummary: undefined,
+        userSport: undefined,
+        needsClarification: false,
+        clarificationQuestion: undefined,
+        escalationReason: undefined,
+        retrievalStatus: "success",
+        emotionalState: "neutral",
+        qualityCheckResult: undefined,
+        qualityRetryCount: 0,
+        expansionAttempted: false,
+        reformulatedQueries: [],
+        isComplexQuery: false,
+        subQueries: [],
+      },
+      trajectory,
+    };
+  } finally {
+    await runner.close();
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #141 — running quality review evals (`pnpm quality:run`) fails after ~32 scenarios with `Error: sorry, too many clients already`.

**Root cause:** Each call to `runPipeline()` / `runMultiTurnPipeline()` creates a new `AgentRunner`, which creates a new `PGVectorStore` with its own internal pg `Pool` (default `max: 10`). These pools are never closed, so connections accumulate until PostgreSQL refuses new ones.

**Changes:**

- **`vectorStore.ts`** — Limit pool to `max: 5` connections with `idleTimeoutMillis: 30s` and `connectionTimeoutMillis: 5s` so idle connections are reclaimed
- **`runner.ts`** — Store `vectorStore` reference and add `close()` method that calls `vectorStore.end()` to release the pool
- **`pipeline.ts` / `multiTurnPipeline.ts`** — Wrap `runner.invoke()` in `try/finally` blocks to always close the runner after each eval scenario
- **Tests** — New test for `close()` delegation, new test for pool config limits, updated existing assertions to use `objectContaining` for the vectorStore mock

## Test plan

- [x] `pnpm --filter @usopc/core test` — all 36 tests pass
- [x] `pnpm --filter @usopc/core typecheck` — clean
- [x] `pnpm --filter @usopc/evals typecheck` — clean
- [ ] Manually run `pnpm quality:run` against staging DB to confirm no connection exhaustion

🤖 Generated with [Claude Code](https://claude.com/claude-code)