### PR TITLE
feat: add tsvector column migration for full-text search

### DIFF
--- a/scripts/migrations/001_add-tsvector.sql
+++ b/scripts/migrations/001_add-tsvector.sql
@@ -1,0 +1,15 @@
+-- Add tsvector column for full-text search on document_chunks.
+-- Weighted fields: title (A), section (B), content (C).
+-- This is a stored generated column — PostgreSQL maintains it automatically
+-- when content, document_title, or section_title change.
+
+ALTER TABLE document_chunks
+  ADD COLUMN IF NOT EXISTS content_tsv tsvector
+    GENERATED ALWAYS AS (
+      setweight(to_tsvector('english', coalesce(document_title, '')), 'A') ||
+      setweight(to_tsvector('english', coalesce(section_title, '')), 'B') ||
+      setweight(to_tsvector('english', content), 'C')
+    ) STORED;
+
+CREATE INDEX IF NOT EXISTS idx_chunks_content_tsv
+  ON document_chunks USING gin (content_tsv);


### PR DESCRIPTION
## Summary

- Add first database migration: `scripts/migrations/001_add-tsvector.sql`
- Adds a stored generated `tsvector` column (`content_tsv`) to `document_chunks` with weighted fields:
  - **Weight A**: `document_title` — highest relevance for keyword matches in titles
  - **Weight B**: `section_title` — medium relevance for section headings
  - **Weight C**: `content` — standard relevance for body text
- Creates a GIN index (`idx_chunks_content_tsv`) for fast full-text search queries

This is **PR 2 of 3** for hybrid search (#421):
1. Migration infrastructure (#425, merged)
2. **This PR: tsvector schema migration**
3. Hybrid search app code (RRF, BM25, retriever integration)

## Design decisions

- **Stored generated column** — PostgreSQL maintains the tsvector automatically when content/title/section change. No triggers needed.
- **Weighted fields** — Keyword matches in titles rank higher than body text, improving relevance for keyword-heavy queries.
- **`IF NOT EXISTS`** — Safe to re-run; idempotent for both column and index.

## Test plan

- [x] `pnpm db:up` → `pnpm db:migrate` → column and index created, migration recorded in `pgmigrations`
- [x] Re-running `pnpm db:migrate` is a no-op (idempotent)
- [x] `pnpm typecheck` passes

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)