### PR TITLE
fix: include contact details inline with resource referrals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 80.0 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 80.4 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 80.0 hours
+**Tracked build time:** 80.4 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-20T14:29:38.807Z
+- Last updated: 2026-02-20T14:54:09.116Z
 <!-- HOURS:END -->
 
 ## License

--- a/packages/core/src/prompts/synthesizer.test.ts
+++ b/packages/core/src/prompts/synthesizer.test.ts
@@ -104,6 +104,7 @@ describe("buildSynthesizerPrompt", () => {
       "Acknowledge gaps with analytical depth",
       "Never fabricate",
       "Use clear, accessible language",
+      "Include contact details with referrals",
     ];
 
     for (const instruction of baseInstructions) {

--- a/packages/core/src/prompts/synthesizer.ts
+++ b/packages/core/src/prompts/synthesizer.ts
@@ -27,7 +27,9 @@ const BASE_INSTRUCTIONS = `## Instructions
 
 7. **Use clear, accessible language.** Athletes may not have legal or governance expertise. Explain technical terms and acronyms on first use.
 
-8. **Prefer higher-authority sources.** When multiple documents address the same topic, prioritize information from higher-authority sources. The hierarchy from highest to lowest is: federal/state law → international rules → USOPC governance → USOPC policies → independent offices (SafeSport, Ombuds) → USADA rules → NGB policies → games-specific rules → educational guidance. If sources conflict, note the conflict and defer to the higher-authority source.`;
+8. **Prefer higher-authority sources.** When multiple documents address the same topic, prioritize information from higher-authority sources. The hierarchy from highest to lowest is: federal/state law → international rules → USOPC governance → USOPC policies → independent offices (SafeSport, Ombuds) → USADA rules → NGB policies → games-specific rules → educational guidance. If sources conflict, note the conflict and defer to the higher-authority source.
+
+9. **Include contact details with referrals.** When recommending that an athlete contact an organization or resource, include available contact details (phone number, email address, and/or URL) inline with the recommendation. Do not rely on the athlete finding contact information elsewhere in the response.`;
 
 /**
  * Response format for factual queries (simple lookups).


### PR DESCRIPTION
## Summary

- Adds instruction #9 to `BASE_INSTRUCTIONS` in the synthesizer prompt, directing the LLM to include contact details (phone, email, URL) inline when recommending an organization or resource
- Adds test coverage for the new instruction in the base instructions test suite

Closes #314

## Test plan

- [x] `pnpm --filter @usopc/core test` — all 681 tests pass
- [ ] Run `/eval-check` to verify response quality with the new prompt instruction

🤖 Generated with [Claude Code](https://claude.com/claude-code)