### PR TITLE
chore(ci): gate Deterministic Evaluations behind run-evals PR label

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -3,16 +3,13 @@ name: Evaluations
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "packages/core/src/agent/**"
-      - "packages/core/src/prompts/**"
-      - "packages/core/src/rag/**"
-      - "packages/evals/**"
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
   deterministic-evals:
     name: Deterministic Evaluations
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'run-evals')
     env:
       LANGCHAIN_API_KEY: ${{ secrets.LANGCHAIN_API_KEY }}
       LANGSMITH_API_KEY: ${{ secrets.LANGCHAIN_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 89.6 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 89.9 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 89.6 hours
+**Tracked build time:** 89.9 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-23T14:49:10.682Z
+- Last updated: 2026-02-23T15:31:32.990Z
 <!-- HOURS:END -->
 
 ## License


### PR DESCRIPTION
## Summary

- Deterministic Evaluations no longer fire automatically on every PR that touches agent/eval paths
- Mirrors the existing `run-llm-evals` label pattern already used by the LLM Judge Evaluations job
- Created the `run-evals` label on the repo

## How to trigger evals on a PR

Add the **`run-evals`** label to the PR. The workflow will fire (or re-fire if already open) and run both the classifier and escalation evals.

## Changes

| Before | After |
|--------|-------|
| Fires automatically on any PR touching `packages/core/src/agent/**` etc. | Only fires when `run-evals` label is added |
| `paths` filter as gate | `if: contains(...labels..., 'run-evals')` as gate |

Closes #361