### PR TITLE
feat: add Zod input validation to chat route (#272)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 75.5 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 75.8 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 75.5 hours
+**Tracked build time:** 75.8 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-20T01:03:57.768Z
+- Last updated: 2026-02-20T01:21:33.247Z
 <!-- HOURS:END -->
 
 ## License


### PR DESCRIPTION
## Summary

- Adds a `ChatRequestSchema` Zod schema to `apps/web/app/api/chat/route.ts` that validates message count (1–50), per-message content length (≤ 10,000 chars), role values (`user` | `assistant`), and `conversationId` UUID format
- Replaces the unvalidated `await req.json()` destructure with `safeParse`, returning HTTP 400 `{ error: "Invalid request" }` on any schema violation
- Adds 7 new tests covering each validation boundary (empty array, overflow, long content, invalid role, bad UUID, valid UUID, max-length content)
- Fixes the existing test mocks: adds `publishDiscoveredUrls` and a proper `generateSummary` async implementation to `@usopc/core` mock so the happy-path 200 tests run cleanly

Closes #272

## Test plan

- [x] `pnpm --filter @usopc/web test` — all 224 tests pass (11 in `route.test.ts`, including 7 new)
- [x] `pnpm typecheck` — clean across all packages
- [x] `npx prettier --write` — no formatting changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)