### PR TITLE
fix: rename middleware.ts to proxy.ts for Next.js 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 97.3 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 97.7 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -150,10 +150,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 97.3 hours
+**Tracked build time:** 97.7 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-25T01:31:50.217Z
+- Last updated: 2026-02-25T01:54:02.545Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/web/proxy.test.ts
+++ b/apps/web/proxy.test.ts
@@ -5,11 +5,11 @@ vi.mock("./auth.js", () => ({
   auth: vi.fn((handler: unknown) => handler),
 }));
 
-import middleware, { config } from "./middleware.js";
+import { proxy, config } from "./proxy.js";
 
-describe("middleware", () => {
-  it("exports a middleware function", () => {
-    expect(typeof middleware).toBe("function");
+describe("proxy", () => {
+  it("exports a proxy function", () => {
+    expect(typeof proxy).toBe("function");
   });
 
   it("matches admin pages", () => {

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -1,7 +1,7 @@
 import { auth } from "./auth.js";
 import { NextResponse } from "next/server";
 
-export default auth((req) => {
+export const proxy = auth((req) => {
   const { pathname } = req.nextUrl;
   const session = req.auth;
 


### PR DESCRIPTION
## Summary

- Rename `apps/web/middleware.ts` → `apps/web/proxy.ts` to fix the Next.js 16 deprecation warning
- Change `export default auth(...)` → `export const proxy = auth(...)` (named export required by new convention)
- Rename and update test file accordingly

The `config.matcher` and `NextResponse` API are unchanged — purely a file/export rename.

Ref: https://nextjs.org/docs/messages/middleware-to-proxy

## Test plan

- [x] `pnpm --filter @usopc/web test proxy` — all 5 tests pass
- [ ] Verify deprecation warning is gone when running `pnpm dev`

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)