### PR TITLE
feat: add Invites link to admin nav and auto-populate invitedBy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 98.7 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 99.2 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -150,10 +150,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 98.7 hours
+**Tracked build time:** 99.2 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-25T03:10:48.346Z
+- Last updated: 2026-02-25T03:37:42.541Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/web/app/api/admin/invites/route.ts
+++ b/apps/web/app/api/admin/invites/route.ts
@@ -34,8 +34,9 @@ export async function GET(_req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const denied = await requireAdmin();
-  if (denied) return denied;
+  const result = await requireAdmin({ returnSession: true });
+  if (result.denied) return result.denied;
+  const { session } = result;
 
   let body: unknown;
   try {
@@ -52,7 +53,8 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const { email, invitedBy } = parsed.data;
+  const { email } = parsed.data;
+  const invitedBy = session.user?.name ?? session.user?.email ?? undefined;
 
   try {
     const inviteEntity = createInviteEntity();

--- a/apps/web/components/admin/AdminNav.tsx
+++ b/apps/web/components/admin/AdminNav.tsx
@@ -23,6 +23,12 @@ export default function AdminNav({ session }: { session: Session }) {
           Discoveries
         </a>
         <a
+          href="/admin/invites"
+          className="text-sm text-gray-500 hover:text-gray-700 transition-colors"
+        >
+          Invites
+        </a>
+        <a
           href="/"
           className="text-sm text-gray-500 hover:text-gray-700 transition-colors"
         >

--- a/apps/web/lib/admin-api.ts
+++ b/apps/web/lib/admin-api.ts
@@ -1,3 +1,4 @@
+import type { Session } from "next-auth";
 import { auth } from "../auth.js";
 import { apiError } from "./apiResponse.js";
 
@@ -5,15 +6,34 @@ import { apiError } from "./apiResponse.js";
  * Guard that checks admin authentication for API routes.
  * Returns null if authenticated and authorized, or a 401/403 NextResponse if not.
  */
-export async function requireAdmin() {
+export async function requireAdmin(): Promise<
+  ReturnType<typeof apiError> | null
+>;
+/**
+ * Guard that checks admin authentication and returns the session.
+ * Returns { session } if authorized, or { denied } with a 401/403 NextResponse.
+ */
+export async function requireAdmin(options: {
+  returnSession: true;
+}): Promise<
+  | { session: Session; denied?: never }
+  | { denied: ReturnType<typeof apiError>; session?: never }
+>;
+export async function requireAdmin(
+  options?: { returnSession: boolean } | undefined,
+) {
   const session = await auth();
   if (!session?.user?.email) {
-    return apiError("Unauthorized", 401);
+    return options?.returnSession
+      ? { denied: apiError("Unauthorized", 401) }
+      : apiError("Unauthorized", 401);
   }
 
   if (session.user.role !== "admin") {
-    return apiError("Forbidden", 403);
+    return options?.returnSession
+      ? { denied: apiError("Forbidden", 403) }
+      : apiError("Forbidden", 403);
   }
 
-  return null;
+  return options?.returnSession ? { session } : null;
 }


### PR DESCRIPTION
## Summary
Closes #398

- Add "Invites" link to admin header nav between Discoveries and Back to Site
- Add `returnSession` overload to `requireAdmin()` so routes can access the admin session
- Auto-populate `invitedBy` from `session.user.name` (falls back to email) when creating invites

## Test plan
- [ ] Admin nav shows Sources | Discoveries | Invites | Back to Site
- [ ] Creating an invite populates the "Invited By" column with the admin's name
- [ ] Existing `requireAdmin()` callers (no args) continue working — `pnpm typecheck` passes
- [ ] `admin-api.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)