### PR TITLE
feat: add React error boundary to admin dashboard (#287)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 76.7 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 77.0 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 76.7 hours
+**Tracked build time:** 77.0 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-20T02:16:16.671Z
+- Last updated: 2026-02-20T02:28:37.490Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/web/app/admin/error.test.tsx
+++ b/apps/web/app/admin/error.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AdminError from "./error.js";
+
+describe("AdminError", () => {
+  it("renders the error message", () => {
+    const error = new Error("Something exploded");
+    render(<AdminError error={error} reset={vi.fn()} />);
+    expect(
+      screen.getByText("Something went wrong in the admin panel"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Something exploded")).toBeInTheDocument();
+  });
+
+  it("renders the Try again button", () => {
+    const error = new Error("Oops");
+    render(<AdminError error={error} reset={vi.fn()} />);
+    expect(
+      screen.getByRole("button", { name: "Try again" }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls reset when Try again is clicked", async () => {
+    const user = userEvent.setup();
+    const reset = vi.fn();
+    const error = new Error("Network failure");
+    render(<AdminError error={error} reset={reset} />);
+
+    await user.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(reset).toHaveBeenCalledOnce();
+  });
+
+  it("renders with an error that has a digest", () => {
+    const error = Object.assign(new Error("Digest error"), {
+      digest: "abc123",
+    });
+    render(<AdminError error={error} reset={vi.fn()} />);
+    expect(screen.getByText("Digest error")).toBeInTheDocument();
+  });
+});

--- a/apps/web/app/admin/error.tsx
+++ b/apps/web/app/admin/error.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+export default function AdminError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="p-8">
+      <div className="border rounded-lg p-6 border-red-200 bg-red-50">
+        <h2 className="text-xl font-bold text-red-800 mb-2">
+          Something went wrong in the admin panel
+        </h2>
+        <p className="text-sm text-red-600 mb-4">{error.message}</p>
+        <button
+          onClick={reset}
+          className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 text-sm font-medium"
+        >
+          Try again
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #287

Adds `app/admin/error.tsx` using Next.js App Router's built-in error boundary convention. Co-located at the `app/admin/` layout level, it catches render errors thrown by any admin page or component (dashboard, sources, discoveries, bulk import) and displays a recovery UI instead of a blank page.

## Changes

- **`apps/web/app/admin/error.tsx`** (new) — Client-side error boundary; renders the error message and a "Try again" button that calls `reset()` to re-render the segment
- **`apps/web/app/admin/error.test.tsx`** (new) — 4 unit tests covering error message rendering, button presence, reset callback invocation, and digest-carrying errors

## Notes

`global-error.tsx` at the root layout level was not added — the root layout contains only static HTML markup with no data fetching, so it cannot meaningfully throw. The admin-level boundary covers all actual dynamic content.