### PR TITLE
docs: document connection pool, state management, update graph topology (#286)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 77.0 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 77.3 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 77.0 hours
+**Tracked build time:** 77.3 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-20T02:28:37.490Z
+- Last updated: 2026-02-20T03:29:28.720Z
 <!-- HOURS:END -->
 
 ## License


### PR DESCRIPTION
## Summary

Closes #286 (DOC-M4, DOC-M6 from comprehensive review).

### Graph topology diagram (`docs/architecture.md`)
- Replaced outdated 8-node diagram with accurate 12-node topology
- Added all 3 conditional edges: `routeByDomain`, `needsMoreInfo`, `routeByQuality`
- Added node table with model usage (Haiku vs Sonnet vs None)
- Documented the quality feedback loop (synthesizer → qualityChecker → retry)

### Connection Pool section (`docs/architecture.md`)
- Singleton pattern with `getPool()` from `@usopc/shared`
- Pool config: `max: 5`, `idleTimeoutMillis: 30000`, `connectionTimeoutMillis: 5000`
- Connection string resolution order (DATABASE_URL → SST Resource → dev fallback)
- Observability via `getPoolStatus()`, Lambda lifecycle, exhaustion behavior
- Dev vs prod environment table

### LangGraph State Management section (`docs/architecture.md`)
- Overview of `AgentStateAnnotation` (27 fields, all last-write-wins except `messages`)
- State fields grouped by function with "written by" attribution
- Initial state from `buildInitialState()` (only 4 fields passed)
- Cross-package gotcha callout for adding new state fields

### Runtime model config note (`docs/architecture.md`)
- Documented that feature flags have been removed
- `config/models.ts` with DynamoDB overrides + 5-min TTL cache + hardcoded fallback

### langgraph-expert.md fixes
- Removed obsolete feature flags section (9 flags that no longer exist)
- Fixed `featureFlags.ts` key file reference → `config/models.ts`
- Fixed model assignments: qualityChecker, retrievalExpander, queryPlanner use Haiku (not Sonnet)
- Updated `routeByDomain` routing (no longer gated by feature flags, always routes to queryPlanner)
- Fixed `needsMoreInfo` routing (no feature flag checks, simplified logic)
- Fixed field count from 28 → 27

## Test plan

- [ ] Verify graph topology matches `packages/core/src/agent/graph.ts`
- [ ] Verify state field groups match `packages/core/src/agent/state.ts`
- [ ] Verify pool config matches `packages/shared/src/pool.ts`
- [ ] Verify connection string resolution matches `packages/shared/src/env.ts`
- [ ] No tests or typecheck needed — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)