### PR TITLE
docs(slack): add Slack App manifest and setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 86.3 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 87.2 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 86.3 hours
+**Tracked build time:** 87.2 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-23T01:52:16.357Z
+- Last updated: 2026-02-23T02:34:01.275Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/slack/slack-app-manifest.yml
+++ b/apps/slack/slack-app-manifest.yml
@@ -1,0 +1,45 @@
+_metadata:
+  major_version: 1
+  minor_version: 1
+
+display_information:
+  name: Athlete Support
+  description: >-
+    AI-powered governance and compliance assistant for U.S. Olympic and
+    Paralympic athletes. Ask about selection criteria, appeals, anti-doping,
+    funding, and more.
+  background_color: "#0033A0"
+
+features:
+  bot_user:
+    display_name: Athlete Support
+    always_online: true
+  slash_commands:
+    - command: /ask-athlete-support
+      description: Ask the Athlete Support AI a governance or compliance question
+      usage_hint: "[your question here]"
+      should_escape: false
+
+oauth_config:
+  scopes:
+    bot:
+      - chat:write
+      - reactions:write
+      - im:history
+      - im:read
+      - im:write
+      - app_mentions:read
+      - channels:history
+
+settings:
+  event_subscriptions:
+    request_url: https://REPLACE_WITH_SLACK_URL/slack/events
+    bot_events:
+      - message.im
+      - app_mention
+  interactivity:
+    is_enabled: true
+    request_url: https://REPLACE_WITH_SLACK_URL/slack/interactions
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+  token_rotation_enabled: false

