### PR TITLE
fix: Implement effective rate limiting (replace in-memory Map) (#232)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 72.3 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 73.0 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 72.3 hours
+**Tracked build time:** 73.0 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-19T15:07:32.429Z
+- Last updated: 2026-02-19T16:56:04.738Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/api/src/trpc.test.ts
+++ b/apps/api/src/trpc.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Must be declared before imports so vi.mock hoisting works
+vi.mock("@usopc/shared", () => ({
+  getOptionalSecretValue: vi.fn(),
+}));
+
+import { getOptionalSecretValue } from "@usopc/shared";
+import {
+  createContext,
+  authenticated,
+  publicProcedure,
+  router,
+} from "./trpc.js";
+import { TRPCError } from "@trpc/server";
+
+const mockGetOptionalSecretValue = vi.mocked(getOptionalSecretValue);
+
+// Build a minimal tRPC caller to exercise the authenticated middleware
+const testRouter = router({
+  protected: publicProcedure.use(authenticated).query(() => "ok"),
+});
+
+function createCaller(apiKey?: string) {
+  const ctx = createContext(
+    apiKey
+      ? {
+          req: new Request("https://example.com", {
+            headers: { "x-api-key": apiKey },
+          }),
+        }
+      : undefined,
+  );
+  return testRouter.createCaller(ctx);
+}
+
+describe("createContext", () => {
+  it("extracts x-api-key header", () => {
+    const req = new Request("https://example.com", {
+      headers: { "x-api-key": "test-key" },
+    });
+    const ctx = createContext({ req });
+    expect(ctx.apiKey).toBe("test-key");
+    expect(ctx.requestId).toBeDefined();
+  });
+
+  it("sets apiKey to undefined when header is absent", () => {
+    const ctx = createContext({ req: new Request("https://example.com") });
+    expect(ctx.apiKey).toBeUndefined();
+  });
+});
+
+describe("authenticated middleware", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes through when no API key is configured (dev mode)", async () => {
+    mockGetOptionalSecretValue.mockReturnValue("");
+
+    const caller = createCaller();
+    const result = await caller.protected();
+    expect(result).toBe("ok");
+  });
+
+  it("passes through with correct API key when one is configured", async () => {
+    mockGetOptionalSecretValue.mockReturnValue("my-secret-key");
+
+    const caller = createCaller("my-secret-key");
+    const result = await caller.protected();
+    expect(result).toBe("ok");
+  });
+
+  it("throws UNAUTHORIZED when API key is missing but one is required", async () => {
+    mockGetOptionalSecretValue.mockReturnValue("my-secret-key");
+
+    const caller = createCaller(); // no key in request
+    await expect(caller.protected()).rejects.toThrow(TRPCError);
+    await expect(caller.protected()).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+      message: "Missing x-api-key header.",
+    });
+  });
+
+  it("throws UNAUTHORIZED for an incorrect API key", async () => {
+    mockGetOptionalSecretValue.mockReturnValue("my-secret-key");
+
+    const caller = createCaller("wrong-key");
+    await expect(caller.protected()).rejects.toThrow(TRPCError);
+    await expect(caller.protected()).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+      message: "Invalid API key.",
+    });
+  });
+
+  it("does not allow key bypass using the 'anonymous' string", async () => {
+    mockGetOptionalSecretValue.mockReturnValue("my-secret-key");
+
+    const caller = createCaller("anonymous");
+    await expect(caller.protected()).rejects.toMatchObject({
+      code: "UNAUTHORIZED",
+    });
+  });
+});

--- a/sst-env.d.ts
+++ b/sst-env.d.ts
@@ -66,6 +66,10 @@ declare module "sst" {
       "type": "sst.sst.Secret"
       "value": string
     }
+    "TrpcApiKey": {
+      "type": "sst.sst.Secret"
+      "value": string
+    }
     "Web": {
       "type": "sst.aws.Nextjs"
       "url": string


### PR DESCRIPTION
## Summary

- Removes the in-memory `Map` rate limiter in `apps/api/src/trpc.ts` that reset on every Lambda cold start and was not shared across concurrent Lambda instances (CVSS 6.5, CWE-770)
- Replaces it with an `authenticated` middleware that validates the `x-api-key` header against a new `TrpcApiKey` SST secret — any non-empty key value enables real API key validation; an empty value (the default) skips auth for frictionless local dev
- Adds API Gateway V2 throttling (`rate: 60, burst: 100`) in `sst.config.ts` as the authoritative infrastructure-level rate limiting layer that works across all Lambda instances without shared state (fixes CVSS 7.5, CWE-306)
- Adds `TrpcApiKey` to `sst-env.d.ts` so the TypeScript type binding is available immediately

## Test plan

- [x] New `src/trpc.test.ts` covers: dev mode passthrough (no key configured), correct key accepted, missing key rejected with `UNAUTHORIZED`, wrong key rejected with `UNAUTHORIZED`, `"anonymous"` string cannot bypass auth
- [x] All existing tests continue to pass (`29 tests` across 4 files)
- [x] Full monorepo typecheck passes (`pnpm typecheck`)

Closes #232

🤖 Generated with [Claude Code](https://claude.ai/claude-code)