### PR TITLE
infra: replace Aurora Serverless v2 with Neon Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 85.3 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 86.3 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 85.3 hours
+**Tracked build time:** 86.3 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-22T22:36:35.281Z
+- Last updated: 2026-02-23T01:52:16.357Z
 <!-- HOURS:END -->
 
 ## License

--- a/packages/shared/src/env.test.ts
+++ b/packages/shared/src/env.test.ts
@@ -111,43 +111,24 @@ describe("getDatabaseUrl", () => {
     expect(getDatabaseUrl()).toBe("postgresql://localhost:5432/test");
   });
 
-  it("returns SST Resource URL when DATABASE_URL is not set", () => {
+  it("returns SST Secret value when DATABASE_URL is not set", () => {
     delete process.env.DATABASE_URL;
-    mockResource.Database = {
-      host: "db.example.com",
-      port: "5432",
-      username: "user",
-      password: "pass",
-      database: "mydb",
+    mockResource.DatabaseUrl = {
+      value:
+        "postgresql://user:pass@ep-cool-morning-123456.us-east-1.aws.neon.tech/mydb?sslmode=require",
     };
 
     expect(getDatabaseUrl()).toBe(
-      "postgresql://user:pass@db.example.com:5432/mydb",
+      "postgresql://user:pass@ep-cool-morning-123456.us-east-1.aws.neon.tech/mydb?sslmode=require",
     );
   });
 
-  it("URL-encodes special characters in username and password", () => {
-    delete process.env.DATABASE_URL;
-    mockResource.Database = {
-      host: "db.example.com",
-      port: "5432",
-      username: "user@domain",
-      password: "p@ss:word/123",
-      database: "mydb",
-    };
-
-    const url = getDatabaseUrl();
-    expect(url).toContain("user%40domain");
-    expect(url).toContain("p%40ss%3Aword%2F123");
-  });
-
-  it("throws when neither DATABASE_URL nor SST Resource is available in production", () => {
+  it("throws when neither DATABASE_URL nor SST Secret is available in production", () => {
     delete process.env.DATABASE_URL;
     process.env.NODE_ENV = "production";
-    // mockResource.Database is not set, so accessing it will throw
 
     expect(() => getDatabaseUrl()).toThrow(
-      "DATABASE_URL is not set and SST Database resource is not available",
+      "DATABASE_URL is not set and SST DatabaseUrl secret is not available",
     );
   });
 
@@ -176,15 +157,9 @@ describe("getDatabaseUrl", () => {
     expect(getDatabaseUrl()).toBe("postgresql://custom:5433/other");
   });
 
-  it("prefers DATABASE_URL over SST Resource", () => {
+  it("prefers DATABASE_URL over SST Secret", () => {
     process.env.DATABASE_URL = "postgresql://env-url/db";
-    mockResource.Database = {
-      host: "sst-host",
-      port: "5432",
-      username: "sst-user",
-      password: "sst-pass",
-      database: "sst-db",
-    };
+    mockResource.DatabaseUrl = { value: "postgresql://sst-secret-url/db" };
 
     expect(getDatabaseUrl()).toBe("postgresql://env-url/db");
   });

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -36,8 +36,7 @@ const LOCAL_DEV_DATABASE_URL =
  *
  * Resolution order:
  *   1. `DATABASE_URL` environment variable (set directly or via .env)
- *   2. SST Resource binding (`Resource.Database` with `host`, `port`,
- *      `username`, `password`, `database` fields).
+ *   2. SST Secret binding (`Resource.DatabaseUrl.value`)
  *   3. In development mode, falls back to the standard local Docker URL.
  *   4. Throws if neither source is available.
  */
@@ -47,17 +46,16 @@ export function getDatabaseUrl(): string {
     return directUrl;
   }
 
-  // Attempt to use SST Resource binding (Database only exists in production stage)
   try {
-    const db = (Resource as unknown as Record<string, Record<string, string>>)
-      .Database!;
-    return `postgresql://${encodeURIComponent(db["username"]!)}:${encodeURIComponent(db["password"]!)}@${db["host"]!}:${db["port"]!}/${db["database"]!}`;
+    const secret = (Resource as unknown as { DatabaseUrl: { value: string } })
+      .DatabaseUrl;
+    return secret.value;
   } catch {
     if (isDevelopment()) {
       return LOCAL_DEV_DATABASE_URL;
     }
     throw new Error(
-      "DATABASE_URL is not set and SST Database resource is not available. " +
+      "DATABASE_URL is not set and SST DatabaseUrl secret is not available. " +
         "Provide DATABASE_URL or deploy with SST resource bindings.",
     );
   }

--- a/packages/shared/src/pool.ts
+++ b/packages/shared/src/pool.ts
@@ -12,15 +12,21 @@ export interface PoolStatus {
 /**
  * Returns a singleton database pool instance.
  * Uses getDatabaseUrl() to resolve the connection string from
- * DATABASE_URL env var or SST Resource binding.
+ * DATABASE_URL env var or SST Secret binding.
+ * Enables SSL automatically for Neon Postgres connections.
  */
 export function getPool(): Pool {
   if (!pool) {
+    const connectionString = getDatabaseUrl();
+    const needsSsl =
+      connectionString.includes("neon.tech") ||
+      connectionString.includes("sslmode=require");
     pool = new Pool({
-      connectionString: getDatabaseUrl(),
+      connectionString,
       max: 5,
       idleTimeoutMillis: 30000,
       connectionTimeoutMillis: 5000,
+      ...(needsSsl ? { ssl: { rejectUnauthorized: false } } : {}),
     });
   }
   return pool;


### PR DESCRIPTION
## Summary

Closes #345

Replace Aurora Serverless v2 (~$88/mo per stage, ~$176/mo total) with Neon Postgres ($0-19/mo). Pure infrastructure wiring change — no application logic changes.

- **`sst.config.ts`**: Replace `sst.aws.Postgres("Database")` and `databaseUrl` variable with `sst.Secret("DatabaseUrl")` added to `linkables`. Remove all `database!` refs from link arrays and `databaseUrl` spreads from environment blocks.
- **`packages/shared/src/env.ts`**: Simplify `getDatabaseUrl()` — read `Resource.DatabaseUrl.value` instead of constructing URL from Aurora `host/port/username/password/database` fields.
- **`packages/shared/src/pool.ts`**: Add conditional SSL (`{ ssl: { rejectUnauthorized: false } }`) when connection string contains `neon.tech` or `sslmode=require`.
- **`packages/shared/src/env.test.ts`**: Replace `mockResource.Database = { host, port, ... }` tests with `mockResource.DatabaseUrl = { value: "..." }` tests. Remove URL-encoding test (no longer constructing URLs from parts).
- **`docs/architecture.md`** and **`.claude/agents/sst-architect.md`**: Update all Aurora references to Neon Postgres, add `DatabaseUrl` to secrets lists, update pool code snippets and environment tables.

### What does NOT change

- `packages/core/src/rag/vectorStore.ts` — standard PGVectorStore, works with any pgvector
- All queries, migrations, ingestion pipeline — pure PostgreSQL
- Local dev workflow: `pnpm db:up` -> Docker Postgres on localhost:5432
- `docker-compose.yml` — unchanged

## Test plan

- [x] `pnpm --filter @usopc/shared test` — 289 tests pass (env.test.ts updated)
- [x] `pnpm typecheck` — full monorepo passes (all 7 packages)
- [x] `npx prettier --write` — all changed files formatted
- [ ] `sst secret set DatabaseUrl "<neon-url>" --stage production` after merge
- [ ] Verify chat endpoint works end-to-end with Neon
- [ ] Verify cold start improvement (no VPC attach penalty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)