### PR TITLE
refactor: fix ingestion deep imports into core internals (#234)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 74.6 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 74.9 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 74.6 hours
+**Tracked build time:** 74.9 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-19T22:52:04.435Z
+- Last updated: 2026-02-20T00:31:09.854Z
 <!-- HOURS:END -->
 
 ## License

--- a/packages/ingestion/src/pipeline.test.ts
+++ b/packages/ingestion/src/pipeline.test.ts
@@ -23,13 +23,10 @@ vi.mock("@usopc/shared", () => ({
 const mockAddVectors = vi.fn();
 const mockEmbedDocuments = vi.fn();
 
-vi.mock("@usopc/core/src/config/index", () => ({
+vi.mock("@usopc/core", () => ({
   MODEL_CONFIG: {
     embeddings: { model: "text-embedding-3-small", dimensions: 1536 },
   },
-}));
-
-vi.mock("@usopc/core/src/rag/index", () => ({
   createRawEmbeddings: vi.fn(() => ({
     embedDocuments: mockEmbedDocuments,
   })),

--- a/packages/ingestion/src/pipeline.ts
+++ b/packages/ingestion/src/pipeline.ts
@@ -1,10 +1,10 @@
 import type { Document } from "@langchain/core/documents";
 import { createLogger, getPool, type AuthorityLevel } from "@usopc/shared";
-import { MODEL_CONFIG } from "@usopc/core/src/config/index";
 import {
+  MODEL_CONFIG,
   createRawEmbeddings,
   createVectorStore,
-} from "@usopc/core/src/rag/index";
+} from "@usopc/core";
 import { loadPdf } from "./loaders/pdfLoader.js";
 import { loadWeb } from "./loaders/webLoader.js";
 import { cleanText } from "./transformers/cleaner.js";


### PR DESCRIPTION
## Summary

Fixes deep imports from `packages/ingestion` into `@usopc/core` internal paths, replacing them with the package barrel export.

- Replace `@usopc/core/src/config/index` and `@usopc/core/src/rag/index` deep imports with a single `@usopc/core` barrel import in `pipeline.ts`
- Consolidate two `vi.mock()` calls targeting internal paths into one `vi.mock("@usopc/core", ...)` in `pipeline.test.ts`

No behavioral changes — core already re-exports all three symbols (`MODEL_CONFIG`, `createRawEmbeddings`, `createVectorStore`) from its barrel.

Closes #234

## Changes

**`packages/ingestion/src/pipeline.ts`**
- Replaced two deep path imports with one `@usopc/core` barrel import

**`packages/ingestion/src/pipeline.test.ts`**
- Consolidated two `vi.mock("@usopc/core/src/...")` calls into a single `vi.mock("@usopc/core", ...)`

## Verification

- `pnpm --filter @usopc/ingestion test` — 258 tests pass
- `pnpm typecheck` — full monorepo, no errors
- `grep -r "@usopc/core/src" packages/ingestion/src/` — returns nothing