### PR TITLE
fix(web): add Zod validation to bulk sources endpoint [SEC-C2]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 81.0 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 82.6 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 81.0 hours
+**Tracked build time:** 82.6 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-22T03:31:41.478Z
+- Last updated: 2026-02-22T14:16:51.618Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/web/app/api/admin/sources/bulk/route.test.ts
+++ b/apps/web/app/api/admin/sources/bulk/route.test.ts
@@ -89,10 +89,8 @@ describe("POST /api/admin/sources/bulk", () => {
     } as never);
 
     const res = await POST(makeRequest({ ids: ["src1"] }));
-    const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toBe("Invalid request: action and ids are required");
   });
 
   it("returns 400 when ids is empty", async () => {
@@ -104,7 +102,7 @@ describe("POST /api/admin/sources/bulk", () => {
     const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toBe("Invalid request: action and ids are required");
+    expect(body.error).toBe("At least one ID is required");
   });
 
   it("returns 400 for invalid action", async () => {
@@ -113,10 +111,31 @@ describe("POST /api/admin/sources/bulk", () => {
     } as never);
 
     const res = await POST(makeRequest({ action: "purge", ids: ["src1"] }));
-    const body = await res.json();
 
     expect(res.status).toBe(400);
-    expect(body.error).toBe("Invalid action");
+  });
+
+  it("returns 400 when ids contain non-string values", async () => {
+    mockAuth.mockResolvedValueOnce({
+      user: { email: "admin@test.com" },
+    } as never);
+
+    const res = await POST(
+      makeRequest({ action: "enable", ids: [123, { malicious: true }] }),
+    );
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when ids exceed max length", async () => {
+    mockAuth.mockResolvedValueOnce({
+      user: { email: "admin@test.com" },
+    } as never);
+
+    const ids = Array.from({ length: 101 }, (_, i) => `src-${i}`);
+    const res = await POST(makeRequest({ action: "enable", ids }));
+
+    expect(res.status).toBe(400);
   });
 
   it("bulk enables sources", async () => {


### PR DESCRIPTION
## Summary
- Replace TypeScript interface cast with Zod schema validation on the bulk sources admin endpoint — the only mutating admin route missing runtime input validation
- Add `z.string().min(1)` validation on each id element (prevents non-string values flowing into DynamoDB/PostgreSQL)
- Add `.max(100)` upper bound on the ids array (prevents Lambda timeout on oversized payloads)
- Add 2 new test cases: non-string array elements, exceeding max array length

## Review Finding
**SEC-C2** — Missing Zod Validation on Bulk Sources Endpoint (CVSS 8.6, CWE-20)

## Test plan
- [x] All 12 tests pass (10 existing updated + 2 new)
- [x] Full monorepo typecheck passes
- [x] Prettier formatted

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)