### PR TITLE
feat: Pass conversationId as LangSmith thread metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 56.4 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 57.0 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 56.4 hours
+**Tracked build time:** 57.0 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-16T18:33:52.156Z
+- Last updated: 2026-02-16T19:56:02.948Z
 <!-- HOURS:END -->
 
 ## License

--- a/packages/core/src/agent/runner.test.ts
+++ b/packages/core/src/agent/runner.test.ts
@@ -201,6 +201,37 @@ describe("AgentRunner", () => {
           userSport: "swimming",
           conversationId: "conv-123",
         }),
+        { metadata: { session_id: "conv-123" } },
+      );
+    });
+
+    it("passes metadata.session_id when conversationId is provided", async () => {
+      const graph = makeFakeGraph();
+      mockCreateAgentGraph.mockReturnValue(graph);
+
+      const runner = await AgentRunner.create(defaultConfig);
+      await runner.invoke({
+        messages: [new HumanMessage("hello")],
+        conversationId: "conv-abc",
+      });
+
+      expect(graph.invoke).toHaveBeenCalledWith(expect.anything(), {
+        metadata: { session_id: "conv-abc" },
+      });
+    });
+
+    it("passes no config when conversationId is absent", async () => {
+      const graph = makeFakeGraph();
+      mockCreateAgentGraph.mockReturnValue(graph);
+
+      const runner = await AgentRunner.create(defaultConfig);
+      await runner.invoke({
+        messages: [new HumanMessage("hello")],
+      });
+
+      expect(graph.invoke).toHaveBeenCalledWith(
+        expect.objectContaining({ conversationId: undefined }),
+        undefined,
       );
     });
 
@@ -264,6 +295,46 @@ describe("AgentRunner", () => {
         expect.objectContaining({
           userSport: "track",
         }),
+        { streamMode: ["values", "messages"] },
+      );
+    });
+
+    it("passes metadata.session_id when conversationId is provided", async () => {
+      const graph = makeFakeGraph();
+      mockCreateAgentGraph.mockReturnValue(graph);
+
+      const runner = await AgentRunner.create(defaultConfig);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for await (const _ of runner.stream({
+        messages: [new HumanMessage("hello")],
+        conversationId: "conv-456",
+      })) {
+        // consume
+      }
+
+      expect(graph.stream).toHaveBeenCalledWith(
+        expect.objectContaining({ conversationId: "conv-456" }),
+        {
+          streamMode: ["values", "messages"],
+          metadata: { session_id: "conv-456" },
+        },
+      );
+    });
+
+    it("passes no metadata when conversationId is absent", async () => {
+      const graph = makeFakeGraph();
+      mockCreateAgentGraph.mockReturnValue(graph);
+
+      const runner = await AgentRunner.create(defaultConfig);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for await (const _ of runner.stream({
+        messages: [new HumanMessage("hello")],
+      })) {
+        // consume
+      }
+
+      expect(graph.stream).toHaveBeenCalledWith(
+        expect.objectContaining({ conversationId: undefined }),
         { streamMode: ["values", "messages"] },
       );
     });


### PR DESCRIPTION
## Summary

- Pass `conversationId` as `session_id` in `RunnableConfig.metadata` when invoking `graph.invoke()` and `graph.stream()`, enabling LangSmith's Threads UI for conversation-level evaluation
- Only set metadata when `conversationId` is present to avoid polluting traces with `undefined`
- Add tests verifying metadata is passed correctly (with and without `conversationId`) for both `invoke()` and `stream()`

Closes #187

## Test plan

- [x] `pnpm --filter @usopc/core test` — all 618 tests pass (27 in runner.test.ts)
- [x] `pnpm --filter @usopc/core typecheck` — clean
- [x] `npx prettier --write` — formatted
- [ ] Deploy to dev, run multi-turn conversation, verify LangSmith Threads UI groups turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)