### PR TITLE
test(slack): add verify middleware tests and local dev docs (#348)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 87.2 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 87.3 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 87.2 hours
+**Tracked build time:** 87.3 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-23T02:34:01.275Z
+- Last updated: 2026-02-23T02:43:10.137Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/slack/src/middleware/verify.test.ts
+++ b/apps/slack/src/middleware/verify.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import crypto from "node:crypto";
+import type { Context, Next } from "hono";
+import { verifySlackRequest } from "./verify.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TEST_SECRET = "test-signing-secret";
+const TEST_BODY = '{"type":"event_callback"}';
+
+function computeSignature(timestamp: string, body: string): string {
+  const sigBasestring = `v0:${timestamp}:${body}`;
+  const hmac = crypto.createHmac("sha256", TEST_SECRET);
+  hmac.update(sigBasestring);
+  return `v0=${hmac.digest("hex")}`;
+}
+
+function makeContext({
+  timestamp,
+  signature,
+  body = TEST_BODY,
+}: {
+  timestamp?: string;
+  signature?: string;
+  body?: string;
+}) {
+  const variables = new Map<string, unknown>();
+  const headers: Record<string, string | undefined> = {};
+  if (timestamp !== undefined) headers["x-slack-request-timestamp"] = timestamp;
+  if (signature !== undefined) headers["x-slack-signature"] = signature;
+
+  const ctx = {
+    req: {
+      header: (name: string) => headers[name],
+      text: vi.fn().mockResolvedValue(body),
+    },
+    set: (key: string, value: unknown) => variables.set(key, value),
+    json: (data: unknown, status: number) =>
+      new Response(JSON.stringify(data), { status }),
+  } as unknown as Context<{ Variables: { rawBody: string } }>;
+
+  return { ctx, variables };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("verifySlackRequest", () => {
+  beforeEach(() => {
+    process.env.SLACK_SIGNING_SECRET = TEST_SECRET;
+  });
+
+  afterEach(() => {
+    delete process.env.SLACK_SIGNING_SECRET;
+  });
+
+  it("returns 401 when x-slack-request-timestamp header is missing", async () => {
+    const { ctx } = makeContext({ signature: "v0=" + "a".repeat(64) });
+    const next = vi.fn();
+
+    const result = await verifySlackRequest(ctx, next as unknown as Next);
+
+    expect((result as Response).status).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when x-slack-signature header is missing", async () => {
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const { ctx } = makeContext({ timestamp });
+    const next = vi.fn();
+
+    const result = await verifySlackRequest(ctx, next as unknown as Next);
+
+    expect((result as Response).status).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when timestamp is older than 5 minutes", async () => {
+    const oldTimestamp = String(Math.floor(Date.now() / 1000) - 301);
+    const { ctx } = makeContext({
+      timestamp: oldTimestamp,
+      signature: computeSignature(oldTimestamp, TEST_BODY),
+    });
+    const next = vi.fn();
+
+    const result = await verifySlackRequest(ctx, next as unknown as Next);
+
+    expect((result as Response).status).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when HMAC signature is wrong", async () => {
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const { ctx } = makeContext({
+      timestamp,
+      // Same length as a real HMAC signature but wrong value
+      signature: "v0=" + "0".repeat(64),
+    });
+    const next = vi.fn();
+
+    const result = await verifySlackRequest(ctx, next as unknown as Next);
+
+    expect((result as Response).status).toBe(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("calls next() and sets rawBody when signature is valid", async () => {
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const { ctx, variables } = makeContext({
+      timestamp,
+      signature: computeSignature(timestamp, TEST_BODY),
+    });
+    const next = vi.fn().mockResolvedValue(undefined);
+
+    await verifySlackRequest(ctx, next as unknown as Next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(variables.get("rawBody")).toBe(TEST_BODY);
+  });
+});

--- a/docs/slack-setup.md
+++ b/docs/slack-setup.md
@@ -84,6 +84,7 @@ In the Slack App dashboard:
 2. The **Request URL** should show a green **✅ Verified** badge
 
 If it shows an error:
+
 - Confirm the URL in the manifest matches the SST `slackUrl` output exactly (no trailing slash)
 - Check CloudWatch logs for the `SlackApi` Lambda for error details
 - Run a health check: `curl https://{slackUrl}/health` → should return `{"status":"ok"}`
@@ -101,6 +102,7 @@ What are the team selection criteria for track cycling?
 ```
 
 The bot should:
+
 1. React with 👀 (eyes emoji) to acknowledge
 2. Post a formatted answer with citations and feedback buttons
 
@@ -139,6 +141,30 @@ sst deploy --stage production
 The production `slackUrl` will be different from staging. Update the Event Subscriptions and Interactivity URLs in the Slack App dashboard to point to the production URL, or create a separate Slack App for production.
 
 If you update `apps/slack/slack-app-manifest.yml` with the real URL, also update the manifest in the Slack App dashboard (**App Manifest** tab) to keep them in sync.
+
+---
+
+## Local Development
+
+### Running the dev server
+
+The dev server (`src/dev.ts`) calls `getAppRunner()`, `postMessage`, and `addReaction`, which all require secrets. Run with `sst shell` to inject them:
+
+```bash
+sst shell -- pnpm --filter @usopc/slack dev
+```
+
+### Receiving real Slack events with ngrok
+
+The dev server runs on `localhost:3002`. Slack requires a public HTTPS URL for event delivery. Use ngrok to create a tunnel:
+
+```bash
+ngrok http 3002
+```
+
+Use the generated URL (e.g. `https://abc123.ngrok.io`) as the temporary **Request URL** in the Slack App dashboard under **Event Subscriptions** and **Interactivity & Shortcuts**.
+
+> **Note:** The ngrok URL changes on every restart. Update the Slack dashboard each time, or use a paid ngrok static domain to keep it stable.
 
 ---
 


### PR DESCRIPTION
Closes #348

## Summary

- **New file** `apps/slack/src/middleware/verify.test.ts` — 5 unit tests for the security-critical `verifySlackRequest` middleware
- **Updated** `docs/slack-setup.md` — adds a Local Development section with `sst shell` note and ngrok tunneling guide

## Implementation

### Tests (`verify.test.ts`)

Five test cases inside `describe("verifySlackRequest")`:

1. Returns 401 when `x-slack-request-timestamp` header is missing
2. Returns 401 when `x-slack-signature` header is missing
3. Returns 401 when timestamp is older than 5 minutes (replay attack)
4. Returns 401 when HMAC signature is wrong (same-length wrong hash to avoid `timingSafeEqual` RangeError)
5. Calls `next()` and sets `rawBody` context variable when signature is valid

Approach: no `@usopc/shared` mock needed — `getRequiredEnv` reads `process.env` directly, so `SLACK_SIGNING_SECRET` is set/deleted in `beforeEach`/`afterEach`. Hono `Context` is mocked as a plain object with `as unknown as Context<...>`.

### Docs (`slack-setup.md`)

New **Local Development** section between Production Deployment and Troubleshooting:
- `sst shell -- pnpm --filter @usopc/slack dev` for secret injection
- ngrok tunneling steps with note about URL rotation

## Test Results

```
✓ src/middleware/verify.test.ts (5 tests)
✓ src/handlers/events.test.ts (7 tests)
✓ src/handlers/mention.test.ts (5 tests)
✓ src/handlers/message.test.ts (6 tests)
✓ src/handlers/slashCommand.test.ts (5 tests)

Tests  28 passed (28)
```

Full monorepo typecheck: clean.