### PR TITLE
perf: fix admin scan, API limits, and findIndex [PERF-H1..H3]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 84.7 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 85.3 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 84.7 hours
+**Tracked build time:** 85.3 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-22T22:05:36.578Z
+- Last updated: 2026-02-22T22:36:35.281Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/web/app/admin/discoveries/DiscoveriesAdminClient.tsx
+++ b/apps/web/app/admin/discoveries/DiscoveriesAdminClient.tsx
@@ -247,6 +247,13 @@ export function DiscoveriesAdminClient() {
     page * ITEMS_PER_PAGE,
   );
 
+  const detailNav = useMemo(() => {
+    const idx = openDiscoveryId
+      ? sorted.findIndex((d) => d.id === openDiscoveryId)
+      : -1;
+    return { idx, hasPrev: idx > 0, hasNext: idx < sorted.length - 1 };
+  }, [sorted, openDiscoveryId]);
+
   // -------------------------------------------------------------------------
   // Selection
   // -------------------------------------------------------------------------
@@ -740,19 +747,15 @@ export function DiscoveriesAdminClient() {
             id={openDiscoveryId}
             onClose={() => setOpenDiscoveryId(null)}
             onMutate={() => mutate()}
-            hasPrev={sorted.findIndex((d) => d.id === openDiscoveryId) > 0}
-            hasNext={
-              sorted.findIndex((d) => d.id === openDiscoveryId) <
-              sorted.length - 1
-            }
+            hasPrev={detailNav.hasPrev}
+            hasNext={detailNav.hasNext}
             onPrev={() => {
-              const idx = sorted.findIndex((d) => d.id === openDiscoveryId);
-              if (idx > 0) setOpenDiscoveryId(sorted[idx - 1]!.id);
+              if (detailNav.idx > 0)
+                setOpenDiscoveryId(sorted[detailNav.idx - 1]!.id);
             }}
             onNext={() => {
-              const idx = sorted.findIndex((d) => d.id === openDiscoveryId);
-              if (idx < sorted.length - 1)
-                setOpenDiscoveryId(sorted[idx + 1]!.id);
+              if (detailNav.idx < sorted.length - 1)
+                setOpenDiscoveryId(sorted[detailNav.idx + 1]!.id);
             }}
           />
         )}

--- a/apps/web/app/admin/hooks/use-discoveries.ts
+++ b/apps/web/app/admin/hooks/use-discoveries.ts
@@ -9,6 +9,7 @@ import { fetcher, mutationFetcher } from "./fetcher.js";
 
 interface DiscoveriesResponse {
   discoveries: DiscoveredSource[];
+  hasMore?: boolean;
 }
 
 export function useDiscoveries(status?: DiscoveryStatus | "") {
@@ -24,6 +25,7 @@ export function useDiscoveries(status?: DiscoveryStatus | "") {
 
   return {
     discoveries: data?.discoveries ?? [],
+    hasMore: data?.hasMore ?? false,
     isLoading,
     error,
     mutate,

--- a/apps/web/app/admin/hooks/use-sources.ts
+++ b/apps/web/app/admin/hooks/use-sources.ts
@@ -9,6 +9,7 @@ import { fetcher, mutationFetcher } from "./fetcher.js";
 
 interface SourcesResponse {
   sources: SourceConfig[];
+  hasMore?: boolean;
 }
 
 export function useSources() {
@@ -19,6 +20,7 @@ export function useSources() {
 
   return {
     sources: data?.sources ?? [],
+    hasMore: data?.hasMore ?? false,
     isLoading,
     error,
     mutate,

--- a/apps/web/app/admin/sources/SourcesAdminClient.tsx
+++ b/apps/web/app/admin/sources/SourcesAdminClient.tsx
@@ -190,6 +190,13 @@ export function SourcesAdminClient() {
     page * ITEMS_PER_PAGE,
   );
 
+  const detailNav = useMemo(() => {
+    const idx = openSourceId
+      ? sorted.findIndex((s) => s.id === openSourceId)
+      : -1;
+    return { idx, hasPrev: idx > 0, hasNext: idx < sorted.length - 1 };
+  }, [sorted, openSourceId]);
+
   // -------------------------------------------------------------------------
   // Selection
   // -------------------------------------------------------------------------
@@ -669,17 +676,15 @@ export function SourcesAdminClient() {
             id={openSourceId}
             onClose={() => setOpenSourceId(null)}
             onMutate={() => mutate()}
-            hasPrev={sorted.findIndex((s) => s.id === openSourceId) > 0}
-            hasNext={
-              sorted.findIndex((s) => s.id === openSourceId) < sorted.length - 1
-            }
+            hasPrev={detailNav.hasPrev}
+            hasNext={detailNav.hasNext}
             onPrev={() => {
-              const idx = sorted.findIndex((s) => s.id === openSourceId);
-              if (idx > 0) setOpenSourceId(sorted[idx - 1]!.id);
+              if (detailNav.idx > 0)
+                setOpenSourceId(sorted[detailNav.idx - 1]!.id);
             }}
             onNext={() => {
-              const idx = sorted.findIndex((s) => s.id === openSourceId);
-              if (idx < sorted.length - 1) setOpenSourceId(sorted[idx + 1]!.id);
+              if (detailNav.idx < sorted.length - 1)
+                setOpenSourceId(sorted[detailNav.idx + 1]!.id);
             }}
           />
         )}


### PR DESCRIPTION
## Summary

Fixes three high-severity performance findings from the full codebase review:

- **PERF-H1**: Replace `DiscoveredSourceEntity.getAll()` full DynamoDB table scan with parallel GSI queries across all 4 statuses. Adds optional `limit` param to both `getByStatus()` and `getAll()`.
- **PERF-H2**: Add configurable `limit` query param (default 1000, clamped 1-5000) and `hasMore` response flag to admin sources and discoveries API routes. Hooks expose `hasMore` for future UI use.
- **PERF-H3**: Memoize 4 redundant `findIndex()` calls per render in `SourcesAdminClient` and `DiscoveriesAdminClient` via a single `useMemo` (`detailNav`).

## Changes

### Entity layer (`packages/shared`)
- `DiscoveredSourceEntity.getAll()` — replaced `.scan({})` with `Promise.all()` over 4 GSI queries
- `getByStatus()` — accepts optional `{ limit }` option, forwarded to `model.find()`
- `getAll()` — accepts optional `{ limit }`, splits across statuses via `Math.ceil(limit/4)`

### API routes (`apps/web`)
- `GET /api/admin/sources` — parses `?limit=`, returns `{ sources, hasMore }`
- `GET /api/admin/discoveries` — parses `?limit=`, passes `limit+1` to entity, returns `{ discoveries, hasMore }`

### Hooks (`apps/web`)
- `useSources()` / `useDiscoveries()` — expose `hasMore` from response

### Client components (`apps/web`)
- `SourcesAdminClient` / `DiscoveriesAdminClient` — `detailNav` useMemo replaces 4 inline `findIndex` calls

## Test plan

- [x] `pnpm --filter @usopc/shared test` — 21 entity tests pass (getAll now asserts parallel GSI queries instead of scan, new limit tests)
- [x] `pnpm --filter @usopc/web test` — 24 route tests pass (new hasMore, limit, buildRequest tests)
- [x] `pnpm typecheck` — full monorepo passes
- [x] `npx prettier --write` — all files formatted

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)