### PR TITLE
infra: move domains to athlete-agent.rosinbum.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 95.4 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 96.1 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 > **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 90.1 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
@@ -145,10 +145,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 95.4 hours
+**Tracked build time:** 96.1 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-24T22:04:25.779Z
+- Last updated: 2026-02-25T00:16:23.154Z
 <!-- HOURS:END -->
 
 ## License

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -80,7 +80,7 @@ export default $config({
     // Custom domains — only for deployed stages (staging, production).
     // Local dev stages use raw AWS URLs (no domain config needed).
     const isDeployed = isProd || stage === "staging";
-    const domainZone = "rosinbum.org";
+    const domainZone = "athlete-agent.rosinbum.org";
 
     // Slack bot webhook — $default catches /slack/events, /slack/commands,
     // and /slack/interactions so all Slack endpoints route to one Lambda.
@@ -204,7 +204,7 @@ export default $config({
       path: "apps/web",
       domain: isDeployed
         ? {
-            name: isProd ? `app.${domainZone}` : `${stage}.${domainZone}`,
+            name: isProd ? domainZone : `${stage}.${domainZone}`,
             dns: sst.aws.dns(),
           }
         : undefined,


### PR DESCRIPTION
## Summary

- Move production web app domain from `app.rosinbum.org` to `athlete-agent.rosinbum.org`
- Slack API moves from `slack.rosinbum.org` to `slack.athlete-agent.rosinbum.org`
- Staging follows the same pattern (`staging.athlete-agent.rosinbum.org`, `slack-staging.athlete-agent.rosinbum.org`)

## Domain mapping

| Service | Production | Staging |
|---------|-----------|---------|
| Web | `athlete-agent.rosinbum.org` | `staging.athlete-agent.rosinbum.org` |
| Slack | `slack.athlete-agent.rosinbum.org` | `slack-staging.athlete-agent.rosinbum.org` |

## Test plan

- [ ] Verify Route 53 hosted zone exists or can resolve `athlete-agent.rosinbum.org`
- [ ] Deploy to staging and confirm DNS resolves
- [ ] Deploy to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)