### PR TITLE
feat: show agent activity status during long-running responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 80.8 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 81.0 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 80.8 hours
+**Tracked build time:** 81.0 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-22T03:17:55.642Z
+- Last updated: 2026-02-22T03:31:41.478Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -162,6 +162,12 @@ export async function POST(req: Request) {
                 { type: "citations", citations: event.citations },
               ] as unknown as JSONValue[]),
             );
+          } else if (event.type === "status" && event.status) {
+            writer.write(
+              formatDataStreamPart("data", [
+                { type: "status", status: event.status },
+              ]),
+            );
           } else if (event.type === "discovered-urls" && event.discoveredUrls) {
             // Captured server-side only for fire-and-forget persistence.
             // Not forwarded to the client — no UX signal for discovery.

--- a/apps/web/app/chat/page.tsx
+++ b/apps/web/app/chat/page.tsx
@@ -1,18 +1,27 @@
 "use client";
 
 import { useChat } from "ai/react";
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { ChatWindow } from "../../components/chat/ChatWindow";
 import { DisclaimerBanner } from "../../components/chat/DisclaimerBanner";
 
 export default function ChatPage() {
   const [userSport] = useState<string | undefined>();
   const [conversationId] = useState(() => crypto.randomUUID());
-  const { messages, input, handleInputChange, handleSubmit, isLoading } =
+  const { messages, input, handleInputChange, handleSubmit, isLoading, data } =
     useChat({
       api: "/api/chat",
       body: { userSport, conversationId },
     });
+
+  const currentStatus = useMemo(() => {
+    if (!data || !isLoading) return undefined;
+    for (let i = data.length - 1; i >= 0; i--) {
+      const item = data[i] as { type?: string; status?: string };
+      if (item?.type === "status" && item.status) return item.status;
+    }
+    return undefined;
+  }, [data, isLoading]);
 
   return (
     <div className="flex flex-col h-screen">
@@ -27,6 +36,7 @@ export default function ChatPage() {
         messages={messages}
         input={input}
         isLoading={isLoading}
+        statusText={currentStatus}
         onInputChange={handleInputChange}
         onSubmit={handleSubmit}
       />

--- a/apps/web/components/chat/ChatWindow.tsx
+++ b/apps/web/components/chat/ChatWindow.tsx
@@ -9,6 +9,7 @@ interface ChatWindowProps {
   messages: Message[];
   input: string;
   isLoading: boolean;
+  statusText?: string | undefined;
   onInputChange: (
     e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>,
   ) => void;
@@ -19,6 +20,7 @@ export function ChatWindow({
   messages,
   input,
   isLoading,
+  statusText,
   onInputChange,
   onSubmit,
 }: ChatWindowProps) {
@@ -45,7 +47,7 @@ export function ChatWindow({
         ))}
         {isLoading && (
           <div className="flex items-center gap-2 text-gray-400">
-            <div className="animate-pulse">Thinking...</div>
+            <div className="animate-pulse">{statusText ?? "Thinking..."}</div>
           </div>
         )}
         <div ref={messagesEndRef} />


### PR DESCRIPTION
## Summary

Closes #318

- Stream real-time status updates to the UI as the agent progresses through graph nodes, replacing the static "Thinking..." indicator
- Add `NODE_STATUS_LABELS` map in `streamAdapter.ts` that maps LangGraph node names to human-readable labels (e.g. classifier → "Understanding your question...", retriever → "Searching governance documents...")
- Detect node transitions from messages mode (`langgraph_node` metadata) and retriever activity from values mode (`retrievedDocuments`), emitting `{ type: "status" }` events
- Forward status events through the chat route as SSE data parts and extract them in the frontend via `useChat` data channel

### Status labels

| Node | Label |
|------|-------|
| classifier | "Understanding your question..." |
| queryPlanner | "Planning search strategy..." |
| retriever | "Searching governance documents..." |
| retrievalExpander | "Broadening search..." |
| researcher | "Searching the web..." |
| synthesizer | "Preparing your answer..." |
| qualityChecker | "Reviewing answer quality..." |
| escalate | "Preparing your answer..." |

Fast nodes (emotionalSupport, citationBuilder, disclaimerGuard, clarify) have no labels since they complete instantly or produce the answer directly.

### Files changed

| File | Change |
|------|--------|
| `packages/core/src/agent/streamAdapter.ts` | Add `"status"` event type, `NODE_STATUS_LABELS` map, emission logic |
| `packages/core/src/agent/streamAdapter.test.ts` | 7 new tests for status event behavior |
| `apps/web/app/api/chat/route.ts` | Forward status events as SSE data parts |
| `apps/web/app/api/chat/route.integration.test.ts` | Wire format test for status SSE data part |
| `apps/web/app/chat/page.tsx` | Extract `currentStatus` from `useChat` data, pass to ChatWindow |
| `apps/web/components/chat/ChatWindow.tsx` | Display `statusText` prop instead of hardcoded "Thinking..." |

## Test plan

- [x] `pnpm --filter @usopc/core test` — 32 streamAdapter tests pass (7 new)
- [x] `pnpm --filter @usopc/web test` — 11 route integration tests pass (1 new)
- [x] `pnpm typecheck` — clean across all packages
- [x] `npx prettier --write` — all files formatted
- [ ] Manual: send a query and verify status text transitions in the UI
- [ ] Consider running `/eval-check` since agent streaming code was modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)