### PR TITLE
fix: Add CORS configuration and Next.js security headers (#230)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 73.5 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 73.6 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 73.5 hours
+**Tracked build time:** 73.6 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-19T17:20:01.481Z
+- Last updated: 2026-02-19T17:31:00.712Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/api/src/lambda.ts
+++ b/apps/api/src/lambda.ts
@@ -1,10 +1,24 @@
 import { Hono } from "hono";
+import { cors } from "hono/cors";
 import { handle } from "hono/aws-lambda";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import { appRouter } from "./router.js";
 import { createContext } from "./trpc.js";
 
 const app = new Hono();
+
+// CORS — restrict to the web app origin in production (ALLOWED_ORIGIN env var),
+// or allow all origins in local dev (when the env var is not set).
+const allowedOrigin = process.env.ALLOWED_ORIGIN ?? "*";
+app.use(
+  "*",
+  cors({
+    origin: allowedOrigin,
+    allowMethods: ["GET", "POST", "OPTIONS"],
+    allowHeaders: ["Content-Type", "x-api-key"],
+    maxAge: 600,
+  }),
+);
 
 app.get("/health", (c) => c.json({ status: "ok" }));
 

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,8 +1,51 @@
 import type { NextConfig } from "next";
 
+const securityHeaders = [
+  // Prevent clickjacking — disallow embedding in iframes
+  { key: "X-Frame-Options", value: "DENY" },
+  // Prevent MIME-type sniffing
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  // Enforce HTTPS for one year (including subdomains)
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=31536000; includeSubDomains",
+  },
+  // Limit referrer info sent to external sites
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  // Disable access to sensitive browser features
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=()",
+  },
+  // Content Security Policy — allow self-hosted assets and inline styles
+  // (Tailwind 4 injects <style> tags at runtime, so unsafe-inline is required).
+  // Adjust connect-src if additional API domains are added.
+  {
+    key: "Content-Security-Policy",
+    value: [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'", // Next.js requires unsafe-eval in dev
+      "style-src 'self' 'unsafe-inline'", // Tailwind CSS-in-JS
+      "img-src 'self' data: https:", // avatars and remote images
+      "font-src 'self'",
+      "connect-src 'self' https:", // tRPC API calls
+      "frame-ancestors 'none'",
+    ].join("; "),
+  },
+];
+
 const nextConfig: NextConfig = {
   transpilePackages: ["@usopc/shared", "@usopc/core"],
   serverExternalPackages: ["sst"],
+  async headers() {
+    return [
+      {
+        // Apply security headers to all routes
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
+  },
   // Use webpack for ESM .js extension resolution in workspace packages
   webpack: (config) => {
     config.resolve.extensionAlias = {


### PR DESCRIPTION
## Summary

- **CORS**: Added Hono `cors()` middleware in `apps/api/src/lambda.ts` that restricts cross-origin requests to the web app's CloudFront origin. The allowed origin is injected via an `ALLOWED_ORIGIN` environment variable (set to `web.url` at deploy time by SST). Local dev defaults to `"*"` when the env var is absent.
- **SST ordering fix**: Moved `api.route()` to after the `Web` resource is created in `sst.config.ts`, resolving the circular dependency between `api` needing `web.url` for CORS and `web` needing `api` to link. Pulumi `Output<string>` references resolve lazily at deploy time so this ordering works correctly.
- **Security headers**: Added `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Strict-Transport-Security`, `Referrer-Policy`, `Permissions-Policy`, and a `Content-Security-Policy` to all Next.js routes via the `headers()` async config in `apps/web/next.config.ts`.

## Confidence

**90%** — The changes are isolated to infrastructure config and the Hono middleware layer. CORS enforcement is well-understood and the Hono `cors()` API is straightforward. The CSP `unsafe-eval` directive is required by Next.js in development; this is standard practice. The `api.route()` ordering change is safe because SST/Pulumi resolves all `Output<T>` values lazily. Residual uncertainty: CORS behavior in SST's local dev emulation hasn't been smoke-tested end-to-end, and the CSP may need tuning if new external CDNs are added.

## Test plan

- [x] Existing tests pass (API: 36 tests, web: 217 tests, full monorepo typecheck)
- [x] CORS middleware added with env-driven origin restriction
- [x] Security headers applied to all Next.js routes
- [x] Full typecheck passes

Closes #230

🤖 Generated with [Claude Code](https://claude.ai/claude-code)