### PR TITLE
fix: remove auth guard from public chat route

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 77.3 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 77.8 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 77.3 hours
+**Tracked build time:** 77.8 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-20T03:29:28.720Z
+- Last updated: 2026-02-20T03:49:02.411Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -5,7 +5,6 @@ import {
 } from "ai";
 import { getResource, logger } from "@usopc/shared";
 import { z } from "zod";
-import { auth } from "../../../auth.js";
 
 const log = logger.child({ service: "chat-route" });
 
@@ -99,11 +98,6 @@ async function getRunner() {
 }
 
 export async function POST(req: Request) {
-  const session = await auth();
-  if (!session) {
-    return Response.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
   try {
     log.info("POST /api/chat called");
     const body = await req.json();


### PR DESCRIPTION
## Summary

- Remove NextAuth session check from `/api/chat` — the chat UI is public and does not require login
- Remove unused `auth` import from the chat route
- Admin dashboard routes retain their auth guards

Closes #308

## Test plan

- [ ] Send a chat message on `http://localhost:3000` without logging in — should receive a streamed response instead of 401
- [ ] Verify admin dashboard routes still require login

🤖 Generated with [Claude Code](https://claude.com/claude-code)