### PR TITLE
fix: Unify database connection pools and fix connection leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 68.9 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 69.2 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 68.9 hours
+**Tracked build time:** 69.2 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-18T21:53:30.416Z
+- Last updated: 2026-02-18T22:08:55.711Z
 <!-- HOURS:END -->
 
 ## License

--- a/packages/core/src/agent/runner.test.ts
+++ b/packages/core/src/agent/runner.test.ts
@@ -85,13 +85,12 @@ describe("AgentRunner", () => {
       expect(mockCreateEmbeddings).toHaveBeenCalledWith("test-openai-key");
     });
 
-    it("creates vector store with embeddings and database URL", async () => {
+    it("creates vector store with embeddings (uses shared pool)", async () => {
       await AgentRunner.create(defaultConfig);
 
-      expect(mockCreateVectorStore).toHaveBeenCalledWith(
-        { fake: "embeddings" },
-        { connectionString: "postgresql://localhost:5432/test" },
-      );
+      expect(mockCreateVectorStore).toHaveBeenCalledWith({
+        fake: "embeddings",
+      });
     });
 
     it("creates Tavily search tool when tavilyApiKey is provided", async () => {

--- a/packages/core/src/agent/runner.ts
+++ b/packages/core/src/agent/runner.ts
@@ -88,9 +88,7 @@ export class AgentRunner {
 
     const embeddings = createEmbeddings(config.openaiApiKey);
 
-    const vectorStore = await createVectorStore(embeddings, {
-      connectionString: config.databaseUrl,
-    });
+    const vectorStore = await createVectorStore(embeddings);
 
     const tavilySearch: TavilySearchLike = config.tavilyApiKey
       ? (createTavilySearchTool(config.tavilyApiKey) as TavilySearchLike)

--- a/packages/core/src/studio.ts
+++ b/packages/core/src/studio.ts
@@ -6,9 +6,7 @@ import { createAgentGraph } from "./agent/graph.js";
 
 export async function createGraph() {
   const embeddings = createEmbeddings(process.env.OPENAI_API_KEY);
-  const vectorStore = await createVectorStore(embeddings, {
-    connectionString: process.env.DATABASE_URL!,
-  });
+  const vectorStore = await createVectorStore(embeddings);
   const tavilySearch: TavilySearchLike = process.env.TAVILY_API_KEY
     ? (createTavilySearchTool(process.env.TAVILY_API_KEY) as TavilySearchLike)
     : { invoke: async () => "" };

--- a/packages/ingestion/src/scripts/ingest.ts
+++ b/packages/ingestion/src/scripts/ingest.ts
@@ -15,12 +15,7 @@
  */
 
 import { createHash } from "node:crypto";
-import {
-  getDatabaseUrl,
-  getSecretValue,
-  createLogger,
-  type SourceConfig,
-} from "@usopc/shared";
+import { getSecretValue, createLogger, type SourceConfig } from "@usopc/shared";
 import { ingestSource } from "../pipeline.js";
 import type { IngestionSource } from "../pipeline.js";
 import { createSourceConfigEntity } from "../entities/index.js";
@@ -106,7 +101,6 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
-  const databaseUrl = getDatabaseUrl();
   const openaiApiKey = getSecretValue("OPENAI_API_KEY", "OpenaiApiKey");
   const { sourceId, all, resume, force } = parseArgs();
 
@@ -181,7 +175,6 @@ async function main(): Promise<void> {
     }
 
     const result = await ingestSource(source, {
-      databaseUrl,
       openaiApiKey,
       s3Key,
     });
@@ -347,7 +340,6 @@ async function main(): Promise<void> {
       }
 
       const result = await ingestSource(source, {
-        databaseUrl,
         openaiApiKey,
         s3Key: batchS3Key,
       });

--- a/packages/ingestion/src/scripts/seed-db.ts
+++ b/packages/ingestion/src/scripts/seed-db.ts
@@ -124,7 +124,7 @@ async function main(): Promise<void> {
     const sources = await loadAllSources();
     logger.info(`Loaded ${sources.length} source configuration(s)`);
 
-    const results = await ingestAll(sources, { databaseUrl, openaiApiKey });
+    const results = await ingestAll(sources, { openaiApiKey });
 
     const succeeded = results.filter((r) => r.status === "completed");
     const failed = results.filter((r) => r.status === "failed");

--- a/packages/ingestion/src/scripts/seed.ts
+++ b/packages/ingestion/src/scripts/seed.ts
@@ -140,7 +140,6 @@ async function main(): Promise<void> {
           );
 
           const result = await ingestSource(source, {
-            databaseUrl,
             openaiApiKey,
           });
 

--- a/packages/ingestion/src/worker.test.ts
+++ b/packages/ingestion/src/worker.test.ts
@@ -56,7 +56,6 @@ vi.mock("./entities/index.js", () => ({
 }));
 
 vi.mock("@usopc/shared", () => ({
-  getDatabaseUrl: () => "postgresql://localhost/test",
   getSecretValue: () => "sk-test-key",
   createLogger: () => ({
     info: vi.fn(),

--- a/packages/ingestion/src/worker.ts
+++ b/packages/ingestion/src/worker.ts
@@ -1,7 +1,7 @@
 import type { SQSBatchResponse, SQSEvent, SQSRecord } from "aws-lambda";
 import { SQSClient, PurgeQueueCommand } from "@aws-sdk/client-sqs";
 import { Resource } from "sst";
-import { createLogger, getDatabaseUrl, getSecretValue } from "@usopc/shared";
+import { createLogger, getSecretValue } from "@usopc/shared";
 import { ingestSource, QuotaExhaustedError } from "./pipeline.js";
 import { upsertIngestionStatus } from "./db.js";
 import type { IngestionMessage } from "./cron.js";
@@ -23,7 +23,6 @@ const logger = createLogger({ service: "ingestion-worker" });
  * as batch item failures so SQS can redeliver them later.
  */
 export async function handler(event: SQSEvent): Promise<SQSBatchResponse> {
-  const databaseUrl = getDatabaseUrl();
   const openaiApiKey = getSecretValue("OPENAI_API_KEY", "OpenaiApiKey");
   const ingestionLogEntity = createIngestionLogEntity();
 
@@ -51,7 +50,6 @@ export async function handler(event: SQSEvent): Promise<SQSBatchResponse> {
         });
 
         const result = await ingestSource(message.source, {
-          databaseUrl,
           openaiApiKey,
           s3Key: message.s3Key,
         });

--- a/packages/shared/src/pool.ts
+++ b/packages/shared/src/pool.ts
@@ -18,7 +18,7 @@ export function getPool(): Pool {
   if (!pool) {
     pool = new Pool({
       connectionString: getDatabaseUrl(),
-      max: 10,
+      max: 5,
       idleTimeoutMillis: 30000,
       connectionTimeoutMillis: 5000,
     });


### PR DESCRIPTION
## Summary

Closes #220

- **`vectorStore.ts`**: Uses `getPool()` from `@usopc/shared` instead of creating a separate 5-connection pool via `postgresConnectionOptions`. Accepts optional `pool` override for testing.
- **`pool.ts`**: Reduces `max` from 10 to 5 — the shared pool is now the only pool, so fewer connections are needed.
- **`pipeline.ts`**: `backfillDenormalizedColumns()` uses `getPool().query()` instead of creating a one-off `pg.Client`. `ingestSource()` accepts an optional pre-created `vectorStore`. `ingestAll()` creates one shared vectorStore for all sources.
- **Callers updated**: Removed `databaseUrl` / `connectionString` from `createVectorStore` calls in `runner.ts`, `studio.ts`, `worker.ts`, `ingest.ts`, `seed.ts`, and `seed-db.ts`.

### Before
Each Lambda invocation created up to 15 database connections (10 from shared pool + 5 from PGVectorStore's private pool). `ingestAll` leaked a new pool per source.

### After
A single shared pool with max 5 connections is reused everywhere. No connection leaks during batch ingestion.

## Test plan

- [x] `pnpm --filter @usopc/core test` — vectorStore and runner tests updated
- [x] `pnpm --filter @usopc/ingestion test` — pipeline, worker tests updated
- [x] `pnpm --filter @usopc/shared test` — pool config change verified
- [x] `pnpm typecheck` — full monorepo passes
- [x] `npx prettier --write` — all changed files formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)