### PR TITLE
test(web): add auth, proxy, and summary loading tests [TEST-01–03]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # USOPC Athlete Support Agent
 
-> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 99.6 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
+> **Work in Progress**: This project is under active development and should be treated as a prototype. It represents approximately 100.1 hours of development time and is not yet production-ready. Features may be incomplete, APIs may change, and the knowledge base needs additional content and quality improvements.
 
 An AI-powered governance and compliance assistant for U.S. Olympic and Paralympic athletes. Ask questions about anti-doping rules, athlete rights, competition eligibility, and other USOPC policies — get accurate, cited answers with appropriate disclaimers.
 
@@ -150,10 +150,10 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 
 <!-- HOURS:START -->
 
-**Tracked build time:** 99.6 hours
+**Tracked build time:** 100.1 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-02-25T13:49:08.051Z
+- Last updated: 2026-02-25T14:08:47.266Z
 <!-- HOURS:END -->
 
 ## License

--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -417,3 +417,75 @@ describe("authentication (SEC-04)", () => {
     expect(response.status).toBe(200);
   });
 });
+
+describe("conversation summary loading (TEST-02)", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    shouldFailInit = false;
+    initCallCount = 0;
+    vi.resetModules();
+  });
+
+  function makeReq(body: Record<string, unknown>) {
+    return new Request("http://localhost/api/chat", {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const validUuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+  const otherUuid = "b2c3d4e5-f6a7-8901-bcde-f12345678901";
+
+  it("calls loadSummary with conversationId when provided", async () => {
+    const { POST } = await importRoute();
+    const { loadSummary } = await import("@usopc/core");
+
+    await POST(
+      makeReq({
+        messages: [{ role: "user", content: "Hello" }],
+        conversationId: validUuid,
+      }),
+    );
+
+    expect(loadSummary).toHaveBeenCalledWith(validUuid);
+  });
+
+  it("does not call loadSummary when conversationId is absent", async () => {
+    const { POST } = await importRoute();
+    const { loadSummary } = await import("@usopc/core");
+
+    await POST(
+      makeReq({
+        messages: [{ role: "user", content: "Hello" }],
+      }),
+    );
+
+    expect(loadSummary).not.toHaveBeenCalled();
+  });
+
+  it("passes loaded summary to the agent runner stream", async () => {
+    const coreMod = await import("@usopc/core");
+    vi.mocked(coreMod.loadSummary).mockResolvedValueOnce(
+      "Previous conversation context",
+    );
+
+    const { POST } = await importRoute();
+
+    await POST(
+      makeReq({
+        messages: [{ role: "user", content: "Continue" }],
+        conversationId: otherUuid,
+        userSport: "swimming",
+      }),
+    );
+
+    expect(mockRunner.stream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationSummary: "Previous conversation context",
+        conversationId: otherUuid,
+        userSport: "swimming",
+      }),
+    );
+  });
+});

