### PR TITLE
perf(slack): make message and mention handlers non-blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 94.0 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 94.2 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 > **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 90.1 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
@@ -145,10 +145,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 94.0 hours
+**Tracked build time:** 94.2 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-24T18:50:47.374Z
+- Last updated: 2026-02-24T19:32:02.027Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/slack/src/handlers/mention.test.ts
+++ b/apps/slack/src/handlers/mention.test.ts
@@ -94,41 +94,54 @@ describe("handleMention", () => {
     mockGetAppRunner.mockResolvedValue(fakeRunner);
   });
 
-  it("invokes the agent and posts the answer", async () => {
+  it("acknowledges immediately and invokes the agent asynchronously", async () => {
     await handleMention(makeEvent());
 
+    // Reaction is added synchronously before returning
     expect(mockAddReaction).toHaveBeenCalledWith(
       "C123",
       "1234567890.123456",
       "eyes",
     );
-    expect(fakeRunner.invoke).toHaveBeenCalledWith(
-      expect.objectContaining({
-        conversationId: "1234567890.123456",
-      }),
-    );
-    expect(mockPostMessage).toHaveBeenCalledWith(
-      "C123",
-      "Appeals must be filed within 30 days.",
-      expect.any(Array),
-      "1234567890.123456",
-    );
+
+    // Agent invocation and response happen asynchronously
+    await vi.waitFor(() => {
+      expect(fakeRunner.invoke).toHaveBeenCalledWith(
+        expect.objectContaining({
+          conversationId: "1234567890.123456",
+        }),
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        "C123",
+        "Appeals must be filed within 30 days.",
+        expect.any(Array),
+        "1234567890.123456",
+      );
+    });
   });
 
   it("uses thread_ts as conversationId when in a thread", async () => {
     await handleMention(makeEvent({ thread_ts: "1111111111.000000" }));
 
-    expect(fakeRunner.invoke).toHaveBeenCalledWith(
-      expect.objectContaining({
-        conversationId: "1111111111.000000",
-      }),
-    );
-    expect(mockPostMessage).toHaveBeenCalledWith(
-      "C123",
-      expect.any(String),
-      expect.any(Array),
-      "1111111111.000000",
-    );
+    await vi.waitFor(() => {
+      expect(fakeRunner.invoke).toHaveBeenCalledWith(
+        expect.objectContaining({
+          conversationId: "1111111111.000000",
+        }),
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        "C123",
+        expect.any(String),
+        expect.any(Array),
+        "1111111111.000000",
+      );
+    });
   });
 
   it("asks for a question when text is empty after stripping mention", async () => {
@@ -148,12 +161,14 @@ describe("handleMention", () => {
 
     await handleMention(makeEvent());
 
-    expect(mockPostMessage).toHaveBeenCalledWith(
-      "C123",
-      "Error processing request",
-      expect.any(Array),
-      "1234567890.123456",
-    );
+    await vi.waitFor(() => {
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        "C123",
+        "Error processing request",
+        expect.any(Array),
+        "1234567890.123456",
+      );
+    });
   });
 
   it("loads conversation summary for the thread", async () => {
@@ -161,11 +176,16 @@ describe("handleMention", () => {
 
     await handleMention(makeEvent());
 
-    expect(mockLoadSummary).toHaveBeenCalledWith("1234567890.123456");
-    expect(fakeRunner.invoke).toHaveBeenCalledWith(
-      expect.objectContaining({
-        conversationSummary: "Previous context about appeals.",
-      }),
-    );
+    await vi.waitFor(() => {
+      expect(mockLoadSummary).toHaveBeenCalledWith("1234567890.123456");
+    });
+
+    await vi.waitFor(() => {
+      expect(fakeRunner.invoke).toHaveBeenCalledWith(
+        expect.objectContaining({
+          conversationSummary: "Previous context about appeals.",
+        }),
+      );
+    });
   });
 });

--- a/apps/slack/src/handlers/message.ts
+++ b/apps/slack/src/handlers/message.ts
@@ -50,6 +50,20 @@ export async function handleMessage(event: SlackMessageEvent): Promise<void> {
   // Add a reaction to acknowledge receipt
   await addReaction(channel, ts, "eyes");
 
+  // Process asynchronously — return immediately so Slack gets a fast 200
+  processMessageAsync(event).catch((error) => {
+    logger.error("Async message processing failed", {
+      error: error instanceof Error ? error.message : String(error),
+      user,
+      channel,
+    });
+  });
+}
+
+async function processMessageAsync(event: SlackMessageEvent): Promise<void> {
+  const { channel, text, ts, user, thread_ts } = event;
+  const replyTs = thread_ts ?? ts;
+
   try {
     const runner = await getAppRunner();
     const conversationId = thread_ts ?? ts;
@@ -64,7 +78,7 @@ export async function handleMessage(event: SlackMessageEvent): Promise<void> {
 
     const disclaimer = getDisclaimer();
     const blocks = buildAnswerBlocks(answer, citations, disclaimer, escalation);
-    await postMessage(channel, answer, blocks, thread_ts ?? ts);
+    await postMessage(channel, answer, blocks, replyTs);
   } catch (error) {
     logger.error("Failed to handle message", {
       error: error instanceof Error ? error.message : String(error),
@@ -75,11 +89,6 @@ export async function handleMessage(event: SlackMessageEvent): Promise<void> {
     const blocks = buildErrorBlocks(
       "Sorry, I encountered an error processing your question. Please try again.",
     );
-    await postMessage(
-      channel,
-      "Error processing request",
-      blocks,
-      thread_ts ?? ts,
-    );
+    await postMessage(channel, "Error processing request", blocks, replyTs);
   }
 }


### PR DESCRIPTION
## Summary

Closes #255 — Decouples Slack acknowledgment from LLM processing so handlers return immediately, preventing Slack's 3-second timeout from triggering retries.

- **`message.ts`**: Extract LLM invocation into `processMessageAsync()`, fire-and-forget with `.catch()` error logging
- **`mention.ts`**: Same pattern — extract into `processMentionAsync()` with fire-and-forget
- Mirrors the existing async pattern already used in `slashCommand.ts`
- Validation, invite checks, and `addReaction("eyes")` remain synchronous (fast operations)

## Test plan

- [x] Updated `message.test.ts` — uses `vi.waitFor()` for async assertions (6 tests)
- [x] Updated `mention.test.ts` — uses `vi.waitFor()` for async assertions (5 tests)
- [x] All 40 Slack tests passing
- [x] Full monorepo typecheck passing
- [x] Prettier formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)