### PR TITLE
feat: Add collapsible source citations to chat UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 53.8 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 54.5 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 53.8 hours
+**Tracked build time:** 54.5 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-16T15:08:50.608Z
+- Last updated: 2026-02-16T16:04:14.816Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -1,4 +1,8 @@
-import { createDataStreamResponse, formatDataStreamPart } from "ai";
+import {
+  createDataStreamResponse,
+  formatDataStreamPart,
+  type JSONValue,
+} from "ai";
 import { logger } from "@usopc/shared";
 
 const log = logger.child({ service: "chat-route" });
@@ -105,6 +109,12 @@ export async function POST(req: Request) {
         } else if (event.type === "error" && event.error) {
           log.error("Agent stream error", { error: String(event.error) });
           writer.write(formatDataStreamPart("error", event.error.message));
+        } else if (event.type === "citations" && event.citations) {
+          writer.write(
+            formatDataStreamPart("message_annotations", [
+              { type: "citations", citations: event.citations },
+            ] as unknown as JSONValue[]),
+          );
         }
       }
 

--- a/apps/web/components/chat/CitationList.test.tsx
+++ b/apps/web/components/chat/CitationList.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CitationList } from "./CitationList.js";
+import type { Citation } from "../../types/citation.js";
+
+const mockCitations: Citation[] = [
+  {
+    title: "SafeSport Policy",
+    url: "https://example.com/safesport",
+    documentType: "policy",
+    section: "Section 3.1",
+    snippet: "Athletes must complete SafeSport training annually.",
+  },
+  {
+    title: "USOPC Bylaws",
+    documentType: "bylaw",
+    snippet: "Governance structure of the USOPC.",
+  },
+];
+
+describe("CitationList", () => {
+  it("renders nothing for empty citations array", () => {
+    const { container } = render(<CitationList citations={[]} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders the correct source count", () => {
+    render(<CitationList citations={mockCitations} />);
+    expect(screen.getByText(/Sources \(2\)/)).toBeInTheDocument();
+  });
+
+  it("is collapsed by default", () => {
+    render(<CitationList citations={mockCitations} />);
+    const details = document.querySelector("details");
+    expect(details).toBeInTheDocument();
+    expect(details).not.toHaveAttribute("open");
+  });
+
+  it("renders citation cards for each citation", () => {
+    render(<CitationList citations={mockCitations} />);
+    expect(screen.getByText("SafeSport Policy")).toBeInTheDocument();
+    expect(screen.getByText("USOPC Bylaws")).toBeInTheDocument();
+  });
+
+  it("renders a single citation correctly", () => {
+    render(<CitationList citations={[mockCitations[0]]} />);
+    expect(screen.getByText(/Sources \(1\)/)).toBeInTheDocument();
+    expect(screen.getByText("SafeSport Policy")).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/chat/CitationList.tsx
+++ b/apps/web/components/chat/CitationList.tsx
@@ -1,0 +1,32 @@
+import { ChevronRight } from "lucide-react";
+import { CitationCard } from "./CitationCard.js";
+import type { Citation } from "../../types/citation.js";
+
+interface CitationListProps {
+  citations: Citation[];
+}
+
+export function CitationList({ citations }: CitationListProps) {
+  if (citations.length === 0) return null;
+
+  return (
+    <details className="group mt-3">
+      <summary className="flex items-center gap-1 cursor-pointer text-sm text-gray-500 hover:text-gray-700 select-none list-none">
+        <ChevronRight className="w-4 h-4 transition-transform group-open:rotate-90" />
+        Sources ({citations.length})
+      </summary>
+      <div className="mt-1">
+        {citations.map((citation, index) => (
+          <CitationCard
+            key={index}
+            title={citation.title}
+            url={citation.url}
+            documentType={citation.documentType}
+            section={citation.section}
+            snippet={citation.snippet}
+          />
+        ))}
+      </div>
+    </details>
+  );
+}

--- a/apps/web/components/chat/MessageBubble.test.tsx
+++ b/apps/web/components/chat/MessageBubble.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MessageBubble } from "./MessageBubble.js";
+import type { Message } from "ai";
+
+function makeMessage(
+  overrides: Partial<Message> & { role: Message["role"] },
+): Message {
+  return {
+    id: "test-id",
+    content: "Test message",
+    ...overrides,
+  };
+}
+
+describe("MessageBubble", () => {
+  it("does not render citations for user messages", () => {
+    const message = makeMessage({
+      role: "user",
+      annotations: [
+        {
+          type: "citations",
+          citations: [
+            { title: "Policy", documentType: "policy", snippet: "text" },
+          ],
+        },
+      ],
+    });
+    render(<MessageBubble message={message} />);
+    expect(screen.queryByText(/Sources/)).not.toBeInTheDocument();
+  });
+
+  it("does not render citations when annotations is undefined", () => {
+    const message = makeMessage({ role: "assistant" });
+    render(<MessageBubble message={message} />);
+    expect(screen.queryByText(/Sources/)).not.toBeInTheDocument();
+  });
+
+  it("renders citations from annotations for assistant messages", () => {
+    const message = makeMessage({
+      role: "assistant",
+      content: "Here is the answer.",
+      annotations: [
+        {
+          type: "citations",
+          citations: [
+            {
+              title: "SafeSport Policy",
+              documentType: "policy",
+              snippet: "Training required.",
+            },
+            {
+              title: "USOPC Bylaws",
+              documentType: "bylaw",
+              snippet: "Governance info.",
+            },
+          ],
+        },
+      ],
+    });
+    render(<MessageBubble message={message} />);
+    expect(screen.getByText(/Sources \(2\)/)).toBeInTheDocument();
+    expect(screen.getByText("SafeSport Policy")).toBeInTheDocument();
+    expect(screen.getByText("USOPC Bylaws")).toBeInTheDocument();
+  });
+
+  it("ignores non-citation annotations", () => {
+    const message = makeMessage({
+      role: "assistant",
+      annotations: [
+        { type: "other", data: "something" },
+        {
+          type: "citations",
+          citations: [
+            { title: "Test Doc", documentType: "rule", snippet: "snippet" },
+          ],
+        },
+      ],
+    });
+    render(<MessageBubble message={message} />);
+    expect(screen.getByText(/Sources \(1\)/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/components/chat/MessageBubble.tsx
+++ b/apps/web/components/chat/MessageBubble.tsx
@@ -1,12 +1,26 @@
 import type { Message } from "ai";
 import { MarkdownMessage } from "./MarkdownMessage.js";
+import { CitationList } from "./CitationList.js";
+import { isCitationAnnotation, type Citation } from "../../types/citation.js";
 
 interface MessageBubbleProps {
   message: Message;
 }
 
+function extractCitations(annotations: Message["annotations"]): Citation[] {
+  if (!annotations) return [];
+  const results: Citation[] = [];
+  for (const ann of annotations) {
+    if (isCitationAnnotation(ann)) {
+      results.push(...ann.citations);
+    }
+  }
+  return results;
+}
+
 export function MessageBubble({ message }: MessageBubbleProps) {
   const isUser = message.role === "user";
+  const citations = isUser ? [] : extractCitations(message.annotations);
 
   return (
     <div
@@ -22,7 +36,10 @@ export function MessageBubble({ message }: MessageBubbleProps) {
             {message.content}
           </div>
         ) : (
-          <MarkdownMessage content={message.content} />
+          <>
+            <MarkdownMessage content={message.content} />
+            <CitationList citations={citations} />
+          </>
         )}
       </div>
     </div>

--- a/apps/web/types/citation.test.ts
+++ b/apps/web/types/citation.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { isCitationAnnotation } from "./citation.js";
+
+describe("isCitationAnnotation", () => {
+  it("returns true for a valid citation annotation", () => {
+    const annotation = {
+      type: "citations",
+      citations: [
+        { title: "Test", documentType: "policy", snippet: "snippet" },
+      ],
+    };
+    expect(isCitationAnnotation(annotation)).toBe(true);
+  });
+
+  it("returns true for empty citations array", () => {
+    expect(isCitationAnnotation({ type: "citations", citations: [] })).toBe(
+      true,
+    );
+  });
+
+  it("returns false for null", () => {
+    expect(isCitationAnnotation(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isCitationAnnotation(undefined)).toBe(false);
+  });
+
+  it("returns false for wrong type value", () => {
+    expect(isCitationAnnotation({ type: "error", citations: [] })).toBe(false);
+  });
+
+  it("returns false for missing citations field", () => {
+    expect(isCitationAnnotation({ type: "citations" })).toBe(false);
+  });
+
+  it("returns false for non-array citations", () => {
+    expect(
+      isCitationAnnotation({ type: "citations", citations: "not-an-array" }),
+    ).toBe(false);
+  });
+
+  it("returns false for a string", () => {
+    expect(isCitationAnnotation("citations")).toBe(false);
+  });
+});

--- a/apps/web/types/citation.ts
+++ b/apps/web/types/citation.ts
@@ -1,0 +1,27 @@
+export interface Citation {
+  title: string;
+  url?: string;
+  documentType: string;
+  section?: string;
+  effectiveDate?: string;
+  snippet: string;
+  authorityLevel?: string;
+}
+
+export interface CitationAnnotation {
+  type: "citations";
+  citations: Citation[];
+}
+
+export function isCitationAnnotation(
+  annotation: unknown,
+): annotation is CitationAnnotation {
+  return (
+    typeof annotation === "object" &&
+    annotation !== null &&
+    "type" in annotation &&
+    (annotation as Record<string, unknown>).type === "citations" &&
+    "citations" in annotation &&
+    Array.isArray((annotation as Record<string, unknown>).citations)
+  );
+}


### PR DESCRIPTION
## Summary

- Wire citation events from the agent stream through the API route to the frontend using Vercel AI SDK `message_annotations`
- Create `CitationList` component that renders citations in a collapsible `<details>` element with "Sources (N)" summary
- Extract and render citations from `message.annotations` in `MessageBubble` for assistant messages only

Closes #177

## Changes

### Implementation
- **`apps/web/app/api/chat/route.ts`** — Forward `citations` events as `message_annotations` stream parts
- **`apps/web/types/citation.ts`** — `Citation` and `CitationAnnotation` interfaces + `isCitationAnnotation` type guard
- **`apps/web/components/chat/CitationList.tsx`** — Collapsible list with chevron rotation, delegates to existing `CitationCard`
- **`apps/web/components/chat/MessageBubble.tsx`** — Extract citations from annotations and render `CitationList` below assistant messages

### Tests
- **`apps/web/types/citation.test.ts`** — 8 tests for type guard (valid/invalid inputs)
- **`apps/web/components/chat/CitationList.test.tsx`** — 5 tests (empty array, count, collapsed default, renders cards)
- **`apps/web/components/chat/MessageBubble.test.tsx`** — 4 tests (user messages, undefined annotations, renders citations, ignores non-citation annotations)

## Test plan

- [x] `pnpm --filter @usopc/web test` — 17 new tests pass
- [x] `pnpm --filter @usopc/web typecheck` — clean
- [x] `npx prettier --write` — formatted
- [ ] Manual: send a query that triggers document retrieval, verify "Sources (N)" appears collapsed below the answer, clicking expands to show citation cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)