### PR TITLE
feat: Integrate LangSmith Studio for local dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,19 @@ LOG_LEVEL=debug
 #   sst secret set LangchainApiKey <key>    # Optional, for LangSmith tracing
 #   sst secret set SlackBotToken <key>
 #   sst secret set SlackSigningSecret <key>
+
+# ---
+# LangSmith Studio (packages/core/.env)
+#
+# Studio runs outside SST, so it needs raw env vars. Copy this block
+# to packages/core/.env and fill in your API keys:
+#
+#   DATABASE_URL=postgresql://postgres:postgres@localhost:5432/usopc_athlete_support
+#   ANTHROPIC_API_KEY=<your key>
+#   OPENAI_API_KEY=<your key>
+#   LANGSMITH_API_KEY=<your key>
+#   LANGCHAIN_TRACING_V2=true
+#   LANGCHAIN_PROJECT=usopc-athlete-support
+#   # TAVILY_API_KEY=<optional>
+#
+# Then run: pnpm --filter @usopc/core studio

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ coverage/
 # misc
 *.tsbuildinfo
 data/sources/llm-generated-sources/
+
+# LangGraph API
+.langgraph_api
+
+# Studio env (contains real API keys)
+packages/core/.env

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 57.6 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 58.9 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 57.6 hours
+**Tracked build time:** 58.9 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-16T23:56:36.787Z
+- Last updated: 2026-02-17T04:21:24.706Z
 <!-- HOURS:END -->
 
 ## License

--- a/packages/core/langgraph.json
+++ b/packages/core/langgraph.json
@@ -1,0 +1,6 @@
+{
+  "graphs": {
+    "agent": "./src/studio.ts:createGraph"
+  },
+  "env": ".env"
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,8 @@
     "build": "tsc",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "studio": "npx @langchain/langgraph-cli dev"
   },
   "dependencies": {
     "@langchain/anthropic": "^0.3.12",

--- a/packages/core/src/studio.ts
+++ b/packages/core/src/studio.ts
@@ -1,0 +1,17 @@
+import { createEmbeddings } from "./rag/embeddings.js";
+import { createVectorStore } from "./rag/vectorStore.js";
+import { createTavilySearchTool } from "./agent/nodes/researcher.js";
+import type { TavilySearchLike } from "./agent/nodes/researcher.js";
+import { createAgentGraph } from "./agent/graph.js";
+
+export async function createGraph() {
+  const embeddings = createEmbeddings(process.env.OPENAI_API_KEY);
+  const vectorStore = await createVectorStore(embeddings, {
+    connectionString: process.env.DATABASE_URL!,
+  });
+  const tavilySearch: TavilySearchLike = process.env.TAVILY_API_KEY
+    ? (createTavilySearchTool(process.env.TAVILY_API_KEY) as TavilySearchLike)
+    : { invoke: async () => "" };
+
+  return createAgentGraph({ vectorStore, tavilySearch });
+}


### PR DESCRIPTION
## Summary

- Add async graph maker function (`packages/core/src/studio.ts`) that initializes embeddings, vector store, and optional Tavily search, then returns the compiled agent graph
- Add LangGraph CLI config (`packages/core/langgraph.json`) pointing to the maker function
- Add `studio` script to `packages/core/package.json` (`npx @langchain/langgraph-cli dev`)
- Gitignore `packages/core/.env` for Studio API keys (runs outside SST)
- Document Studio setup in `.env.example`

## Usage

```bash
# Fill in API keys in packages/core/.env
pnpm db:up
pnpm --filter @usopc/core studio
# Open Studio URL printed in terminal
```

## Test plan

- [ ] `pnpm --filter @usopc/core typecheck` passes
- [ ] `pnpm db:up` then `pnpm --filter @usopc/core studio` starts the LangGraph dev server
- [ ] Studio UI loads and can send messages through the agent graph
- [ ] Traces appear in LangSmith

🤖 Generated with [Claude Code](https://claude.com/claude-code)