### PR TITLE
refactor(web): extract SourceService from admin route handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 **Tracked build time:** 84.7 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-22T21:51:55.207Z
+- Last updated: 2026-02-22T22:05:36.578Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/web/app/api/admin/sources/bulk/route.ts
+++ b/apps/web/app/api/admin/sources/bulk/route.ts
@@ -1,17 +1,15 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
-import {
-  getPool,
-  deleteChunksBySourceId,
-  getResource,
-  logger,
-} from "@usopc/shared";
+import { getPool, getResource, logger } from "@usopc/shared";
 
 const log = logger.child({ service: "admin-sources-bulk" });
 import { requireAdmin } from "../../../../../lib/admin-api.js";
 import { createSourceConfigEntity } from "../../../../../lib/source-config.js";
 import { apiError } from "../../../../../lib/apiResponse.js";
+import {
+  triggerIngestion,
+  deleteSource,
+} from "../../../../../lib/services/source-service.js";
 
 // ---------------------------------------------------------------------------
 // Validation
@@ -44,13 +42,10 @@ export async function POST(request: Request) {
     let succeeded = 0;
     let failed = 0;
 
-    // For ingest actions, resolve the queue URL and create the SQS client once
-    let sqs: SQSClient | undefined;
-    let queueUrl: string | undefined;
+    // For ingest actions, verify queue is available before looping
     if (action === "ingest") {
       try {
-        queueUrl = getResource("IngestionQueue").url;
-        sqs = new SQSClient({});
+        getResource("IngestionQueue");
       } catch {
         return apiError("Ingestion queue not available (dev environment)", 501);
       }
@@ -68,35 +63,10 @@ export async function POST(request: Request) {
             failed++;
             continue;
           }
-
-          const message = {
-            source: {
-              id: source.id,
-              title: source.title,
-              documentType: source.documentType,
-              topicDomains: source.topicDomains,
-              url: source.url,
-              format: source.format,
-              ngbId: source.ngbId,
-              priority: source.priority,
-              description: source.description,
-              authorityLevel: source.authorityLevel,
-            },
-            contentHash: "manual",
-            triggeredAt: new Date().toISOString(),
-          };
-
-          await sqs!.send(
-            new SendMessageCommand({
-              QueueUrl: queueUrl!,
-              MessageBody: JSON.stringify(message),
-              MessageGroupId: source.id,
-            }),
-          );
+          await triggerIngestion(source);
         } else if (action === "delete") {
           const pool = getPool();
-          await deleteChunksBySourceId(pool, id);
-          await entity.delete(id);
+          await deleteSource(id, entity, pool);
         }
         succeeded++;
       } catch {

--- a/apps/web/lib/services/source-service.test.ts
+++ b/apps/web/lib/services/source-service.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockDeleteChunks = vi.fn().mockResolvedValue(0);
+const mockUpdateChunkMetadata = vi.fn().mockResolvedValue(0);
+
+vi.mock("@usopc/shared", () => ({
+  deleteChunksBySourceId: (...args: unknown[]) => mockDeleteChunks(...args),
+  updateChunkMetadataBySourceId: (...args: unknown[]) =>
+    mockUpdateChunkMetadata(...args),
+  getResource: vi.fn((key: string) => {
+    if (key === "IngestionQueue")
+      return { url: "https://sqs.us-east-1.amazonaws.com/test-queue" };
+    throw new Error(`SST Resource '${key}' not available`);
+  }),
+  getPool: () => "mock-pool",
+  logger: {
+    child: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() })),
+  },
+}));
+
+const mockSqsSend = vi.fn();
+vi.mock("@aws-sdk/client-sqs", () => ({
+  SQSClient: vi.fn(() => ({ send: mockSqsSend })),
+  SendMessageCommand: vi.fn((input: unknown) => input),
+}));
+
+import {
+  buildIngestionMessage,
+  triggerIngestion,
+  deleteSource,
+  updateSource,
+  CONTENT_AFFECTING_FIELDS,
+  METADATA_FIELDS,
+} from "./source-service.js";
+
+const SAMPLE_SOURCE = {
+  id: "usopc-bylaws",
+  title: "USOPC Bylaws",
+  documentType: "bylaws",
+  topicDomains: ["governance"],
+  url: "https://example.com/bylaws.pdf",
+  format: "pdf" as const,
+  ngbId: null,
+  priority: "high" as const,
+  description: "Bylaws doc",
+  authorityLevel: "usopc_governance" as const,
+  enabled: true,
+  lastIngestedAt: null,
+  lastContentHash: null,
+  consecutiveFailures: 0,
+  lastError: null,
+  s3Key: null,
+  s3VersionId: null,
+  createdAt: "2025-01-01T00:00:00Z",
+  updatedAt: "2025-01-01T00:00:00Z",
+};
+
+// ===========================================================================
+// buildIngestionMessage
+// ===========================================================================
+
+describe("buildIngestionMessage", () => {
+  it("builds a message with source fields and metadata", () => {
+    const msg = buildIngestionMessage(SAMPLE_SOURCE);
+
+    expect(msg.source.id).toBe("usopc-bylaws");
+    expect(msg.source.title).toBe("USOPC Bylaws");
+    expect(msg.source.url).toBe("https://example.com/bylaws.pdf");
+    expect(msg.source.format).toBe("pdf");
+    expect(msg.source.documentType).toBe("bylaws");
+    expect(msg.source.topicDomains).toEqual(["governance"]);
+    expect(msg.source.ngbId).toBeNull();
+    expect(msg.source.priority).toBe("high");
+    expect(msg.source.description).toBe("Bylaws doc");
+    expect(msg.source.authorityLevel).toBe("usopc_governance");
+    expect(msg.contentHash).toBe("manual");
+    expect(msg.triggeredAt).toBeDefined();
+  });
+
+  it("does not include internal fields like enabled or createdAt", () => {
+    const msg = buildIngestionMessage(SAMPLE_SOURCE);
+    const keys = Object.keys(msg.source);
+
+    expect(keys).not.toContain("enabled");
+    expect(keys).not.toContain("createdAt");
+    expect(keys).not.toContain("lastIngestedAt");
+  });
+});
+
+// ===========================================================================
+// triggerIngestion
+// ===========================================================================
+
+describe("triggerIngestion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends SQS message and returns triggered: true", async () => {
+    mockSqsSend.mockResolvedValueOnce({});
+
+    const result = await triggerIngestion(SAMPLE_SOURCE);
+
+    expect(result).toEqual({ triggered: true });
+    expect(mockSqsSend).toHaveBeenCalledOnce();
+  });
+
+  it("throws when SQS send fails", async () => {
+    mockSqsSend.mockRejectedValueOnce(new Error("SQS error"));
+
+    await expect(triggerIngestion(SAMPLE_SOURCE)).rejects.toThrow("SQS error");
+  });
+});
+
+// ===========================================================================
+// deleteSource
+// ===========================================================================
+
+describe("deleteSource", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deletes chunks then config and returns chunk count", async () => {
+    mockDeleteChunks.mockResolvedValueOnce(15);
+    const mockEntityDelete = vi.fn().mockResolvedValue(undefined);
+    const entity = { delete: mockEntityDelete } as never;
+
+    const result = await deleteSource("src-1", entity, "mock-pool" as never);
+
+    expect(result).toEqual({ chunksDeleted: 15 });
+    expect(mockDeleteChunks).toHaveBeenCalledWith("mock-pool", "src-1");
+    expect(mockEntityDelete).toHaveBeenCalledWith("src-1");
+  });
+
+  it("calls delete in correct order (chunks before config)", async () => {
+    const callOrder: string[] = [];
+    mockDeleteChunks.mockImplementationOnce(() => {
+      callOrder.push("chunks");
+      return Promise.resolve(0);
+    });
+    const entity = {
+      delete: vi.fn().mockImplementation(() => {
+        callOrder.push("config");
+        return Promise.resolve(undefined);
+      }),
+    } as never;
+
+    await deleteSource("src-1", entity, "mock-pool" as never);
+
+    expect(callOrder).toEqual(["chunks", "config"]);
+  });
+});
+
+// ===========================================================================
+// updateSource
+// ===========================================================================
+
+describe("updateSource", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("handles no-vector-impact fields (enabled only)", async () => {
+    const updated = { ...SAMPLE_SOURCE, enabled: false };
+    const entity = {
+      update: vi.fn().mockResolvedValueOnce(updated),
+    } as never;
+
+    const result = await updateSource(
+      "usopc-bylaws",
+      { enabled: false },
+      entity,
+      "mock-pool" as never,
+    );
+
+    expect(result.source.enabled).toBe(false);
+    expect(result.actions).toEqual({});
+    expect(mockDeleteChunks).not.toHaveBeenCalled();
+    expect(mockUpdateChunkMetadata).not.toHaveBeenCalled();
+  });
+
+  it("updates metadata fields and syncs chunks", async () => {
+    const updated = { ...SAMPLE_SOURCE, title: "Updated Title" };
+    const entity = {
+      update: vi.fn().mockResolvedValueOnce(updated),
+    } as never;
+    mockUpdateChunkMetadata.mockResolvedValueOnce(5);
+
+    const result = await updateSource(
+      "usopc-bylaws",
+      { title: "Updated Title" },
+      entity,
+      "mock-pool" as never,
+    );
+
+    expect(result.source.title).toBe("Updated Title");
+    expect(result.actions.chunksUpdated).toBe(5);
+    expect(mockUpdateChunkMetadata).toHaveBeenCalledWith(
+      "mock-pool",
+      "usopc-bylaws",
+      { title: "Updated Title" },
+    );
+  });
+
+  it("deletes chunks and triggers re-ingestion for content changes", async () => {
+    const updated = { ...SAMPLE_SOURCE, url: "https://example.com/new.pdf" };
+    const entity = {
+      update: vi.fn().mockResolvedValueOnce(updated),
+    } as never;
+    mockDeleteChunks.mockResolvedValueOnce(10);
+    mockSqsSend.mockResolvedValueOnce({});
+
+    const result = await updateSource(
+      "usopc-bylaws",
+      { url: "https://example.com/new.pdf" },
+      entity,
+      "mock-pool" as never,
+    );
+
+    expect(result.actions.chunksDeleted).toBe(10);
+    expect(result.actions.reIngestionTriggered).toBe(true);
+    expect(mockDeleteChunks).toHaveBeenCalledWith("mock-pool", "usopc-bylaws");
+    expect(mockSqsSend).toHaveBeenCalledOnce();
+  });
+
+  it("content-affecting change wins over metadata change", async () => {
+    const updated = {
+      ...SAMPLE_SOURCE,
+      url: "https://example.com/new.pdf",
+      title: "New Title",
+    };
+    const entity = {
+      update: vi.fn().mockResolvedValueOnce(updated),
+    } as never;
+    mockDeleteChunks.mockResolvedValueOnce(3);
+    mockSqsSend.mockResolvedValueOnce({});
+
+    const result = await updateSource(
+      "usopc-bylaws",
+      { url: "https://example.com/new.pdf", title: "New Title" },
+      entity,
+      "mock-pool" as never,
+    );
+
+    expect(result.actions.chunksDeleted).toBe(3);
+    expect(result.actions.reIngestionTriggered).toBe(true);
+    expect(mockUpdateChunkMetadata).not.toHaveBeenCalled();
+  });
+
+  it("proceeds with update when SQS fails for content change", async () => {
+    const updated = { ...SAMPLE_SOURCE, url: "https://example.com/new.pdf" };
+    const entity = {
+      update: vi.fn().mockResolvedValueOnce(updated),
+    } as never;
+    mockDeleteChunks.mockResolvedValueOnce(2);
+    mockSqsSend.mockRejectedValueOnce(new Error("SQS unavailable"));
+
+    const result = await updateSource(
+      "usopc-bylaws",
+      { url: "https://example.com/new.pdf" },
+      entity,
+      "mock-pool" as never,
+    );
+
+    expect(result.actions.reIngestionTriggered).toBe(false);
+    expect(result.source.url).toBe("https://example.com/new.pdf");
+  });
+});
+
+// ===========================================================================
+// Field sets
+// ===========================================================================
+
+describe("field sets", () => {
+  it("CONTENT_AFFECTING_FIELDS contains url and format", () => {
+    expect(CONTENT_AFFECTING_FIELDS.has("url")).toBe(true);
+    expect(CONTENT_AFFECTING_FIELDS.has("format")).toBe(true);
+    expect(CONTENT_AFFECTING_FIELDS.size).toBe(2);
+  });
+
+  it("METADATA_FIELDS contains expected fields", () => {
+    expect(METADATA_FIELDS.has("title")).toBe(true);
+    expect(METADATA_FIELDS.has("documentType")).toBe(true);
+    expect(METADATA_FIELDS.has("topicDomains")).toBe(true);
+    expect(METADATA_FIELDS.has("ngbId")).toBe(true);
+    expect(METADATA_FIELDS.has("authorityLevel")).toBe(true);
+    expect(METADATA_FIELDS.size).toBe(5);
+  });
+});

