### PR TITLE
fix(docs): correct critical documentation inaccuracies [DOC-01, DOC-02, DOC-03]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 99.2 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 99.6 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -150,10 +150,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 99.2 hours
+**Tracked build time:** 99.6 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-25T03:37:42.541Z
+- Last updated: 2026-02-25T13:49:08.051Z
 <!-- HOURS:END -->
 
 ## License

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -130,7 +130,7 @@ curl "https://athlete-agent.rosinbum.org/api/sources?action=stats"
 
 Stream an AI-generated response. Uses Server-Sent Events (SSE).
 
-**Auth:** None (rate-limited)
+**Auth:** Session (requires authenticated user)
 
 **Rate limits:**
 
@@ -169,7 +169,53 @@ The stream emits events via the Vercel AI SDK `createDataStreamResponse()`:
 | `message_annotations` | Citations: `[{ type: "citations", citations: [...] }]` |
 | `error`               | Error message                                          |
 
-**Error responses:** `400` (validation), `429` (rate limited), `500` (server error).
+**Error responses:** `400` (validation), `401` (unauthorized), `429` (rate limited), `500` (server error).
+
+---
+
+### `POST /api/chat/feedback`
+
+Submit feedback (thumbs up/down) for a chat message.
+
+**Auth:** Session (requires authenticated user)
+
+**Request body:**
+
+| Field            | Type    | Required | Description                             |
+| ---------------- | ------- | -------- | --------------------------------------- |
+| `conversationId` | string  | Yes      | UUID of the conversation                |
+| `messageId`      | string  | Yes      | ID of the message being rated           |
+| `score`          | integer | Yes      | `1` (helpful) or `0` (not helpful)      |
+| `comment`        | string  | No       | Optional feedback text (max 2000 chars) |
+
+```bash
+curl -X POST https://athlete-agent.rosinbum.org/api/chat/feedback \
+  -H "Content-Type: application/json" \
+  -H "Cookie: next-auth.session-token=<token>" \
+  -d '{
+    "conversationId": "123e4567-e89b-12d3-a456-426614174000",
+    "messageId": "msg-abc123",
+    "score": 1,
+    "comment": "Very helpful answer!"
+  }'
+```
+
+**Response** `201`:
+
+```json
+{
+  "feedback": {
+    "conversationId": "123e4567-e89b-12d3-a456-426614174000",
+    "messageId": "msg-abc123",
+    "channel": "web",
+    "score": 1,
+    "comment": "Very helpful answer!",
+    "userId": "athlete@example.com"
+  }
+}
+```
+
+**Error responses:** `400` (validation), `401` (unauthorized), `500` (server error).
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes three Critical documentation findings from the comprehensive code review:

- **DOC-01**: Chat endpoint was documented as "Public/unauthenticated" but actually requires session auth. Updated endpoint inventory, removed SEC-L2 accepted risk, rewrote chat endpoint section.
- **DOC-02**: Security docs referenced `middleware.ts` which was renamed to `proxy.ts` in PR #386 (Next.js 16). Fixed all references and corrected SEC-C1 resolution text.
- **DOC-03**: `/api/chat/feedback` endpoint was completely undocumented. Added full API reference section (Zod schema, auth, request/response examples) and added to security endpoint inventory.

### Additional accuracy fixes
- Session model: updated role re-evaluation note (SEC-05 was fixed — role IS re-evaluated on token refresh now)
- Admin known limitation: updated to reflect that revoked admins lose access on next token refresh
- OWASP A06: updated from "Unknown — dependency audit needed" to "Partially mitigated — pnpm overrides"

## Files changed
- `docs/security.md` — Endpoint inventory, auth model, middleware reference, accepted risks, OWASP table
- `docs/api-reference.md` — Chat auth level, new feedback endpoint section

## Test plan

- [x] Documentation-only changes — no code modified
- [x] Prettier formatting verified
- [x] Cross-referenced actual code (`proxy.ts`, `route.ts`, `feedback/route.ts`) to confirm accuracy

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)