--- a/apps/web/auth.test.ts
+++ b/apps/web/auth.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+const { mockGetAdminEmails, mockIsInvited, capturedCallbacks } = vi.hoisted(
+  () => ({
+    mockGetAdminEmails: vi.fn().mockReturnValue(["admin@usopc.org"]),
+    mockIsInvited: vi.fn().mockResolvedValue(true),
+    capturedCallbacks: {
+      signIn: null as ((...args: unknown[]) => unknown) | null,
+      jwt: null as ((...args: unknown[]) => unknown) | null,
+      session: null as ((...args: unknown[]) => unknown) | null,
+      authorized: null as ((...args: unknown[]) => unknown) | null,
+    },
+  }),
+);
+
+vi.mock("@usopc/shared", () => ({
+  createInviteEntity: vi.fn(() => ({ isInvited: mockIsInvited })),
+  getResource: vi.fn(() => ({ name: "AuthTable" })),
+  getSecretValue: vi.fn(() => "test-secret"),
+}));
+
+vi.mock("./lib/auth-env.js", () => ({
+  getAuthSecret: vi.fn(() => "test-secret"),
+  getGitHubClientId: vi.fn(() => "test-client-id"),
+  getGitHubClientSecret: vi.fn(() => "test-client-secret"),
+  getAdminEmails: mockGetAdminEmails,
+  getResendApiKey: vi.fn(() => "test-resend-key"),
+}));
+
+vi.mock("@aws-sdk/client-dynamodb", () => ({
+  DynamoDB: vi.fn(),
+}));
+
+vi.mock("@aws-sdk/lib-dynamodb", () => ({
+  DynamoDBDocument: { from: vi.fn(() => ({})) },
+}));
+
+vi.mock("@auth/dynamodb-adapter", () => ({
+  DynamoDBAdapter: vi.fn(() => ({})),
+}));
+
+vi.mock("next-auth", () => ({
+  default: vi.fn(
+    (config: {
+      callbacks: {
+        signIn: (...args: unknown[]) => unknown;
+        jwt: (...args: unknown[]) => unknown;
+        session: (...args: unknown[]) => unknown;
+        authorized: (...args: unknown[]) => unknown;
+      };
+    }) => {
+      capturedCallbacks.signIn = config.callbacks.signIn;
+      capturedCallbacks.jwt = config.callbacks.jwt;
+      capturedCallbacks.session = config.callbacks.session;
+      capturedCallbacks.authorized = config.callbacks.authorized;
+      return {
+        handlers: {},
+        auth: vi.fn(),
+        signIn: vi.fn(),
+        signOut: vi.fn(),
+      };
+    },
+  ),
+}));
+
+vi.mock("next-auth/providers/github", () => ({
+  default: vi.fn(() => ({ id: "github", name: "GitHub" })),
+}));
+
+vi.mock("next-auth/providers/resend", () => ({
+  default: vi.fn(() => ({ id: "resend", name: "Resend" })),
+}));
+
+// ---------------------------------------------------------------------------
+// Import triggers NextAuth() and captures callbacks
+// ---------------------------------------------------------------------------
+await import("./auth.js");
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetAdminEmails.mockReturnValue(["admin@usopc.org"]);
+  mockIsInvited.mockResolvedValue(true);
+});
+
+describe("NextAuth callbacks", () => {
+  describe("signIn callback (TEST-01)", () => {
+    it("rejects users with no email", async () => {
+      const result = await capturedCallbacks.signIn!({
+        profile: {},
+        user: {},
+        account: { provider: "github" },
+      });
+      expect(result).toBe(false);
+    });
+
+    it("allows GitHub users on admin allowlist", async () => {
+      const result = await capturedCallbacks.signIn!({
+        profile: { email: "admin@usopc.org" },
+        user: {},
+        account: { provider: "github" },
+      });
+      expect(result).toBe(true);
+    });
+
+    it("rejects GitHub users not on admin allowlist", async () => {
+      const result = await capturedCallbacks.signIn!({
+        profile: { email: "hacker@evil.com" },
+        user: {},
+        account: { provider: "github" },
+      });
+      expect(result).toBe(false);
+    });
+
+    it("allows Resend users on invite list", async () => {
+      mockIsInvited.mockResolvedValue(true);
+      const result = await capturedCallbacks.signIn!({
+        profile: {},
+        user: { email: "athlete@example.com" },
+        account: { provider: "resend" },
+      });
+      expect(result).toBe(true);
+      expect(mockIsInvited).toHaveBeenCalledWith("athlete@example.com");
+    });
+
+    it("rejects Resend users not on invite list", async () => {
+      mockIsInvited.mockResolvedValue(false);
+      const result = await capturedCallbacks.signIn!({
+        profile: {},
+        user: { email: "uninvited@example.com" },
+        account: { provider: "resend" },
+      });
+      expect(result).toBe(false);
+    });
+
+    it("rejects unknown providers", async () => {
+      const result = await capturedCallbacks.signIn!({
+        profile: { email: "user@example.com" },
+        user: {},
+        account: { provider: "twitter" },
+      });
+      expect(result).toBe(false);
+    });
+
+    it("is case-insensitive for email matching", async () => {
+      const result = await capturedCallbacks.signIn!({
+        profile: { email: "ADMIN@USOPC.ORG" },
+        user: {},
+        account: { provider: "github" },
+      });
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("jwt callback — role re-evaluation (TEST-01, SEC-05)", () => {
+    it("assigns admin role for GitHub user on allowlist", async () => {
+      const token = (await capturedCallbacks.jwt!({
+        token: { email: "admin@usopc.org", provider: "github" },
+        profile: null,
+        user: null,
+        account: null,
+      })) as Record<string, unknown>;
+      expect(token.role).toBe("admin");
+    });
+
+    it("demotes removed admin to athlete on next token refresh", async () => {
+      // First call: admin is on list
+      mockGetAdminEmails.mockReturnValue(["admin@usopc.org"]);
+      const token1 = (await capturedCallbacks.jwt!({
+        token: { email: "admin@usopc.org", provider: "github" },
+        profile: null,
+        user: null,
+        account: null,
+      })) as Record<string, unknown>;
+      expect(token1.role).toBe("admin");
+
+      // Second call: admin removed from list
+      mockGetAdminEmails.mockReturnValue([]);
+      const token2 = (await capturedCallbacks.jwt!({
+        token: { email: "admin@usopc.org", provider: "github" },
+        profile: null,
+        user: null,
+        account: null,
+      })) as Record<string, unknown>;
+      expect(token2.role).toBe("athlete");
+    });
+
+    it("assigns athlete role for Resend provider", async () => {
+      const token = (await capturedCallbacks.jwt!({
+        token: { email: "athlete@example.com", provider: "resend" },
+        profile: null,
+        user: null,
+        account: null,
+      })) as Record<string, unknown>;
+      expect(token.role).toBe("athlete");
+    });
+
+    it("sets provider from account on initial sign-in", async () => {
+      const token = (await capturedCallbacks.jwt!({
+        token: {},
+        profile: { email: "admin@usopc.org", name: "Admin" },
+        user: null,
+        account: { provider: "github" },
+      })) as Record<string, unknown>;
+      expect(token.provider).toBe("github");
+    });
+
+    it("populates email from user object for email provider", async () => {
+      const token = (await capturedCallbacks.jwt!({
+        token: { provider: "resend" },
+        profile: null,
+        user: { email: "athlete@example.com", name: null },
+        account: null,
+      })) as Record<string, unknown>;
+      expect(token.email).toBe("athlete@example.com");
+    });
+  });
+
+  describe("session callback (TEST-01)", () => {
+    it("propagates role from token to session", async () => {
+      const session = (await capturedCallbacks.session!({
+        session: { user: { email: "", name: "", image: "" } },
+        token: {
+          email: "admin@usopc.org",
+          name: "Admin",
+          picture: "https://avatar.url",
+          role: "admin",
+        },
+      })) as { user: Record<string, unknown> };
+      expect(session.user.role).toBe("admin");
+      expect(session.user.email).toBe("admin@usopc.org");
+      expect(session.user.name).toBe("Admin");
+      expect(session.user.image).toBe("https://avatar.url");
+    });
+
+    it("does not set role when token has no role", async () => {
+      const session = (await capturedCallbacks.session!({
+        session: { user: { email: "" } },
+        token: { email: "user@example.com" },
+      })) as { user: Record<string, unknown> };
+      expect(session.user.role).toBeUndefined();
+    });
+  });
+});

--- a/apps/web/proxy.test.ts
+++ b/apps/web/proxy.test.ts
@@ -1,30 +1,128 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
 
-vi.mock("./auth.js", () => ({
-  // auth() wraps a handler and returns it — mock that behavior
-  auth: vi.fn((handler: unknown) => handler),
+// ---------------------------------------------------------------------------
+// Hoisted: capture the handler function passed to auth()
+// ---------------------------------------------------------------------------
+const { capturedHandler } = vi.hoisted(() => ({
+  capturedHandler: {
+    current: null as ((req: unknown) => unknown) | null,
+  },
 }));
 
-import { proxy, config } from "./proxy.js";
+vi.mock("./auth.js", () => ({
+  auth: vi.fn((handler: (req: unknown) => unknown) => {
+    capturedHandler.current = handler;
+    return handler;
+  }),
+}));
 
+import { config } from "./proxy.js";
+
+// ---------------------------------------------------------------------------
+// Helper: create a fake request with auth session
+// ---------------------------------------------------------------------------
+function makeRequest(
+  pathname: string,
+  session: { user?: { role?: string } } | null,
+) {
+  return {
+    nextUrl: { pathname },
+    url: "http://localhost:3000" + pathname,
+    auth: session,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 describe("proxy", () => {
-  it("exports a proxy function", () => {
-    expect(typeof proxy).toBe("function");
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
-  it("matches admin pages", () => {
-    expect(config.matcher).toContain("/admin/:path*");
+  describe("route matcher config", () => {
+    it("matches admin pages", () => {
+      expect(config.matcher).toContain("/admin/:path*");
+    });
+
+    it("matches admin API routes", () => {
+      expect(config.matcher).toContain("/api/admin/:path*");
+    });
+
+    it("matches chat routes", () => {
+      expect(config.matcher).toContain("/chat/:path*");
+    });
+
+    it("matches chat API route", () => {
+      expect(config.matcher).toContain("/api/chat/:path*");
+    });
   });
 
-  it("matches admin API routes", () => {
-    expect(config.matcher).toContain("/api/admin/:path*");
-  });
+  describe("authorization behavior (TEST-03)", () => {
+    it("redirects unauthenticated users to /auth/login", () => {
+      const result = capturedHandler.current!(
+        makeRequest("/chat/abc", null),
+      ) as NextResponse;
+      expect(result.status).toBe(307);
+      const location = result.headers.get("location");
+      expect(location).toContain("/auth/login");
+      expect(location).toContain("callbackUrl=%2Fchat%2Fabc");
+    });
 
-  it("matches chat routes", () => {
-    expect(config.matcher).toContain("/chat/:path*");
-  });
+    it("includes callbackUrl for admin routes", () => {
+      const result = capturedHandler.current!(
+        makeRequest("/admin/sources", null),
+      ) as NextResponse;
+      expect(result.status).toBe(307);
+      const location = result.headers.get("location");
+      expect(location).toContain("callbackUrl=%2Fadmin%2Fsources");
+    });
 
-  it("matches chat API route", () => {
-    expect(config.matcher).toContain("/api/chat/:path*");
+    it("redirects non-admin users from /admin routes", () => {
+      const result = capturedHandler.current!(
+        makeRequest("/admin/sources", { user: { role: "athlete" } }),
+      ) as NextResponse;
+      expect(result.status).toBe(307);
+      const location = result.headers.get("location");
+      expect(location).toContain("error=AccessDenied");
+    });
+
+    it("redirects non-admin users from /api/admin routes", () => {
+      const result = capturedHandler.current!(
+        makeRequest("/api/admin/sources", { user: { role: "athlete" } }),
+      ) as NextResponse;
+      expect(result.status).toBe(307);
+      const location = result.headers.get("location");
+      expect(location).toContain("error=AccessDenied");
+    });
+
+    it("allows admin users to access /admin routes", () => {
+      const result = capturedHandler.current!(
+        makeRequest("/admin/sources", { user: { role: "admin" } }),
+      ) as NextResponse;
+      expect(result.headers.get("location")).toBeNull();
+    });
+
+    it("allows admin users to access /api/admin routes", () => {
+      const result = capturedHandler.current!(
+        makeRequest("/api/admin/invites", { user: { role: "admin" } }),
+      ) as NextResponse;
+      expect(result.headers.get("location")).toBeNull();
+    });
+
+    it("allows authenticated non-admin users to access /chat routes", () => {
+      const result = capturedHandler.current!(
+        makeRequest("/chat/abc", { user: { role: "athlete" } }),
+      ) as NextResponse;
+      expect(result.headers.get("location")).toBeNull();
+    });
+
+    it("allows authenticated non-admin users to access /api/chat routes", () => {
+      const result = capturedHandler.current!(
+        makeRequest("/api/chat", { user: { role: "athlete" } }),
+      ) as NextResponse;
+      expect(result.headers.get("location")).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- **TEST-01**: New `auth.test.ts` with 14 tests covering all NextAuth callback paths — signIn (admin allowlist, invite gating, unknown providers, case-insensitive email), jwt (role assignment, demotion on removal per SEC-05, provider setting), and session (role propagation)
- **TEST-02**: 3 new tests in `route.test.ts` verifying `loadSummary` is called with `conversationId` when provided, skipped when absent, and its result is passed to the agent runner
- **TEST-03**: Rewritten `proxy.test.ts` with 12 tests — 4 route matcher assertions + 8 behavioral authorization tests (unauthenticated redirect with callbackUrl, admin-only enforcement for /admin and /api/admin, athlete access to /chat routes)

Closes #403

## Test plan

- [x] `pnpm --filter @usopc/web test` — all 365 tests pass
- [x] `pnpm typecheck` — clean across all packages
- [x] `npx prettier --check` — no formatting issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)