--- a/apps/web/lib/services/source-service.ts
+++ b/apps/web/lib/services/source-service.ts
@@ -1,0 +1,137 @@
+import { SQSClient, SendMessageCommand } from "@aws-sdk/client-sqs";
+import {
+  deleteChunksBySourceId,
+  updateChunkMetadataBySourceId,
+  getResource,
+  getPool,
+  type SourceConfig,
+  type SourceConfigEntity,
+} from "@usopc/shared";
+
+type Pool = ReturnType<typeof getPool>;
+
+// Fields that require re-ingestion (content changes)
+export const CONTENT_AFFECTING_FIELDS = new Set(["url", "format"]);
+
+// Fields that require chunk metadata updates (no re-ingestion)
+export const METADATA_FIELDS = new Set([
+  "title",
+  "documentType",
+  "topicDomains",
+  "ngbId",
+  "authorityLevel",
+]);
+
+/**
+ * Build the SQS message body for triggering document ingestion.
+ */
+export function buildIngestionMessage(source: SourceConfig) {
+  return {
+    source: {
+      id: source.id,
+      title: source.title,
+      documentType: source.documentType,
+      topicDomains: source.topicDomains,
+      url: source.url,
+      format: source.format,
+      ngbId: source.ngbId,
+      priority: source.priority,
+      description: source.description,
+      authorityLevel: source.authorityLevel,
+    },
+    contentHash: "manual",
+    triggeredAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Send an ingestion message to SQS for a source.
+ * Returns `{ triggered: true }` on success.
+ * Throws if the queue is unavailable or send fails.
+ */
+export async function triggerIngestion(
+  source: SourceConfig,
+): Promise<{ triggered: boolean }> {
+  const queueUrl = getResource("IngestionQueue").url;
+  const message = buildIngestionMessage(source);
+
+  const sqs = new SQSClient({});
+  await sqs.send(
+    new SendMessageCommand({
+      QueueUrl: queueUrl,
+      MessageBody: JSON.stringify(message),
+      MessageGroupId: source.id,
+    }),
+  );
+  return { triggered: true };
+}
+
+/**
+ * Delete a source — removes PG chunks first, then DynamoDB config.
+ */
+export async function deleteSource(
+  id: string,
+  entity: SourceConfigEntity,
+  pool: Pool,
+): Promise<{ chunksDeleted: number }> {
+  const chunksDeleted = await deleteChunksBySourceId(pool, id);
+  await entity.delete(id);
+  return { chunksDeleted };
+}
+
+/**
+ * Update a source — detects content vs metadata changes, orchestrates
+ * chunk deletion/update, DynamoDB update, and optional re-ingestion.
+ */
+export async function updateSource(
+  id: string,
+  data: Partial<Omit<SourceConfig, "id" | "createdAt">>,
+  entity: SourceConfigEntity,
+  pool: Pool,
+): Promise<{ source: SourceConfig; actions: Record<string, unknown> }> {
+  const changedKeys = Object.keys(data);
+  const hasContentChange = changedKeys.some((k) =>
+    CONTENT_AFFECTING_FIELDS.has(k),
+  );
+  const hasMetadataChange = changedKeys.some((k) => METADATA_FIELDS.has(k));
+  const actions: Record<string, unknown> = {};
+
+  if (hasContentChange) {
+    const chunksDeleted = await deleteChunksBySourceId(pool, id);
+    actions.chunksDeleted = chunksDeleted;
+
+    const source = await entity.update(id, data);
+
+    try {
+      await triggerIngestion(source);
+      actions.reIngestionTriggered = true;
+    } catch {
+      // SQS not available in dev — still proceed with the update
+      actions.reIngestionTriggered = false;
+    }
+
+    return { source, actions };
+  }
+
+  if (hasMetadataChange) {
+    const metadataUpdates: Record<string, unknown> = {};
+    if (data.title !== undefined) metadataUpdates.title = data.title;
+    if (data.documentType !== undefined)
+      metadataUpdates.documentType = data.documentType;
+    if (data.topicDomains !== undefined)
+      metadataUpdates.topicDomains = data.topicDomains;
+    if (data.ngbId !== undefined) metadataUpdates.ngbId = data.ngbId;
+    if (data.authorityLevel !== undefined)
+      metadataUpdates.authorityLevel = data.authorityLevel;
+
+    const chunksUpdated = await updateChunkMetadataBySourceId(
+      pool,
+      id,
+      metadataUpdates,
+    );
+    actions.chunksUpdated = chunksUpdated;
+  }
+
+  const source = await entity.update(id, data);
+  return { source, actions };
+}


### PR DESCRIPTION
## Summary

- **Extract `SourceService` module** (`apps/web/lib/services/source-service.ts`) centralizing duplicated source business logic from 3 admin route handlers:
  - `buildIngestionMessage()` — SQS message construction (was duplicated 3x)
  - `triggerIngestion()` — resolves queue URL, sends SQS message
  - `deleteSource()` — deletes PG chunks then DynamoDB config
  - `updateSource()` — detects content vs metadata changes, orchestrates chunk deletion/update, DynamoDB update, and optional re-ingestion
- **Slim route handlers** to validate → delegate → respond pattern (removed ~160 lines of duplicated logic)
- **Add service unit tests** (`source-service.test.ts`) covering all business logic independently of HTTP layer
- **Update route tests** to mock the service module instead of `@aws-sdk/client-sqs` internals

## Changed Files

| File | Change |
|------|--------|
| `apps/web/lib/services/source-service.ts` | **New** — extracted service module |
| `apps/web/lib/services/source-service.test.ts` | **New** — 13 unit tests for service logic |
| `apps/web/app/api/admin/sources/[id]/route.ts` | Refactored PATCH/DELETE to delegate to service |
| `apps/web/app/api/admin/sources/[id]/ingest/route.ts` | Refactored to delegate to `triggerIngestion()` |
| `apps/web/app/api/admin/sources/bulk/route.ts` | Refactored ingest/delete actions to use service |
| `apps/web/app/api/admin/sources/[id]/route.test.ts` | Mock service instead of SQS/chunk functions |
| `apps/web/app/api/admin/sources/[id]/ingest/route.test.ts` | Mock `triggerIngestion` instead of SQS |
| `apps/web/app/api/admin/sources/bulk/route.test.ts` | Mock service instead of SQS/chunk functions |

## Test plan

- [x] `pnpm --filter @usopc/web test` — all 316 tests pass (36 files)
- [x] `pnpm typecheck` — full monorepo passes (7 packages)
- [x] `npx prettier --write` — all files formatted

Closes #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)