### PR TITLE
fix: hide feedback buttons while message is streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 98.6 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 98.7 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -150,10 +150,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 98.6 hours
+**Tracked build time:** 98.7 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-25T03:03:35.047Z
+- Last updated: 2026-02-25T03:10:48.346Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/web/components/chat/ChatWindow.tsx
+++ b/apps/web/components/chat/ChatWindow.tsx
@@ -44,11 +44,12 @@ export function ChatWindow({
             </p>
           </div>
         )}
-        {messages.map((message) => (
+        {messages.map((message, index) => (
           <MessageBubble
             key={message.id}
             message={message}
             conversationId={conversationId}
+            isStreaming={isLoading && index === messages.length - 1}
           />
         ))}
         {isLoading && (

--- a/apps/web/components/chat/MessageBubble.test.tsx
+++ b/apps/web/components/chat/MessageBubble.test.tsx
@@ -64,6 +64,32 @@ describe("MessageBubble", () => {
     expect(screen.getByText("USOPC Bylaws")).toBeInTheDocument();
   });
 
+  it("hides feedback buttons while streaming", () => {
+    const message = makeMessage({ role: "assistant", content: "Partial..." });
+    render(
+      <MessageBubble
+        message={message}
+        conversationId="conv-1"
+        isStreaming={true}
+      />,
+    );
+    expect(screen.queryByLabelText("Helpful")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Not helpful")).not.toBeInTheDocument();
+  });
+
+  it("shows feedback buttons after streaming completes", () => {
+    const message = makeMessage({ role: "assistant", content: "Done." });
+    render(
+      <MessageBubble
+        message={message}
+        conversationId="conv-1"
+        isStreaming={false}
+      />,
+    );
+    expect(screen.getByLabelText("Helpful")).toBeInTheDocument();
+    expect(screen.getByLabelText("Not helpful")).toBeInTheDocument();
+  });
+
   it("ignores non-citation annotations", () => {
     const message = makeMessage({
       role: "assistant",

--- a/apps/web/components/chat/MessageBubble.tsx
+++ b/apps/web/components/chat/MessageBubble.tsx
@@ -7,6 +7,7 @@ import { isCitationAnnotation, type Citation } from "../../types/citation.js";
 interface MessageBubbleProps {
   message: Message;
   conversationId?: string | undefined;
+  isStreaming?: boolean;
 }
 
 function extractCitations(annotations: Message["annotations"]): Citation[] {
@@ -20,7 +21,11 @@ function extractCitations(annotations: Message["annotations"]): Citation[] {
   return results;
 }
 
-export function MessageBubble({ message, conversationId }: MessageBubbleProps) {
+export function MessageBubble({
+  message,
+  conversationId,
+  isStreaming,
+}: MessageBubbleProps) {
   const isUser = message.role === "user";
   const citations = isUser ? [] : extractCitations(message.annotations);
 
@@ -41,7 +46,7 @@ export function MessageBubble({ message, conversationId }: MessageBubbleProps) {
           <>
             <MarkdownMessage content={message.content} />
             <CitationList citations={citations} />
-            {conversationId && (
+            {conversationId && !isStreaming && (
               <FeedbackButtons
                 conversationId={conversationId}
                 messageId={message.id}


### PR DESCRIPTION
## Summary

- Pass `isStreaming` prop from `ChatWindow` to `MessageBubble` (true for the last message when `isLoading`)
- Gate `FeedbackButtons` rendering on `!isStreaming` so thumbs up/down only appear after the response is complete
- Add 2 tests covering both streaming and completed states

## Test plan

- [x] 338 web tests pass
- [ ] Manually verify: feedback buttons appear only after message finishes streaming

Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)