### PR TITLE
refactor: generalize LLM interface for multi-provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 89.9 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 90.1 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -144,10 +144,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 89.9 hours
+**Tracked build time:** 90.1 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-23T15:31:32.990Z
+- Last updated: 2026-02-23T16:01:01.619Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/api/src/routers/health.test.ts
+++ b/apps/api/src/routers/health.test.ts
@@ -30,7 +30,7 @@ vi.mock("../db/client.js", () => ({
 }));
 
 vi.mock("@usopc/core", () => ({
-  getAnthropicCircuitMetrics: vi.fn(() => closedMetrics),
+  getLlmCircuitMetrics: vi.fn(() => closedMetrics),
   getEmbeddingsCircuitMetrics: vi.fn(() => closedMetrics),
   getTavilyCircuitMetrics: vi.fn(() => closedMetrics),
   getVectorStoreReadCircuitMetrics: vi.fn(() => closedMetrics),
@@ -39,10 +39,7 @@ vi.mock("@usopc/core", () => ({
 
 import { healthRouter } from "./health.js";
 import { createContext } from "../trpc.js";
-import {
-  getAnthropicCircuitMetrics,
-  getTavilyCircuitMetrics,
-} from "@usopc/core";
+import { getLlmCircuitMetrics, getTavilyCircuitMetrics } from "@usopc/core";
 
 const createCaller = () => {
   const ctx = createContext();
@@ -66,20 +63,20 @@ describe("healthRouter", () => {
       idleConnections: 2,
       waitingRequests: 0,
     });
-    expect(result.circuits.anthropic.state).toBe("closed");
+    expect(result.circuits.llm.state).toBe("closed");
   });
 
   it("returns degraded when any circuit is open", async () => {
-    vi.mocked(getAnthropicCircuitMetrics).mockReturnValueOnce(openMetrics);
+    vi.mocked(getLlmCircuitMetrics).mockReturnValueOnce(openMetrics);
 
     const caller = createCaller();
     const result = await caller.check();
 
     expect(result.status).toBe("degraded");
-    expect(result.circuits.anthropic.state).toBe("open");
+    expect(result.circuits.llm.state).toBe("open");
   });
 
-  it("returns degraded when a non-anthropic circuit is open", async () => {
+  it("returns degraded when a non-llm circuit is open", async () => {
     vi.mocked(getTavilyCircuitMetrics).mockReturnValueOnce(openMetrics);
 
     const caller = createCaller();

--- a/apps/api/src/routers/health.ts
+++ b/apps/api/src/routers/health.ts
@@ -1,7 +1,7 @@
 import { router, publicProcedure } from "../trpc.js";
 import { getPoolStatus } from "../db/client.js";
 import {
-  getAnthropicCircuitMetrics,
+  getLlmCircuitMetrics,
   getEmbeddingsCircuitMetrics,
   getTavilyCircuitMetrics,
   getVectorStoreReadCircuitMetrics,
@@ -11,7 +11,7 @@ import {
 export const healthRouter = router({
   check: publicProcedure.query(async () => {
     const circuits = {
-      anthropic: getAnthropicCircuitMetrics(),
+      llm: getLlmCircuitMetrics(),
       embeddings: getEmbeddingsCircuitMetrics(),
       tavily: getTavilyCircuitMetrics(),
       vectorStoreRead: getVectorStoreReadCircuitMetrics(),

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
     "@langchain/anthropic": "^1.3.18",
     "@langchain/community": "^1.1.16",
     "@langchain/core": "^1.1.26",
+    "@langchain/google-genai": "^2.1.20",
     "@langchain/langgraph": "^1.1.5",
     "@langchain/openai": "^1.2.8",
     "@langchain/tavily": "^1.2.0",

--- a/packages/core/src/agent/graph.ts
+++ b/packages/core/src/agent/graph.ts
@@ -1,4 +1,4 @@
-import type { ChatAnthropic } from "@langchain/anthropic";
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { StateGraph } from "@langchain/langgraph";
 import { AgentStateAnnotation } from "./state.js";
 import {
@@ -27,7 +27,7 @@ import { withMetrics } from "./nodeMetrics.js";
  *
  * Model instances are created once by {@link AgentRunner.create} and shared
  * across all graph nodes via closure injection (factory functions). This
- * eliminates redundant `ChatAnthropic` allocations per request — in a Lambda
+ * eliminates redundant model allocations per request — in a Lambda
  * warm container the same instances are reused for the lifetime of the process.
  *
  * Changing model configuration (model name, temperature, maxTokens) requires
@@ -37,9 +37,9 @@ export interface GraphDependencies {
   vectorStore: VectorStoreLike;
   tavilySearch: TavilySearchLike;
   /** Sonnet instance used by synthesizer, escalate, and other heavy-reasoning nodes. */
-  agentModel: ChatAnthropic;
+  agentModel: BaseChatModel;
   /** Haiku instance used by classifier, qualityChecker, queryPlanner, and retrievalExpander. */
-  classifierModel: ChatAnthropic;
+  classifierModel: BaseChatModel;
 }
 
 /**

--- a/packages/core/src/agent/nodes/classifier.test.ts
+++ b/packages/core/src/agent/nodes/classifier.test.ts
@@ -4,13 +4,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // Mocks — must be declared before importing the module under test
 // ---------------------------------------------------------------------------
 
-const { mockInvoke } = vi.hoisted(() => ({ mockInvoke: vi.fn() }));
-
-vi.mock("@langchain/anthropic", () => ({
-  ChatAnthropic: vi.fn().mockImplementation(() => ({
-    invoke: mockInvoke,
-  })),
-}));
+const mockInvoke = vi.fn();
 
 vi.mock("@usopc/shared", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@usopc/shared")>();
@@ -29,12 +23,11 @@ vi.mock("@usopc/shared", async (importOriginal) => {
 });
 
 import { createClassifierNode, parseClassifierResponse } from "./classifier.js";
-import { ChatAnthropic } from "@langchain/anthropic";
 import { AIMessage, HumanMessage } from "@langchain/core/messages";
 import { CircuitBreakerError } from "@usopc/shared";
 import type { AgentState } from "../state.js";
 
-const classifierNode = createClassifierNode(new ChatAnthropic());
+const classifierNode = createClassifierNode({ invoke: mockInvoke } as any);
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/core/src/agent/nodes/classifier.ts
+++ b/packages/core/src/agent/nodes/classifier.ts
@@ -1,11 +1,11 @@
-import type { ChatAnthropic } from "@langchain/anthropic";
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { HumanMessage } from "@langchain/core/messages";
 import { logger, CircuitBreakerError } from "@usopc/shared";
 import { buildClassifierPromptWithHistory } from "../../prompts/index.js";
 import {
-  invokeAnthropic,
+  invokeLlm,
   extractTextFromResponse,
-} from "../../services/anthropicService.js";
+} from "../../services/llmService.js";
 import {
   buildContextualQuery,
   stateContext,
@@ -174,7 +174,7 @@ export function parseClassifierResponse(raw: string): ParseResult {
  * the state as `queryIntent === "escalation"` so downstream conditional
  * edges can route accordingly.
  */
-export function createClassifierNode(model: ChatAnthropic) {
+export function createClassifierNode(model: BaseChatModel) {
   return async (state: AgentState): Promise<Partial<AgentState>> => {
     // Build contextual query from conversation history
     const { currentMessage, conversationContext } = buildContextualQuery(
@@ -197,7 +197,7 @@ export function createClassifierNode(model: ChatAnthropic) {
     );
 
     try {
-      const response = await invokeAnthropic(model, [new HumanMessage(prompt)]);
+      const response = await invokeLlm(model, [new HumanMessage(prompt)]);
       const responseText = extractTextFromResponse(response);
       const { output: result, warnings } =
         parseClassifierResponse(responseText);

--- a/packages/core/src/agent/nodes/escalate.test.ts
+++ b/packages/core/src/agent/nodes/escalate.test.ts
@@ -4,13 +4,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // Mocks — must be declared before importing the module under test
 // ---------------------------------------------------------------------------
 
-const { mockInvoke } = vi.hoisted(() => ({ mockInvoke: vi.fn() }));
-
-vi.mock("@langchain/anthropic", () => ({
-  ChatAnthropic: vi.fn().mockImplementation(() => ({
-    invoke: mockInvoke,
-  })),
-}));
+const mockInvoke = vi.fn();
 
 vi.mock("@usopc/shared", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@usopc/shared")>();
@@ -29,12 +23,11 @@ vi.mock("@usopc/shared", async (importOriginal) => {
 });
 
 import { createEscalateNode } from "./escalate.js";
-import { ChatAnthropic } from "@langchain/anthropic";
 import { HumanMessage } from "@langchain/core/messages";
 import { CircuitBreakerError } from "@usopc/shared";
 import type { AgentState } from "../state.js";
 
-const escalateNode = createEscalateNode(new ChatAnthropic());
+const escalateNode = createEscalateNode({ invoke: mockInvoke } as any);
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/core/src/agent/nodes/qualityChecker.test.ts
+++ b/packages/core/src/agent/nodes/qualityChecker.test.ts
@@ -4,13 +4,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // Mocks
 // ---------------------------------------------------------------------------
 
-const { mockInvoke } = vi.hoisted(() => ({ mockInvoke: vi.fn() }));
-
-vi.mock("@langchain/anthropic", () => ({
-  ChatAnthropic: vi.fn().mockImplementation(() => ({
-    invoke: mockInvoke,
-  })),
-}));
+const mockInvoke = vi.fn();
 
 vi.mock("@usopc/shared", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@usopc/shared")>();
@@ -29,12 +23,13 @@ vi.mock("@usopc/shared", async (importOriginal) => {
 
 import { createQualityCheckerNode } from "./qualityChecker.js";
 import { HumanMessage } from "@langchain/core/messages";
-import { ChatAnthropic } from "@langchain/anthropic";
 import { CircuitBreakerError } from "@usopc/shared";
 import type { AgentState } from "../state.js";
 import type { RetrievedDocument } from "../../types/index.js";
 
-const qualityCheckerNode = createQualityCheckerNode(new ChatAnthropic());
+const qualityCheckerNode = createQualityCheckerNode({
+  invoke: mockInvoke,
+} as any);
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/core/src/agent/nodes/qualityChecker.ts
+++ b/packages/core/src/agent/nodes/qualityChecker.ts
@@ -1,12 +1,12 @@
-import type { ChatAnthropic } from "@langchain/anthropic";
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { HumanMessage } from "@langchain/core/messages";
 import { logger, CircuitBreakerError } from "@usopc/shared";
 import { QUALITY_CHECKER_CONFIG } from "../../config/index.js";
 import { buildQualityCheckerPrompt } from "../../prompts/index.js";
 import {
-  invokeAnthropic,
+  invokeLlm,
   extractTextFromResponse,
-} from "../../services/anthropicService.js";
+} from "../../services/llmService.js";
 import {
   buildContextualQuery,
   stateContext,
@@ -60,7 +60,7 @@ function evaluateResult(result: QualityCheckResult): boolean {
  * completeness using Haiku (fast, cheap). Fail-open on all errors —
  * if anything goes wrong, the answer passes through unchanged.
  */
-export function createQualityCheckerNode(model: ChatAnthropic) {
+export function createQualityCheckerNode(model: BaseChatModel) {
   return async (state: AgentState): Promise<Partial<AgentState>> => {
     // Fail-open: skip if no answer or answer is a known error message
     if (!state.answer) {
@@ -90,7 +90,7 @@ export function createQualityCheckerNode(model: ChatAnthropic) {
         ...stateContext(state),
       });
 
-      const response = await invokeAnthropic(model, [new HumanMessage(prompt)]);
+      const response = await invokeLlm(model, [new HumanMessage(prompt)]);
       const text = extractTextFromResponse(response);
       const parsed = parseLlmJson<QualityCheckResult>(text);
 

--- a/packages/core/src/agent/nodes/queryPlanner.test.ts
+++ b/packages/core/src/agent/nodes/queryPlanner.test.ts
@@ -4,13 +4,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // Mocks — must be declared before importing the module under test
 // ---------------------------------------------------------------------------
 
-const { mockInvoke } = vi.hoisted(() => ({ mockInvoke: vi.fn() }));
-
-vi.mock("@langchain/anthropic", () => ({
-  ChatAnthropic: vi.fn().mockImplementation(() => ({
-    invoke: mockInvoke,
-  })),
-}));
+const mockInvoke = vi.fn();
 
 vi.mock("@usopc/shared", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@usopc/shared")>();
@@ -32,12 +26,11 @@ import {
   createQueryPlannerNode,
   parseQueryPlannerResponse,
 } from "./queryPlanner.js";
-import { ChatAnthropic } from "@langchain/anthropic";
 import { HumanMessage } from "@langchain/core/messages";
 import { CircuitBreakerError } from "@usopc/shared";
 import type { AgentState } from "../state.js";
 
-const queryPlannerNode = createQueryPlannerNode(new ChatAnthropic());
+const queryPlannerNode = createQueryPlannerNode({ invoke: mockInvoke } as any);
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/core/src/agent/nodes/queryPlanner.ts
+++ b/packages/core/src/agent/nodes/queryPlanner.ts
@@ -1,11 +1,11 @@
-import type { ChatAnthropic } from "@langchain/anthropic";
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { HumanMessage } from "@langchain/core/messages";
 import { logger, CircuitBreakerError } from "@usopc/shared";
 import { buildQueryPlannerPrompt } from "../../prompts/index.js";
 import {
-  invokeAnthropic,
+  invokeLlm,
   extractTextFromResponse,
-} from "../../services/anthropicService.js";
+} from "../../services/llmService.js";
 import {
   getLastUserMessage,
   stateContext,
@@ -120,7 +120,7 @@ export function parseQueryPlannerResponse(raw: string): ParseResult {
  * Simple queries pass through unchanged (isComplexQuery: false).
  * Errors fail open — the pipeline continues with normal single-domain retrieval.
  */
-export function createQueryPlannerNode(model: ChatAnthropic) {
+export function createQueryPlannerNode(model: BaseChatModel) {
   return async (state: AgentState): Promise<Partial<AgentState>> => {
     const userMessage = getLastUserMessage(state.messages);
 
@@ -136,7 +136,7 @@ export function createQueryPlannerNode(model: ChatAnthropic) {
     );
 
     try {
-      const response = await invokeAnthropic(model, [new HumanMessage(prompt)]);
+      const response = await invokeLlm(model, [new HumanMessage(prompt)]);
       const responseText = extractTextFromResponse(response);
       const { output: result, warnings } =
         parseQueryPlannerResponse(responseText);

--- a/packages/core/src/agent/nodes/researcher.ts
+++ b/packages/core/src/agent/nodes/researcher.ts
@@ -1,12 +1,12 @@
-import type { ChatAnthropic } from "@langchain/anthropic";
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { TavilySearch } from "@langchain/tavily";
 import { logger, CircuitBreakerError } from "@usopc/shared";
 import { TRUSTED_DOMAINS } from "../../config/index.js";
 import {
-  invokeAnthropic,
+  invokeLlm,
   extractTextFromResponse,
-} from "../../services/anthropicService.js";
+} from "../../services/llmService.js";
 import { searchWithTavily } from "../../services/tavilyService.js";
 import {
   buildContextualQuery,
@@ -101,7 +101,7 @@ function parseSearchQueries(text: string): string[] {
  * - The response cannot be parsed as a JSON array
  */
 async function generateSearchQueries(
-  model: ChatAnthropic,
+  model: BaseChatModel,
   state: AgentState,
 ): Promise<string[]> {
   const { currentMessage, conversationContext } = buildContextualQuery(
@@ -125,7 +125,7 @@ async function generateSearchQueries(
       state.topicDomain,
     );
 
-    const response = await invokeAnthropic(model, [
+    const response = await invokeLlm(model, [
       new SystemMessage(
         "You are a web search query generator. Respond with only a JSON array of strings.",
       ),
@@ -205,7 +205,7 @@ function extractStructuredResults(rawResult: unknown): WebSearchResult[] {
  */
 export function createResearcherNode(
   tavilySearch: TavilySearchLike,
-  model: ChatAnthropic,
+  model: BaseChatModel,
 ) {
   return async (state: AgentState): Promise<Partial<AgentState>> => {
     const userMessage = getLastUserMessage(state.messages);

--- a/packages/core/src/agent/nodes/retrievalExpander.ts
+++ b/packages/core/src/agent/nodes/retrievalExpander.ts
@@ -1,10 +1,10 @@
-import type { ChatAnthropic } from "@langchain/anthropic";
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { logger } from "@usopc/shared";
 import {
-  invokeAnthropic,
+  invokeLlm,
   extractTextFromResponse,
-} from "../../services/anthropicService.js";
+} from "../../services/llmService.js";
 import { vectorStoreSearch } from "../../services/vectorStoreService.js";
 import { buildContextualQuery, stateContext } from "../../utils/index.js";
 import { buildRetrievalExpanderPrompt } from "../../prompts/index.js";
@@ -69,7 +69,7 @@ function buildFilter(state: AgentState): Record<string, unknown> | undefined {
  */
 export function createRetrievalExpanderNode(
   vectorStore: VectorStoreLike,
-  model: ChatAnthropic,
+  model: BaseChatModel,
 ) {
   return async (state: AgentState): Promise<Partial<AgentState>> => {
     const { currentMessage } = buildContextualQuery(state.messages);
@@ -90,7 +90,7 @@ export function createRetrievalExpanderNode(
         existingDocTitles,
       );
 
-      const response = await invokeAnthropic(model, [
+      const response = await invokeLlm(model, [
         new SystemMessage(
           "You are a search query reformulation assistant. Respond with only a JSON array.",
         ),

--- a/packages/core/src/agent/nodes/synthesizer.test.ts
+++ b/packages/core/src/agent/nodes/synthesizer.test.ts
@@ -4,13 +4,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // Mocks
 // ---------------------------------------------------------------------------
 
-const { mockInvoke } = vi.hoisted(() => ({ mockInvoke: vi.fn() }));
-
-vi.mock("@langchain/anthropic", () => ({
-  ChatAnthropic: vi.fn().mockImplementation(() => ({
-    invoke: mockInvoke,
-  })),
-}));
+const mockInvoke = vi.fn();
 
 vi.mock("@usopc/shared", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@usopc/shared")>();
@@ -29,13 +23,12 @@ vi.mock("@usopc/shared", async (importOriginal) => {
 });
 
 import { createSynthesizerNode } from "./synthesizer.js";
-import { ChatAnthropic } from "@langchain/anthropic";
 import { HumanMessage } from "@langchain/core/messages";
 import { CircuitBreakerError } from "@usopc/shared";
 import type { AgentState } from "../state.js";
 import type { RetrievedDocument } from "../../types/index.js";
 
-const synthesizerNode = createSynthesizerNode(new ChatAnthropic());
+const synthesizerNode = createSynthesizerNode({ invoke: mockInvoke } as any);
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/core/src/agent/nodes/synthesizer.ts
+++ b/packages/core/src/agent/nodes/synthesizer.ts
@@ -1,4 +1,4 @@
-import type { ChatAnthropic } from "@langchain/anthropic";
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { logger, CircuitBreakerError } from "@usopc/shared";
 import {
@@ -8,9 +8,9 @@ import {
   getEmotionalToneGuidance,
 } from "../../prompts/index.js";
 import {
-  invokeAnthropic,
+  invokeLlm,
   extractTextFromResponse,
-} from "../../services/anthropicService.js";
+} from "../../services/llmService.js";
 import {
   buildContextualQuery,
   stateContext,
@@ -35,7 +35,7 @@ const log = logger.child({ service: "synthesizer-node" });
  * When retrying after a quality check failure, appends the critique as
  * feedback to guide the model toward a more specific response.
  */
-export function createSynthesizerNode(model: ChatAnthropic) {
+export function createSynthesizerNode(model: BaseChatModel) {
   return async (state: AgentState): Promise<Partial<AgentState>> => {
     // Build contextual query from conversation history
     const { currentMessage, conversationContext } = buildContextualQuery(
@@ -107,7 +107,7 @@ export function createSynthesizerNode(model: ChatAnthropic) {
         ...stateContext(state),
       });
 
-      const response = await invokeAnthropic(model, [
+      const response = await invokeLlm(model, [
         new SystemMessage(SYSTEM_PROMPT),
         new HumanMessage(prompt),
       ]);

--- a/packages/core/src/agent/runner.ts
+++ b/packages/core/src/agent/runner.ts
@@ -1,4 +1,4 @@
-import type { ChatAnthropic } from "@langchain/anthropic";
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { HumanMessage, AIMessage } from "@langchain/core/messages";
 import type { BaseMessage } from "@langchain/core/messages";
 import { createEmbeddings } from "../rag/embeddings.js";
@@ -77,12 +77,12 @@ export function convertMessages(
 export class AgentRunner {
   private graph: ReturnType<typeof createAgentGraph>;
   private vectorStore: PGVectorStore;
-  private _classifierModel: ChatAnthropic;
+  private _classifierModel: BaseChatModel;
 
   private constructor(
     graph: ReturnType<typeof createAgentGraph>,
     vectorStore: PGVectorStore,
-    classifierModel: ChatAnthropic,
+    classifierModel: BaseChatModel,
   ) {
     this.graph = graph;
     this.vectorStore = vectorStore;
@@ -93,7 +93,7 @@ export class AgentRunner {
    * The shared Haiku model instance. Exposed so callers (e.g., route handlers)
    * can pass it to `generateSummary()` without a module-level singleton.
    */
-  get classifierModel(): ChatAnthropic {
+  get classifierModel(): BaseChatModel {
     return this._classifierModel;
   }
 
@@ -104,7 +104,7 @@ export class AgentRunner {
    * Model instances (`agentModel` for Sonnet, `classifierModel` for Haiku) are
    * constructed once here and injected into every graph node via factory closures.
    * In a Lambda warm container these instances persist across sequential requests,
-   * avoiding 3-5 redundant `ChatAnthropic` allocations per invocation.
+   * avoiding 3-5 redundant model allocations per invocation.
    *
    * Config changes (model name, temperature, maxTokens) take effect only on
    * cold start, when a new `AgentRunner` is created.

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -11,4 +11,8 @@ export {
   TRUSTED_DOMAINS,
   QUALITY_CHECKER_CONFIG,
 } from "./settings.js";
-export { createAgentModels, type AgentModels } from "./modelFactory.js";
+export {
+  createAgentModels,
+  createChatModel,
+  type AgentModels,
+} from "./modelFactory.js";

--- a/packages/core/src/config/modelFactory.ts
+++ b/packages/core/src/config/modelFactory.ts
@@ -1,15 +1,54 @@
 import { ChatAnthropic } from "@langchain/anthropic";
+import { ChatOpenAI } from "@langchain/openai";
+import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
+import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { getModelConfig } from "./models.js";
 
 export interface AgentModels {
-  /** Sonnet instance for synthesizer, escalate, and other heavy-reasoning nodes. */
-  agentModel: ChatAnthropic;
-  /** Haiku instance for classifier, qualityChecker, queryPlanner, retrievalExpander, and conversationMemory. */
-  classifierModel: ChatAnthropic;
+  /** Model instance for synthesizer, escalate, and other heavy-reasoning nodes. */
+  agentModel: BaseChatModel;
+  /** Model instance for classifier, qualityChecker, queryPlanner, retrievalExpander, and conversationMemory. */
+  classifierModel: BaseChatModel;
 }
 
 /**
- * Creates the shared ChatAnthropic instances used by all graph nodes.
+ * Creates a chat model instance based on the provider in the config.
+ *
+ * Supports "anthropic" (default), "openai", and "google" providers.
+ * Only this function (and this file) imports concrete provider classes.
+ */
+export function createChatModel(config: {
+  model: string;
+  temperature?: number;
+  maxTokens?: number;
+  provider?: string;
+}): BaseChatModel {
+  const opts: Record<string, unknown> = { model: config.model };
+  if (config.temperature !== undefined) opts.temperature = config.temperature;
+
+  switch (config.provider) {
+    case "openai":
+      if (config.maxTokens !== undefined) opts.maxTokens = config.maxTokens;
+      return new ChatOpenAI(opts);
+    case "google":
+      return new ChatGoogleGenerativeAI({
+        model: config.model,
+        ...(config.temperature !== undefined && {
+          temperature: config.temperature,
+        }),
+        ...(config.maxTokens !== undefined && {
+          maxOutputTokens: config.maxTokens,
+        }),
+      });
+    case "anthropic":
+    default:
+      if (config.maxTokens !== undefined) opts.maxTokens = config.maxTokens;
+      return new ChatAnthropic(opts);
+  }
+}
+
+/**
+ * Creates the shared model instances used by all graph nodes.
  *
  * Call once at startup (AgentRunner.create, studio.ts, eval setup) and pass
  * the returned models into `createAgentGraph`. The classifierModel can also
@@ -18,15 +57,7 @@ export interface AgentModels {
  */
 export async function createAgentModels(): Promise<AgentModels> {
   const config = await getModelConfig();
-  const agentModel = new ChatAnthropic({
-    model: config.agent.model,
-    temperature: config.agent.temperature,
-    maxTokens: config.agent.maxTokens,
-  });
-  const classifierModel = new ChatAnthropic({
-    model: config.classifier.model,
-    temperature: config.classifier.temperature,
-    maxTokens: config.classifier.maxTokens,
-  });
+  const agentModel = createChatModel(config.agent);
+  const classifierModel = createChatModel(config.classifier);
   return { agentModel, classifierModel };
 }

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -5,15 +5,18 @@ export const MODEL_CONFIG = {
     model: "claude-sonnet-4-20250514",
     temperature: 0.1,
     maxTokens: 4096,
+    provider: "anthropic" as const,
   },
   classifier: {
     model: "claude-haiku-4-5-20251001",
     temperature: 0,
     maxTokens: 1024,
+    provider: "anthropic" as const,
   },
   embeddings: {
     model: "text-embedding-3-small",
     dimensions: 1536,
+    provider: "openai" as const,
   },
 } as const;
 
@@ -56,17 +59,20 @@ export async function getModelConfig(): Promise<ModelConfig> {
         model: agent?.model ?? MODEL_CONFIG.agent.model,
         temperature: agent?.temperature ?? MODEL_CONFIG.agent.temperature,
         maxTokens: agent?.maxTokens ?? MODEL_CONFIG.agent.maxTokens,
+        provider: agent?.provider ?? MODEL_CONFIG.agent.provider,
       },
       classifier: {
         model: classifier?.model ?? MODEL_CONFIG.classifier.model,
         temperature:
           classifier?.temperature ?? MODEL_CONFIG.classifier.temperature,
         maxTokens: classifier?.maxTokens ?? MODEL_CONFIG.classifier.maxTokens,
+        provider: classifier?.provider ?? MODEL_CONFIG.classifier.provider,
       },
       embeddings: {
         model: embeddings?.model ?? MODEL_CONFIG.embeddings.model,
         dimensions:
           embeddings?.dimensions ?? MODEL_CONFIG.embeddings.dimensions,
+        provider: embeddings?.provider ?? MODEL_CONFIG.embeddings.provider,
       },
     } as unknown as ModelConfig;
 

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -1,12 +1,12 @@
 export {
-  invokeAnthropic,
-  invokeAnthropicWithFallback,
+  invokeLlm,
+  invokeLlmWithFallback,
   extractTextFromResponse,
   isTransientError,
   withSingleRetry,
-  getAnthropicCircuitMetrics,
-  resetAnthropicCircuit,
-} from "./anthropicService.js";
+  getLlmCircuitMetrics,
+  resetLlmCircuit,
+} from "./llmService.js";
 
 export {
   ProtectedOpenAIEmbeddings,

--- a/packages/evals/src/helpers/resolveEnv.ts
+++ b/packages/evals/src/helpers/resolveEnv.ts
@@ -49,6 +49,19 @@ export function resolveEnv(): void {
     }
   }
 
+  // GOOGLE_API_KEY — used by ChatGoogleGenerativeAI when provider is "google"
+  if (!process.env.GOOGLE_API_KEY) {
+    try {
+      process.env.GOOGLE_API_KEY = getOptionalSecretValue(
+        "GOOGLE_API_KEY",
+        "GoogleApiKey",
+        "",
+      );
+    } catch {
+      // Optional — not required unless Google provider is configured
+    }
+  }
+
   // TAVILY_API_KEY — optional, used by web search fallback
   if (!process.env.TAVILY_API_KEY) {
     try {

--- a/packages/shared/src/entities/AgentModelEntity.ts
+++ b/packages/shared/src/entities/AgentModelEntity.ts
@@ -10,6 +10,7 @@ export interface AgentModelConfig {
   model: string; // model name (e.g., "claude-sonnet-4-20250514")
   temperature?: number | undefined;
   maxTokens?: number | undefined;
+  provider?: string | undefined; // "anthropic" | "openai" | "google"
   dimensions?: number | undefined; // for embeddings only
   createdAt?: string | undefined;
   updatedAt?: string | undefined;
@@ -31,6 +32,7 @@ export class AgentModelEntity {
       model: item.model as string,
       temperature: item.temperature as number | undefined,
       maxTokens: item.maxTokens as number | undefined,
+      provider: item.provider as string | undefined,
       dimensions: item.dimensions as number | undefined,
       createdAt: item.createdAt as string | undefined,
       updatedAt: item.updatedAt as string | undefined,
@@ -53,6 +55,7 @@ export class AgentModelEntity {
     };
     if (config.temperature !== undefined) item.temperature = config.temperature;
     if (config.maxTokens !== undefined) item.maxTokens = config.maxTokens;
+    if (config.provider !== undefined) item.provider = config.provider;
     if (config.dimensions !== undefined) item.dimensions = config.dimensions;
     if (!config.createdAt) item.createdAt = now;
     else item.createdAt = config.createdAt;

--- a/packages/shared/src/entities/schema.ts
+++ b/packages/shared/src/entities/schema.ts
@@ -140,6 +140,7 @@ export const AppTableSchema = {
       model: { type: String, required: true },
       temperature: { type: Number },
       maxTokens: { type: Number },
+      provider: { type: String },
       dimensions: { type: Number },
       createdAt: { type: String },
       updatedAt: { type: String },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,6 +229,9 @@ importers:
       '@langchain/core':
         specifier: ^1.1.26
         version: 1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))
+      '@langchain/google-genai':
+        specifier: ^2.1.20
+        version: 2.1.20(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))
       '@langchain/langgraph':
         specifier: ^1.1.5
         version: 1.1.5(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.24.1(zod@3.25.76))(zod@3.25.76)
@@ -277,13 +280,13 @@ importers:
         version: link:../shared
       agentevals:
         specifier: ^0.0.6
-        version: 0.0.6(@langchain/anthropic@1.3.18(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(@langchain/langgraph@1.1.5(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.24.1(zod@3.25.76))(zod@3.25.76))(@opentelemetry/api@1.9.0)(axios@1.13.5)(cheerio@1.2.0)(handlebars@4.7.8)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))(typescript@5.9.3)(ws@8.19.0)(zod@3.25.76)
+        version: 0.0.6(@langchain/anthropic@1.3.18(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(@langchain/google-genai@2.1.20(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@langchain/langgraph@1.1.5(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.24.1(zod@3.25.76))(zod@3.25.76))(@opentelemetry/api@1.9.0)(axios@1.13.5)(cheerio@1.2.0)(handlebars@4.7.8)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))(typescript@5.9.3)(ws@8.19.0)(zod@3.25.76)
       langsmith:
         specifier: ^0.5.4
         version: 0.5.4(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))
       openevals:
         specifier: ^0.1.4
-        version: 0.1.4(@langchain/anthropic@1.3.18(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.5)(cheerio@1.2.0)(handlebars@4.7.8)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))(typescript@5.9.3)(ws@8.19.0)(zod@3.25.76)
+        version: 0.1.4(@langchain/anthropic@1.3.18(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(@langchain/google-genai@2.1.20(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@opentelemetry/api@1.9.0)(axios@1.13.5)(cheerio@1.2.0)(handlebars@4.7.8)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))(typescript@5.9.3)(ws@8.19.0)(zod@3.25.76)
     devDependencies:
       sst:
         specifier: 3.18.10
@@ -1136,6 +1139,10 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@google/generative-ai@0.24.1':
+    resolution: {integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==}
+    engines: {node: '>=18.0.0'}
+
   '@hapi/bourne@3.0.0':
     resolution: {integrity: sha512-Waj1cwPXJDucOib4a3bAISsKJVb15MKi9IvmTI/7ssVEm6sywXGjVJDhl6/umt1pK1ZS7PacXU3A1PmFKHEZ2w==}
 
@@ -1699,6 +1706,12 @@ packages:
   '@langchain/core@1.1.26':
     resolution: {integrity: sha512-Xnwi4xEKEtZcGwjW5xpZVP/Dc+WckFxULMShETuCpD6TxNFS6yRM+FhNUO1DDCkRkGn9b1fuzVZrNYb9W7F32A==}
     engines: {node: '>=20'}
+
+  '@langchain/google-genai@2.1.20':
+    resolution: {integrity: sha512-x4zS3iv6x27M38izV/einJM9qXAGvVAYt2fUW8hiQnh9AX0vYVJBkoqGpxsvHNejqGYlTXOollPUp3XuVjlHjQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@langchain/core': ^1.1.27
 
   '@langchain/langgraph-checkpoint@1.0.0':
     resolution: {integrity: sha512-xrclBGvNCXDmi0Nz28t3vjpxSH6UYx6w5XAXSiiB1WEdc2xD2iY/a913I3x3a31XpInUW/GGfXXfePfaghV54A==}
@@ -6006,6 +6019,8 @@ snapshots:
 
   '@exodus/bytes@1.14.1': {}
 
+  '@google/generative-ai@0.24.1': {}
+
   '@hapi/bourne@3.0.0': {}
 
   '@hono/node-server@1.19.9(hono@4.11.10)':
@@ -6225,6 +6240,12 @@ snapshots:
       - '@opentelemetry/exporter-trace-otlp-proto'
       - '@opentelemetry/sdk-trace-base'
       - openai
+
+  '@langchain/google-genai@2.1.20(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))':
+    dependencies:
+      '@google/generative-ai': 0.24.1
+      '@langchain/core': 1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))
+      uuid: 11.1.0
 
   '@langchain/langgraph-checkpoint@1.0.0(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))':
     dependencies:
@@ -7236,6 +7257,14 @@ snapshots:
     optionalDependencies:
       vite: 5.4.21(@types/node@22.19.7)(lightningcss@1.31.1)
 
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@25.2.3)(lightningcss@1.31.1))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@25.2.3)(lightningcss@1.31.1)
+
   '@vitest/pretty-format@2.1.9':
     dependencies:
       tinyrainbow: 1.2.0
@@ -7272,14 +7301,14 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  agentevals@0.0.6(@langchain/anthropic@1.3.18(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(@langchain/langgraph@1.1.5(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.24.1(zod@3.25.76))(zod@3.25.76))(@opentelemetry/api@1.9.0)(axios@1.13.5)(cheerio@1.2.0)(handlebars@4.7.8)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))(typescript@5.9.3)(ws@8.19.0)(zod@3.25.76):
+  agentevals@0.0.6(@langchain/anthropic@1.3.18(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(@langchain/google-genai@2.1.20(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@langchain/langgraph@1.1.5(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.24.1(zod@3.25.76))(zod@3.25.76))(@opentelemetry/api@1.9.0)(axios@1.13.5)(cheerio@1.2.0)(handlebars@4.7.8)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))(typescript@5.9.3)(ws@8.19.0)(zod@3.25.76):
     dependencies:
       '@langchain/core': 1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))
       '@langchain/langgraph': 1.1.5(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod-to-json-schema@3.24.1(zod@3.25.76))(zod@3.25.76)
       '@langchain/openai': 1.2.8(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(ws@8.19.0)
-      langchain: 0.3.37(@langchain/anthropic@1.3.18(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.5)(cheerio@1.2.0)(handlebars@4.7.8)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      langchain: 0.3.37(@langchain/anthropic@1.3.18(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(@langchain/google-genai@2.1.20(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@opentelemetry/api@1.9.0)(axios@1.13.5)(cheerio@1.2.0)(handlebars@4.7.8)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       langsmith: 0.5.4(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))
-      openevals: 0.1.4(@langchain/anthropic@1.3.18(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.5)(cheerio@1.2.0)(handlebars@4.7.8)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))(typescript@5.9.3)(ws@8.19.0)(zod@3.25.76)
+      openevals: 0.1.4(@langchain/anthropic@1.3.18(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(@langchain/google-genai@2.1.20(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@opentelemetry/api@1.9.0)(axios@1.13.5)(cheerio@1.2.0)(handlebars@4.7.8)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))(typescript@5.9.3)(ws@8.19.0)(zod@3.25.76)
     transitivePeerDependencies:
       - '@langchain/anthropic'
       - '@langchain/aws'
@@ -8263,7 +8292,7 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
-  langchain@0.3.37(@langchain/anthropic@1.3.18(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.5)(cheerio@1.2.0)(handlebars@4.7.8)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0):
+  langchain@0.3.37(@langchain/anthropic@1.3.18(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(@langchain/google-genai@2.1.20(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@opentelemetry/api@1.9.0)(axios@1.13.5)(cheerio@1.2.0)(handlebars@4.7.8)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0):
     dependencies:
       '@langchain/core': 1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))
       '@langchain/openai': 1.2.8(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(ws@8.19.0)
@@ -8279,6 +8308,7 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@langchain/anthropic': 1.3.18(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))
+      '@langchain/google-genai': 2.1.20(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))
       axios: 1.13.5(debug@4.4.3)
       cheerio: 1.2.0
       handlebars: 4.7.8
@@ -8882,11 +8912,11 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  openevals@0.1.4(@langchain/anthropic@1.3.18(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.5)(cheerio@1.2.0)(handlebars@4.7.8)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))(typescript@5.9.3)(ws@8.19.0)(zod@3.25.76):
+  openevals@0.1.4(@langchain/anthropic@1.3.18(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(@langchain/google-genai@2.1.20(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@opentelemetry/api@1.9.0)(axios@1.13.5)(cheerio@1.2.0)(handlebars@4.7.8)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))(typescript@5.9.3)(ws@8.19.0)(zod@3.25.76):
     dependencies:
       '@langchain/core': 1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))
       '@langchain/openai': 1.2.8(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(ws@8.19.0)
-      langchain: 0.3.37(@langchain/anthropic@1.3.18(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(@opentelemetry/api@1.9.0)(axios@1.13.5)(cheerio@1.2.0)(handlebars@4.7.8)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
+      langchain: 0.3.37(@langchain/anthropic@1.3.18(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76)))(@langchain/google-genai@2.1.20(@langchain/core@1.1.26(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))))(@opentelemetry/api@1.9.0)(axios@1.13.5)(cheerio@1.2.0)(handlebars@4.7.8)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))(ws@8.19.0)
       langsmith: 0.5.4(@opentelemetry/api@1.9.0)(openai@6.21.0(ws@8.19.0)(zod@3.25.76))
       uuid: 11.1.0
       zod: 3.25.76
@@ -9807,7 +9837,7 @@ snapshots:
   vitest@2.1.9(@types/node@25.2.3)(jsdom@28.1.0)(lightningcss@1.31.1):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.7)(lightningcss@1.31.1))
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@25.2.3)(lightningcss@1.31.1))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -18,6 +18,7 @@ export default $config({
     // Secrets
     const anthropicKey = new sst.Secret("AnthropicApiKey");
     const openaiKey = new sst.Secret("OpenaiApiKey");
+    const googleKey = new sst.Secret("GoogleApiKey");
     const tavilyKey = new sst.Secret("TavilyApiKey");
     const langchainKey = new sst.Secret("LangchainApiKey");
     const slackBotToken = new sst.Secret("SlackBotToken");
@@ -47,6 +48,7 @@ export default $config({
     const linkables: sst.Linkable<any>[] = [
       anthropicKey,
       openaiKey,
+      googleKey,
       tavilyKey,
       langchainKey,
       databaseUrlSecret,


### PR DESCRIPTION
## Summary

Closes #354.

Decouples the agent graph from `ChatAnthropic` by replacing all ~30 file references with LangChain's provider-agnostic `BaseChatModel`. Adds a `provider` field to the DynamoDB model config entity and centralizes provider dispatch (Anthropic, OpenAI, Google Gemini) in the model factory. After this refactor, switching LLM providers is a DynamoDB config update — no code deploy needed.

**Key insight**: Every node only calls `model.invoke(messages)` through the circuit breaker service. No Anthropic-specific APIs are used. This is a mechanical refactor with zero behavioral change for the default Anthropic path.

### Changes

- **Rename `anthropicService` → `llmService`**: Generalize all function names (`invokeAnthropic` → `invokeLlm`, etc.) and circuit breaker name (`"anthropic"` → `"llm"`)
- **Add `provider` field**: New field on `AgentModel` entity schema and `AgentModelConfig` interface, with defaults in `MODEL_CONFIG`
- **Provider dispatch in `createChatModel()`**: Switch on `config.provider` to instantiate `ChatAnthropic`, `ChatOpenAI`, or `ChatGoogleGenerativeAI`. Only `modelFactory.ts` retains concrete provider imports
- **Add `@langchain/google-genai` dependency** and `GoogleApiKey` SST secret
- **Update all 7 node files**: `BaseChatModel` type + `invokeLlm` import (classifier, synthesizer, escalate, qualityChecker, queryPlanner, researcher, retrievalExpander)
- **Update graph, runner, conversationMemory**: `BaseChatModel` types throughout
- **Update health router**: `getLlmCircuitMetrics` + response key `circuits.llm`
- **Update all test files**: Remove Anthropic constructor mocks, use provider-agnostic mock patterns

### Out of scope

- `packages/ingestion/src/services/evaluationService.ts` — creates its own `ChatAnthropic` for document evaluation, separate from the agent graph. Will track as a follow-up issue.

## Test plan

- [x] `pnpm typecheck` — full monorepo passes (all 7 packages)
- [x] `pnpm test` — all packages pass (shared: 289, core: 696, api: 39, web: 319, ingestion: 258)
- [x] Default Anthropic path: no behavioral change (same models, same config)
- [ ] Post-merge: set `provider: "openai"` + `model: "gpt-4.1"` in DynamoDB, verify chat works end-to-end
- [ ] Post-merge: set `provider: "google"` + `model: "gemini-2.5-pro"` in DynamoDB, verify chat works

🤖 Generated with [Claude Code](https://claude.com/claude-code)