### PR TITLE
fix(slack): remove duplicate disclaimer from bot responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 94.2 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 94.8 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 > **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 90.1 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
@@ -145,10 +145,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 94.2 hours
+**Tracked build time:** 94.8 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-24T19:32:02.027Z
+- Last updated: 2026-02-24T21:24:03.557Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/slack/src/handlers/mention.test.ts
+++ b/apps/slack/src/handlers/mention.test.ts
@@ -35,7 +35,6 @@ vi.mock("@usopc/core", () => ({
     .mockImplementation((msgs: { role: string; content: string }[]) =>
       msgs.map((m) => ({ content: m.content })),
     ),
-  getDisclaimer: vi.fn().mockReturnValue("This is not legal advice."),
 }));
 
 vi.mock("../slack/client.js", () => ({

--- a/apps/slack/src/handlers/mention.ts
+++ b/apps/slack/src/handlers/mention.ts
@@ -1,10 +1,5 @@
 import { createLogger } from "@usopc/shared";
-import {
-  getAppRunner,
-  loadSummary,
-  convertMessages,
-  getDisclaimer,
-} from "@usopc/core";
+import { getAppRunner, loadSummary, convertMessages } from "@usopc/core";
 import { postMessage, addReaction } from "../slack/client.js";
 import { buildAnswerBlocks, buildErrorBlocks } from "../slack/blocks.js";
 import { isUserInvited } from "../lib/inviteGuard.js";
@@ -85,8 +80,7 @@ async function processMentionAsync(
       conversationSummary,
     });
 
-    const disclaimer = getDisclaimer();
-    const blocks = buildAnswerBlocks(answer, citations, disclaimer, escalation);
+    const blocks = buildAnswerBlocks(answer, citations, undefined, escalation);
     await postMessage(channel, answer, blocks, replyTs);
   } catch (error) {
     logger.error("Failed to handle mention", {

--- a/apps/slack/src/handlers/message.test.ts
+++ b/apps/slack/src/handlers/message.test.ts
@@ -35,7 +35,6 @@ vi.mock("@usopc/core", () => ({
     .mockImplementation((msgs: { role: string; content: string }[]) =>
       msgs.map((m) => ({ content: m.content })),
     ),
-  getDisclaimer: vi.fn().mockReturnValue("This is not legal advice."),
 }));
 
 vi.mock("../slack/client.js", () => ({

--- a/apps/slack/src/handlers/message.ts
+++ b/apps/slack/src/handlers/message.ts
@@ -1,10 +1,5 @@
 import { createLogger } from "@usopc/shared";
-import {
-  getAppRunner,
-  loadSummary,
-  convertMessages,
-  getDisclaimer,
-} from "@usopc/core";
+import { getAppRunner, loadSummary, convertMessages } from "@usopc/core";
 import { postMessage, addReaction } from "../slack/client.js";
 import { buildAnswerBlocks, buildErrorBlocks } from "../slack/blocks.js";
 import { isUserInvited } from "../lib/inviteGuard.js";
@@ -76,8 +71,7 @@ async function processMessageAsync(event: SlackMessageEvent): Promise<void> {
       conversationSummary,
     });
 
-    const disclaimer = getDisclaimer();
-    const blocks = buildAnswerBlocks(answer, citations, disclaimer, escalation);
+    const blocks = buildAnswerBlocks(answer, citations, undefined, escalation);
     await postMessage(channel, answer, blocks, replyTs);
   } catch (error) {
     logger.error("Failed to handle message", {

--- a/apps/slack/src/handlers/slashCommand.test.ts
+++ b/apps/slack/src/handlers/slashCommand.test.ts
@@ -32,7 +32,6 @@ vi.mock("@usopc/core", () => ({
     .mockImplementation((msgs: { role: string; content: string }[]) =>
       msgs.map((m) => ({ content: m.content })),
     ),
-  getDisclaimer: vi.fn().mockReturnValue("This is not legal advice."),
 }));
 
 vi.mock("../slack/client.js", () => ({

--- a/apps/slack/src/handlers/slashCommand.ts
+++ b/apps/slack/src/handlers/slashCommand.ts
@@ -1,5 +1,5 @@
 import { createLogger } from "@usopc/shared";
-import { getAppRunner, convertMessages, getDisclaimer } from "@usopc/core";
+import { getAppRunner, convertMessages } from "@usopc/core";
 import { postMessage } from "../slack/client.js";
 import { buildAnswerBlocks, buildErrorBlocks } from "../slack/blocks.js";
 
@@ -67,11 +67,10 @@ async function processSlashCommandAsync(
 
     const preamble = `<@${userId}> asked: _${query}_\n\n`;
     const fullAnswer = preamble + answer;
-    const disclaimer = getDisclaimer();
     const blocks = buildAnswerBlocks(
       fullAnswer,
       citations,
-      disclaimer,
+      undefined,
       escalation,
     );
     await postMessage(channel, fullAnswer, blocks);

--- a/apps/slack/src/slack/blocks.test.ts
+++ b/apps/slack/src/slack/blocks.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildAnswerBlocks,
+  buildErrorBlocks,
+  buildThinkingBlock,
+} from "./blocks.js";
+
+describe("buildAnswerBlocks", () => {
+  it("includes disclaimer context block when disclaimer is provided", () => {
+    const blocks = buildAnswerBlocks(
+      "Test answer",
+      [],
+      "This is not legal advice.",
+    );
+
+    const contextBlocks = blocks.filter(
+      (b) =>
+        b.type === "context" &&
+        Array.isArray(b.elements) &&
+        (b.elements as { text?: string }[]).some((e) => e.text?.includes("⚠️")),
+    );
+    expect(contextBlocks).toHaveLength(1);
+  });
+
+  it("omits disclaimer context block when disclaimer is undefined", () => {
+    const blocks = buildAnswerBlocks("Test answer", []);
+
+    const contextBlocks = blocks.filter(
+      (b) =>
+        b.type === "context" &&
+        Array.isArray(b.elements) &&
+        (b.elements as { text?: string }[]).some((e) => e.text?.includes("⚠️")),
+    );
+    expect(contextBlocks).toHaveLength(0);
+  });
+
+  it("always includes feedback action buttons", () => {
+    const blocks = buildAnswerBlocks("Test answer", []);
+
+    const actionBlocks = blocks.filter((b) => b.type === "actions");
+    expect(actionBlocks).toHaveLength(1);
+  });
+
+  it("generates unique feedback block_id across invocations", () => {
+    const blocks1 = buildAnswerBlocks("Answer 1", []);
+    const blocks2 = buildAnswerBlocks("Answer 2", []);
+
+    const id1 = blocks1.find((b) => b.type === "actions")!.block_id;
+    const id2 = blocks2.find((b) => b.type === "actions")!.block_id;
+
+    expect(id1).toBeDefined();
+    expect(id2).toBeDefined();
+    expect(id1).not.toBe(id2);
+  });
+
+  it("renders citations when provided", () => {
+    const blocks = buildAnswerBlocks("Answer", [
+      { title: "Bylaws", documentType: "policy", snippet: "..." },
+    ]);
+
+    const sourceHeader = blocks.find(
+      (b) => b.type === "section" && b.text?.text === "*Sources:*",
+    );
+    expect(sourceHeader).toBeDefined();
+  });
+
+  it("renders escalation block when provided", () => {
+    const blocks = buildAnswerBlocks("Answer", [], undefined, {
+      target: "SafeSport",
+      organization: "SafeSport",
+      reason: "Contact SafeSport for abuse concerns.",
+      urgency: "immediate",
+      contactEmail: "help@safesport.org",
+    });
+
+    const escalationBlock = blocks.find(
+      (b) => b.type === "section" && b.text?.text?.includes("SafeSport"),
+    );
+    expect(escalationBlock).toBeDefined();
+  });
+});
+
+describe("buildErrorBlocks", () => {
+  it("renders error message and support context", () => {
+    const blocks = buildErrorBlocks("Something went wrong");
+
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]!.text?.text).toContain("Something went wrong");
+    expect(blocks[1]!.type).toBe("context");
+  });
+});
+
+describe("buildThinkingBlock", () => {
+  it("renders thinking indicator", () => {
+    const block = buildThinkingBlock();
+
+    expect(block.type).toBe("section");
+    expect(block.text?.text).toContain("Looking into that");
+  });
+});

--- a/apps/slack/src/slack/blocks.ts
+++ b/apps/slack/src/slack/blocks.ts
@@ -11,7 +11,7 @@ interface KnownBlock {
 export function buildAnswerBlocks(
   answer: string,
   citations: Citation[],
-  disclaimer: string,
+  disclaimer?: string,
   escalation?: EscalationInfo,
 ): KnownBlock[] {
   const blocks: KnownBlock[] = [];
@@ -40,12 +40,14 @@ export function buildAnswerBlocks(
     }
   }
 
-  // Disclaimer
-  blocks.push({ type: "divider" });
-  blocks.push({
-    type: "context",
-    elements: [{ type: "mrkdwn", text: `⚠️ ${disclaimer}` }],
-  });
+  // Disclaimer (only when explicitly provided — disclaimerGuard embeds it in the answer)
+  if (disclaimer) {
+    blocks.push({ type: "divider" });
+    blocks.push({
+      type: "context",
+      elements: [{ type: "mrkdwn", text: `⚠️ ${disclaimer}` }],
+    });
+  }
 
   // Feedback buttons
   blocks.push(buildFeedbackBlock());
@@ -101,7 +103,7 @@ function buildCitationBlock(citation: Citation): KnownBlock {
 function buildFeedbackBlock(): KnownBlock {
   return {
     type: "actions",
-    block_id: "feedback_actions",
+    block_id: `feedback_actions_${Math.random().toString(36).slice(2, 8)}`,
     elements: [
       {
         type: "button",


### PR DESCRIPTION
## Summary

- **Remove duplicate disclaimer** from Slack bot responses. The `disclaimerGuardNode` already embeds the domain-specific disclaimer in `state.answer`, but Slack handlers were calling `getDisclaimer()` separately and passing it to `buildAnswerBlocks()`, which rendered a second (general) disclaimer as a context block.
- **Make `disclaimer` parameter optional** in `buildAnswerBlocks()` — only renders the disclaimer divider + context block when explicitly provided.
- **Make feedback `block_id` unique** per invocation (random suffix) to avoid Slack block ID conflicts when multiple responses exist in a thread.

### Files changed

**Implementation:**
- `apps/slack/src/slack/blocks.ts` — Optional disclaimer param, conditional rendering, unique block_id
- `apps/slack/src/handlers/message.ts` — Remove `getDisclaimer` import/call
- `apps/slack/src/handlers/mention.ts` — Same
- `apps/slack/src/handlers/slashCommand.ts` — Same

**Tests:**
- `apps/slack/src/slack/blocks.test.ts` (new) — 8 tests for blocks utility functions
- `apps/slack/src/handlers/message.test.ts` — Remove `getDisclaimer` from mock
- `apps/slack/src/handlers/mention.test.ts` — Same
- `apps/slack/src/handlers/slashCommand.test.ts` — Same

## Test plan

- [x] `pnpm --filter @usopc/slack test` — 48 tests pass
- [x] `pnpm typecheck` — no new errors (pre-existing `@langchain/google-genai` issue only)
- [x] `npx prettier --write` — all files formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)