### PR TITLE
refactor: extract shared normalizeUrl and urlToId (#200)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 61.8 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 62.2 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 61.8 hours
+**Tracked build time:** 62.2 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-17T17:11:08.776Z
+- Last updated: 2026-02-17T17:29:56.582Z
 <!-- HOURS:END -->
 
 ## License

--- a/packages/core/src/services/discoveryFeedService.test.ts
+++ b/packages/core/src/services/discoveryFeedService.test.ts
@@ -25,7 +25,7 @@ vi.mock("@usopc/shared", async (importOriginal) => {
 });
 
 import { SendMessageCommand } from "@aws-sdk/client-sqs";
-import { publishDiscoveredUrls, normalizeUrl } from "./discoveryFeedService.js";
+import { publishDiscoveredUrls } from "./discoveryFeedService.js";
 import type { WebSearchResult } from "../types/index.js";
 
 const MockSendMessageCommand = vi.mocked(SendMessageCommand);
@@ -52,40 +52,6 @@ function makeResults(
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
-
-describe("normalizeUrl", () => {
-  it("strips fragment", () => {
-    expect(normalizeUrl("https://usopc.org/page#section")).toBe(
-      "https://usopc.org/page",
-    );
-  });
-
-  it("strips trailing slash on paths", () => {
-    expect(normalizeUrl("https://usopc.org/page/")).toBe(
-      "https://usopc.org/page",
-    );
-  });
-
-  it("preserves root path trailing slash", () => {
-    expect(normalizeUrl("https://usopc.org/")).toBe("https://usopc.org/");
-  });
-
-  it("strips www. prefix", () => {
-    expect(normalizeUrl("https://www.usopc.org/page")).toBe(
-      "https://usopc.org/page",
-    );
-  });
-
-  it("handles all normalizations together", () => {
-    expect(normalizeUrl("https://www.usopc.org/page/#section")).toBe(
-      "https://usopc.org/page",
-    );
-  });
-
-  it("returns invalid URLs as-is", () => {
-    expect(normalizeUrl("not-a-url")).toBe("not-a-url");
-  });
-});
 
 describe("publishDiscoveredUrls", () => {
   beforeEach(() => {

--- a/packages/core/src/services/discoveryFeedService.ts
+++ b/packages/core/src/services/discoveryFeedService.ts
@@ -1,43 +1,11 @@
-import { createHash } from "node:crypto";
 import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
-import { logger } from "@usopc/shared";
+import { logger, normalizeUrl, urlToId } from "@usopc/shared";
 import type { WebSearchResult, DiscoveryFeedMessage } from "../types/index.js";
+
+export { normalizeUrl, urlToId };
 
 const log = logger.child({ service: "discovery-feed" });
 const sqs = new SQSClient({});
-
-/**
- * Normalizes a URL for deduplication:
- * - Strips fragment (#...)
- * - Strips trailing slash
- * - Strips www. prefix from host
- */
-export function normalizeUrl(raw: string): string {
-  try {
-    const parsed = new URL(raw);
-    parsed.hash = "";
-    // Strip www. prefix
-    if (parsed.hostname.startsWith("www.")) {
-      parsed.hostname = parsed.hostname.slice(4);
-    }
-    let normalized = parsed.toString();
-    // Strip trailing slash (but not for root "/")
-    if (normalized.endsWith("/") && parsed.pathname !== "/") {
-      normalized = normalized.slice(0, -1);
-    }
-    return normalized;
-  } catch {
-    // If URL parsing fails, return as-is
-    return raw;
-  }
-}
-
-/**
- * Generates a deterministic SHA-256 ID from a normalized URL.
- */
-export function urlToId(normalizedUrl: string): string {
-  return createHash("sha256").update(normalizedUrl).digest("hex");
-}
 
 /**
  * Publishes discovered URLs from the researcher's web search results

--- a/packages/ingestion/src/discoveryFeedWorker.test.ts
+++ b/packages/ingestion/src/discoveryFeedWorker.test.ts
@@ -13,6 +13,8 @@ vi.mock("@usopc/shared", () => ({
   getSecretValue: vi.fn(() => "test-anthropic-key"),
   createAppTable: vi.fn(() => ({})),
   DiscoveredSourceEntity: vi.fn(),
+  normalizeUrl: vi.fn((url: string) => url),
+  urlToId: vi.fn(() => "test-id-hash"),
 }));
 
 // Mock SST Resource
@@ -20,12 +22,6 @@ vi.mock("sst", () => ({
   Resource: {
     AppTable: { name: "test-table" },
   },
-}));
-
-// Mock @usopc/core
-vi.mock("@usopc/core", () => ({
-  normalizeUrl: vi.fn((url: string) => url),
-  urlToId: vi.fn(() => "test-id-hash"),
 }));
 
 // Mock EvaluationService
@@ -38,8 +34,7 @@ vi.mock("./loaders/index.js", () => ({
   loadWeb: vi.fn(),
 }));
 
-import { DiscoveredSourceEntity } from "@usopc/shared";
-import { normalizeUrl } from "@usopc/core";
+import { DiscoveredSourceEntity, normalizeUrl } from "@usopc/shared";
 import { EvaluationService } from "./services/evaluationService.js";
 import { loadWeb } from "./loaders/index.js";
 import { handler } from "./discoveryFeedWorker.js";

--- a/packages/ingestion/src/discoveryFeedWorker.ts
+++ b/packages/ingestion/src/discoveryFeedWorker.ts
@@ -4,8 +4,9 @@ import {
   getSecretValue,
   DiscoveredSourceEntity,
   createAppTable,
+  normalizeUrl,
+  urlToId,
 } from "@usopc/shared";
-import { normalizeUrl, urlToId } from "@usopc/core";
 import type { DiscoveryFeedMessage } from "@usopc/core";
 import { Resource } from "sst";
 import { EvaluationService } from "./services/evaluationService.js";

--- a/packages/ingestion/src/discoveryOrchestrator.test.ts
+++ b/packages/ingestion/src/discoveryOrchestrator.test.ts
@@ -8,6 +8,7 @@ vi.mock("@usopc/shared", () => ({
     warn: vi.fn(),
     debug: vi.fn(),
   })),
+  normalizeUrl: vi.fn((url: string) => url),
 }));
 
 // Mock SST Resource
@@ -16,11 +17,6 @@ vi.mock("sst", () => ({
     TavilyApiKey: { value: "test-tavily-key" },
     DiscoveryFeedQueue: { url: "https://sqs.us-east-1.amazonaws.com/queue" },
   },
-}));
-
-// Mock @usopc/core
-vi.mock("@usopc/core", () => ({
-  normalizeUrl: vi.fn((url: string) => url),
 }));
 
 // Mock SQS

--- a/packages/ingestion/src/discoveryOrchestrator.ts
+++ b/packages/ingestion/src/discoveryOrchestrator.ts
@@ -1,6 +1,5 @@
 import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
-import { createLogger } from "@usopc/shared";
-import { normalizeUrl } from "@usopc/core";
+import { createLogger, normalizeUrl } from "@usopc/shared";
 import type { DiscoveryFeedMessage } from "@usopc/core";
 import { Resource } from "sst";
 import { DiscoveryService } from "./services/discoveryService.js";

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -89,3 +89,5 @@ export type {
   OrgType,
   SportOrganization,
 } from "./types/sport-org.js";
+
+export { normalizeUrl, urlToId } from "./url.js";

--- a/packages/shared/src/url.test.ts
+++ b/packages/shared/src/url.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { normalizeUrl, urlToId } from "./url.js";
+
+describe("normalizeUrl", () => {
+  it("strips fragment", () => {
+    expect(normalizeUrl("https://usopc.org/page#section")).toBe(
+      "https://usopc.org/page",
+    );
+  });
+
+  it("strips trailing slash on paths", () => {
+    expect(normalizeUrl("https://usopc.org/page/")).toBe(
+      "https://usopc.org/page",
+    );
+  });
+
+  it("preserves root path trailing slash", () => {
+    expect(normalizeUrl("https://usopc.org/")).toBe("https://usopc.org/");
+  });
+
+  it("strips www. prefix", () => {
+    expect(normalizeUrl("https://www.usopc.org/page")).toBe(
+      "https://usopc.org/page",
+    );
+  });
+
+  it("handles all normalizations together", () => {
+    expect(normalizeUrl("https://www.usopc.org/page/#section")).toBe(
+      "https://usopc.org/page",
+    );
+  });
+
+  it("returns invalid URLs as-is", () => {
+    expect(normalizeUrl("not-a-url")).toBe("not-a-url");
+  });
+});
+
+describe("urlToId", () => {
+  it("returns a deterministic hash", () => {
+    const id1 = urlToId("https://usopc.org/page");
+    const id2 = urlToId("https://usopc.org/page");
+    expect(id1).toBe(id2);
+  });
+
+  it("returns a 64-char hex string (SHA-256)", () => {
+    const id = urlToId("https://usopc.org/page");
+    expect(id).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("different URLs produce different IDs", () => {
+    const id1 = urlToId("https://usopc.org/page-a");
+    const id2 = urlToId("https://usopc.org/page-b");
+    expect(id1).not.toBe(id2);
+  });
+});

--- a/packages/shared/src/url.ts
+++ b/packages/shared/src/url.ts
@@ -1,0 +1,34 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Normalizes a URL for deduplication:
+ * - Strips fragment (#...)
+ * - Strips trailing slash
+ * - Strips www. prefix from host
+ */
+export function normalizeUrl(raw: string): string {
+  try {
+    const parsed = new URL(raw);
+    parsed.hash = "";
+    // Strip www. prefix
+    if (parsed.hostname.startsWith("www.")) {
+      parsed.hostname = parsed.hostname.slice(4);
+    }
+    let normalized = parsed.toString();
+    // Strip trailing slash (but not for root "/")
+    if (normalized.endsWith("/") && parsed.pathname !== "/") {
+      normalized = normalized.slice(0, -1);
+    }
+    return normalized;
+  } catch {
+    // If URL parsing fails, return as-is
+    return raw;
+  }
+}
+
+/**
+ * Generates a deterministic SHA-256 ID from a normalized URL.
+ */
+export function urlToId(normalizedUrl: string): string {
+  return createHash("sha256").update(normalizedUrl).digest("hex");
+}


### PR DESCRIPTION
## Summary

- Extract `normalizeUrl()` and `urlToId()` from `packages/core` and `packages/ingestion` into `packages/shared/src/url.ts` — single source of truth
- Update `packages/core/src/services/discoveryFeedService.ts` to re-export from `@usopc/shared` (preserves barrel exports for existing callers)
- Update `packages/ingestion` workers and service to import from `@usopc/shared` instead of `@usopc/core`
- Move `normalizeUrl` tests to `packages/shared/src/url.test.ts`, add `urlToId` tests
- Update test mocks in ingestion to mock `@usopc/shared` instead of `@usopc/core`

Closes #200

## Test plan

- [x] `pnpm --filter @usopc/shared test` — 9 new url tests pass
- [x] `pnpm --filter @usopc/core test` — existing tests pass (4 tests)
- [x] `pnpm --filter @usopc/ingestion test` — existing tests pass (22 tests)
- [x] `pnpm typecheck` — full monorepo type-check passes (all 7 packages)
- [x] `npx prettier --write` — all changed files formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)