### PR TITLE
fix: warm tone for classifier clarification questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 79.7 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 80.0 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 79.7 hours
+**Tracked build time:** 80.0 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-20T12:44:04.884Z
+- Last updated: 2026-02-20T14:29:38.807Z
 <!-- HOURS:END -->
 
 ## License

--- a/packages/core/src/agent/nodes/clarify.test.ts
+++ b/packages/core/src/agent/nodes/clarify.test.ts
@@ -41,13 +41,13 @@ describe("clarifyNode", () => {
   it("returns the clarification question from state", async () => {
     const state = makeState({
       clarificationQuestion:
-        "Which sport's selection criteria are you asking about?",
+        "That's a great question — which sport is this about?",
     });
 
     const result = await clarifyNode(state);
 
     expect(result.answer).toBe(
-      "Which sport's selection criteria are you asking about?",
+      "That's a great question — which sport is this about?",
     );
   });
 

--- a/packages/core/src/agent/nodes/classifier.test.ts
+++ b/packages/core/src/agent/nodes/classifier.test.ts
@@ -305,7 +305,8 @@ describe("classifierNode", () => {
         hasTimeConstraint: false,
         shouldEscalate: false,
         needsClarification: true,
-        clarificationQuestion: "Which sport are you asking about?",
+        clarificationQuestion:
+          "That's a great question — which sport is this about?",
       }),
     );
 
@@ -316,7 +317,7 @@ describe("classifierNode", () => {
 
     expect(result.needsClarification).toBe(true);
     expect(result.clarificationQuestion).toBe(
-      "Which sport are you asking about?",
+      "That's a great question — which sport is this about?",
     );
   });
 
@@ -444,7 +445,8 @@ describe("classifierNode", () => {
           hasTimeConstraint: false,
           shouldEscalate: false,
           needsClarification: true,
-          clarificationQuestion: "Which sport are you asking about?",
+          clarificationQuestion:
+            "Happy to help with that. Which sport are you asking about?",
         }),
       );
 
@@ -457,7 +459,7 @@ describe("classifierNode", () => {
       // Without context, classifier should ask for clarification
       expect(result.needsClarification).toBe(true);
       expect(result.clarificationQuestion).toBe(
-        "Which sport are you asking about?",
+        "Happy to help with that. Which sport are you asking about?",
       );
     });
   });

--- a/packages/core/src/prompts/classifier.ts
+++ b/packages/core/src/prompts/classifier.ts
@@ -76,10 +76,15 @@ When the user says "my NGB" without naming it, that does NOT make the question a
 Only set needsClarification to true when the ambiguity would lead to a potentially incorrect or irrelevant answer.
 
 ### clarificationQuestion (required if needsClarification is true)
-A brief, specific question to ask the user that will resolve the ambiguity. Keep it under 50 words. Examples:
-- "Which sport are you asking about?"
-- "Are you asking about Olympic or Paralympic selection?"
-- "Which competition's selection procedures are you interested in (e.g., Olympics, World Championships, World Cup, World Series)?"
+A warm, conversational question that resolves the ambiguity. Keep it under 60 words. Guidelines:
+- Briefly acknowledge what the user is asking about before requesting details
+- Ask one clear question — do not stack multiple questions in one sentence
+- Use plain language — avoid parenthetical jargon lists
+- Sound like a helpful person, not an intake form
+Examples:
+- "That's a great question — which sport or NGB is this about?"
+- "Happy to help with that. Are you asking about Olympic or Paralympic selection?"
+- "I can look into that for you. Which competition are you asking about — the Olympics, World Championships, or something else?"
 
 ### emotionalState (required)
 One of the following values:
@@ -130,7 +135,7 @@ Example with clarification needed:
   "hasTimeConstraint": false,
   "shouldEscalate": false,
   "needsClarification": true,
-  "clarificationQuestion": "Which sport's selection criteria are you asking about?",
+  "clarificationQuestion": "That's a great question — which sport is this about?",
   "emotionalState": "neutral"
 }
 


### PR DESCRIPTION
## Summary

Fixes #313 — clarification questions from the classifier read like a bureaucratic intake form (blunt interrogatives, stacked questions, jargon-heavy parenthetical lists).

- Rewrote `clarificationQuestion` instructions in the classifier prompt (`packages/core/src/prompts/classifier.ts`) with tone guidelines: acknowledge the user's concern, ask one question at a time, use plain language, sound like a helpful person
- Replaced cold examples with warm conversational ones
- Updated test fixtures in `clarify.test.ts` and `classifier.test.ts` to use warm-toned question strings

## Test plan

- [x] `pnpm --filter @usopc/core test` — all 663 tests pass
- [x] `pnpm typecheck` — clean across all packages
- [x] `npx prettier --write` — no formatting changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)