--- a/docs/slack-setup.md
+++ b/docs/slack-setup.md
@@ -1,0 +1,172 @@
+# Slack App Setup Guide
+
+This guide walks through creating and configuring the Athlete Support Slack App at api.slack.com, connecting it to the deployed Lambda, and verifying end-to-end functionality.
+
+## Prerequisites
+
+- AWS credentials configured locally
+- SST CLI installed (`npm install -g sst`)
+- Access to a Slack workspace with permission to create apps
+- The repo cloned and `pnpm install` run
+
+---
+
+## Step 1: Initial Deploy (Placeholder Secrets)
+
+SST requires secrets to exist before deploying, even if the values aren't real yet. Set placeholder values, then deploy to get the Lambda URL.
+
+```bash
+sst secret set SlackBotToken placeholder
+sst secret set SlackSigningSecret placeholder
+sst deploy --stage staging
+```
+
+Note the `slackUrl` output from SST — it looks like:
+
+```
+slackUrl: https://abc123.execute-api.us-east-1.amazonaws.com
+```
+
+---
+
+## Step 2: Create the Slack App
+
+1. Go to [https://api.slack.com/apps](https://api.slack.com/apps)
+2. Click **Create New App → From Manifest**
+3. Select your workspace and click **Next**
+4. Open `apps/slack/slack-app-manifest.yml` from this repo
+5. Replace both occurrences of `REPLACE_WITH_SLACK_URL` with the actual `slackUrl` from Step 1
+6. Paste the updated manifest into the text area and click **Next**
+7. Review the summary (scopes, events, slash command) and click **Create**
+
+---
+
+## Step 3: Install the App and Get Credentials
+
+### Install to Workspace
+
+1. In the app dashboard, click **Install App** in the left sidebar
+2. Click **Install to Workspace** and authorize the requested permissions
+3. Copy the **Bot User OAuth Token** (starts with `xoxb-…`)
+
+### Get the Signing Secret
+
+1. Click **Basic Information** in the left sidebar
+2. Under **App Credentials**, find **Signing Secret**
+3. Click **Show** and copy the value
+
+---
+
+## Step 4: Set Real Secrets
+
+```bash
+sst secret set SlackBotToken xoxb-...
+sst secret set SlackSigningSecret <signing-secret>
+```
+
+---
+
+## Step 5: Redeploy with Real Secrets
+
+```bash
+sst deploy --stage staging
+```
+
+This picks up the real credentials and makes the Lambda functional.
+
+---
+
+## Step 6: Verify URL Verification
+
+In the Slack App dashboard:
+
+1. Go to **Event Subscriptions** in the left sidebar
+2. The **Request URL** should show a green **✅ Verified** badge
+
+If it shows an error:
+- Confirm the URL in the manifest matches the SST `slackUrl` output exactly (no trailing slash)
+- Check CloudWatch logs for the `SlackApi` Lambda for error details
+- Run a health check: `curl https://{slackUrl}/health` → should return `{"status":"ok"}`
+
+---
+
+## Step 7: Test the Bot
+
+### DM the bot
+
+Send a direct message to **Athlete Support**:
+
+```
+What are the team selection criteria for track cycling?
+```
+
+The bot should:
+1. React with 👀 (eyes emoji) to acknowledge
+2. Post a formatted answer with citations and feedback buttons
+
+### @mention in a channel
+
+Invite the bot to a channel, then mention it:
+
+```
+@Athlete Support What are the anti-doping testing obligations?
+```
+
+The bot should respond in a thread.
+
+### Slash command
+
+In any channel:
+
+```
+/ask-athlete-support What is the athlete ombudsman process?
+```
+
+The bot posts an ephemeral "thinking" message, then the full answer.
+
+---
+
+## Production Deployment
+
+Repeat Steps 4–7 for the production stage:
+
+```bash
+sst secret set SlackBotToken xoxb-... --stage production
+sst secret set SlackSigningSecret <signing-secret> --stage production
+sst deploy --stage production
+```
+
+The production `slackUrl` will be different from staging. Update the Event Subscriptions and Interactivity URLs in the Slack App dashboard to point to the production URL, or create a separate Slack App for production.
+
+If you update `apps/slack/slack-app-manifest.yml` with the real URL, also update the manifest in the Slack App dashboard (**App Manifest** tab) to keep them in sync.
+
+---
+
+## Troubleshooting
+
+### Signature verification failures (401 responses)
+
+The Lambda checks `X-Slack-Signature` on every request. Failures mean:
+
+- `SlackSigningSecret` is wrong — double-check the value in the Slack dashboard (**Basic Information → Signing Secret**)
+- The secret wasn't picked up — redeploy after setting the secret
+
+### Bot not responding to DMs
+
+- Confirm `message.im` is listed under **Event Subscriptions → Subscribe to bot events**
+- Confirm `im:read`, `im:history`, and `im:write` scopes are granted (reinstall the app if scopes changed)
+
+### Circuit breaker open
+
+If the agent is erroring repeatedly, the circuit breaker trips and the bot responds with a fallback message. Check CloudWatch logs for the root cause. The circuit breaker resets automatically after the cooldown period.
+
+### CloudWatch logs
+
+Lambda logs are in the `SlackApi` log group. Filter by `ERROR` to find failures:
+
+```bash
+aws logs filter-log-events \
+  --log-group-name /aws/lambda/SlackApi-staging \
+  --filter-pattern ERROR \
+  --start-time $(date -v-1H +%s000)
+```


### PR DESCRIPTION
Closes #349

## Summary

- `apps/slack/slack-app-manifest.yml` — official Slack App manifest checked into the repo; paste directly into api.slack.com when creating the app via **Create New App → From Manifest**
- `docs/slack-setup.md` — step-by-step guide for the full setup flow

## Changes

### `apps/slack/slack-app-manifest.yml` (new)

Includes all required OAuth bot scopes sourced from the code:
- `chat:write`, `reactions:write` — postMessage and eyes-emoji ACK
- `im:history`, `im:read`, `im:write` — DM handling
- `app_mentions:read`, `channels:history` — @mention handling

Event subscriptions: `message.im`, `app_mention`

Slash command: `/ask-athlete-support`

Interactivity enabled for feedback button interactions.

URLs use `REPLACE_WITH_SLACK_URL` placeholder (substituted with the SST Lambda URL during setup).

### `docs/slack-setup.md` (new)

Covers:
1. Initial deploy with placeholder secrets to get the Lambda URL
2. Create the app from the manifest at api.slack.com
3. Install to workspace and collect Bot Token + Signing Secret
4. Set real SST secrets
5. Redeploy to pick up real credentials
6. Verify URL verification in the Slack dashboard
7. Test DM, @mention, and `/ask-athlete-support` slash command
8. Production deployment notes
9. Troubleshooting (signature failures, circuit breaker, CloudWatch logs)

## Related

- No code changes — handlers, agent integration, Slack client, and block builders were already implemented in #7
- #348 tracks follow-on testing/dev gaps (verify.test.ts, ngrok, sst shell)