### PR TITLE
perf: replace SourceConfig table scan with gsi1 GSI query

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 75.8 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 76.1 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 75.8 hours
+**Tracked build time:** 76.1 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-20T01:21:33.247Z
+- Last updated: 2026-02-20T01:37:35.498Z
 <!-- HOURS:END -->
 
 ## License

--- a/packages/shared/src/entities/SourceConfigEntity.test.ts
+++ b/packages/shared/src/entities/SourceConfigEntity.test.ts
@@ -198,8 +198,8 @@ describe("SourceConfigEntity", () => {
   });
 
   describe("getAll", () => {
-    it("returns all sources via model.scan", async () => {
-      mockScan.mockResolvedValueOnce([
+    it("queries gsi1 with SOURCE#ALL partition key", async () => {
+      mockFind.mockResolvedValueOnce([
         internalItem({ id: "src1" }),
         internalItem({ id: "src2", enabled: "false" }),
       ]);
@@ -210,10 +210,14 @@ describe("SourceConfigEntity", () => {
       expect(results[0].id).toBe("src1");
       expect(results[1].id).toBe("src2");
       expect(results[1].enabled).toBe(false);
+      expect(mockFind).toHaveBeenCalledWith(
+        { gsi1pk: "SOURCE#ALL" },
+        { index: "gsi1" },
+      );
     });
 
     it("returns empty array when no sources exist", async () => {
-      mockScan.mockResolvedValueOnce([]);
+      mockFind.mockResolvedValueOnce([]);
 
       const results = await entity.getAll();
 

--- a/packages/shared/src/entities/SourceConfigEntity.ts
+++ b/packages/shared/src/entities/SourceConfigEntity.ts
@@ -63,6 +63,7 @@ export interface MarkSuccessOptions {
  * GSIs:
  * - ngbId-index: Query sources by NGB
  * - enabled-priority-index: Query enabled sources
+ * - gsi1: Query all sources via static partition key "SOURCE#ALL"
  */
 export class SourceConfigEntity {
   private model;
@@ -166,10 +167,13 @@ export class SourceConfigEntity {
 
   /**
    * Get all source configurations (enabled and disabled).
-   * OneTable handles pagination internally.
+   * Queries the gsi1 index using the static partition key "SOURCE#ALL"
+   * to avoid a full table scan.
    */
   async getAll(): Promise<SourceConfig[]> {
-    const items = await this.model.scan({} as never);
+    const items = await this.model.find({ gsi1pk: "SOURCE#ALL" } as never, {
+      index: "gsi1",
+    });
     return items.map((item) =>
       this.toExternal(item as unknown as Record<string, unknown>),
     );

--- a/packages/shared/src/entities/schema.ts
+++ b/packages/shared/src/entities/schema.ts
@@ -43,6 +43,8 @@ export const AppTableSchema = {
       lastError: { type: String },
       s3Key: { type: String },
       s3VersionId: { type: String },
+      gsi1pk: { type: String, value: "SOURCE#ALL" },
+      gsi1sk: { type: String, value: "${createdAt}" },
       createdAt: { type: String },
       updatedAt: { type: String },
     },


### PR DESCRIPTION
Closes #278

## Summary

Replaces the full DynamoDB table scan in `SourceConfigEntity.getAll()` with a targeted GSI query, eliminating unnecessary read capacity consumption as the table grows.

## Changes

### `packages/shared/src/entities/schema.ts`
- Added `gsi1pk: { type: String, value: "SOURCE#ALL" }` and `gsi1sk: { type: String, value: "${createdAt}" }` to the `SourceConfig` model
- Follows the same pattern as `IngestionLog` (`"Ingest"`) and `UsageMetric` (`"Usage"`)

### `packages/shared/src/entities/SourceConfigEntity.ts`
- `getAll()`: replaced `model.scan({})` → `model.find({ gsi1pk: "SOURCE#ALL" }, { index: "gsi1" })`
- Updated JSDoc to document the gsi1 index usage
- Public API unchanged — return type remains `Promise<SourceConfig[]>`

### `packages/shared/src/entities/SourceConfigEntity.test.ts`
- Updated `getAll` tests to assert `mockFind` is called with `{ gsi1pk: "SOURCE#ALL" }` and `{ index: "gsi1" }` instead of `mockScan`

## Data Backfill Note

Existing DynamoDB records won't have `gsi1pk`/`gsi1sk` attributes until they are next written — OneTable populates template values on `create` and `update`. For existing deployments with live data, call `entity.update(id, {})` on each source config to backfill the GSI attributes. Fresh deployments are unaffected.

## Test Plan

- [x] `pnpm --filter @usopc/shared test` — 258 tests pass
- [x] `pnpm typecheck` — clean across all packages
- [x] `apps/web` route tests unaffected (mock at entity method level, not `model.scan`/`model.find`)