### PR TITLE
fix(core): canonicalize NGB IDs & restrict multi-NGB retrieval (#441)

### DIFF
--- a/packages/core/src/agent/nodes/disclaimerGuard.test.ts
+++ b/packages/core/src/agent/nodes/disclaimerGuard.test.ts
@@ -1,15 +1,19 @@
 import { describe, it, expect, vi } from "vitest";
 
-vi.mock("@usopc/shared", () => ({
-  logger: {
-    child: () => ({
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-    }),
-  },
-}));
+vi.mock("@usopc/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@usopc/shared")>();
+  return {
+    ...actual,
+    logger: {
+      child: () => ({
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      }),
+    },
+  };
+});
 
 import { disclaimerGuardNode } from "./disclaimerGuard.js";
 import { HumanMessage } from "@langchain/core/messages";

--- a/packages/core/src/agent/nodes/retriever.ts
+++ b/packages/core/src/agent/nodes/retriever.ts
@@ -387,6 +387,20 @@ export function createRetrieverNode(vectorStore: VectorStoreLike, pool: Pool) {
           RETRIEVAL_CONFIG.topK,
         );
       }
+      if (
+        results.length === 0 &&
+        input.sqlFilter.ngbIds &&
+        input.sqlFilter.ngbIds.length > 0
+      ) {
+        log.warn(
+          "Narrow NGB-filtered search returned 0 results — possible no ingested docs for this NGB",
+          {
+            ngbIds: input.sqlFilter.ngbIds,
+            topicDomain: input.sqlFilter.topicDomain,
+          },
+        );
+      }
+
       return {
         results,
         resultCount: results.length,

--- a/packages/core/src/prompts/classifier.test.ts
+++ b/packages/core/src/prompts/classifier.test.ts
@@ -88,6 +88,17 @@ describe("CLASSIFIER_PROMPT", () => {
     expect(CLASSIFIER_PROMPT).toContain("{{userMessage}}");
   });
 
+  it("includes canonical NGB IDs in the prompt", () => {
+    expect(CLASSIFIER_PROMPT).toContain("usa-swimming");
+    expect(CLASSIFIER_PROMPT).toContain("us-speedskating");
+    expect(CLASSIFIER_PROMPT).toContain("usopc-breaking");
+    expect(CLASSIFIER_PROMPT).toContain("us-ski-snowboard");
+  });
+
+  it("includes the single-NGB rule", () => {
+    expect(CLASSIFIER_PROMPT).toContain("at most ONE NGB ID");
+  });
+
   it("lists all 7 topic domains", () => {
     const domains = [
       "team_selection",

--- a/packages/core/src/prompts/classifier.ts
+++ b/packages/core/src/prompts/classifier.ts
@@ -1,3 +1,7 @@
+import { NGB_IDS } from "@usopc/shared";
+
+const NGB_ID_LIST = NGB_IDS.join("\n");
+
 export const CLASSIFIER_PROMPT = `You are a query classifier for the USOPC Athlete Support Assistant. \
 Your job is to analyze a user message and extract structured metadata that will guide \
 document retrieval and response generation.
@@ -19,9 +23,18 @@ One of the following values:
 - "financial_assistance" -- Questions about athlete grants, stipends, USOPC financial programs, Op Gold, training expense assistance, or financial aid for athletes.
 
 ### detectedNgbIds (required)
-An array of NGB or sport organization identifiers mentioned or implied in the query. \
-Use standard abbreviations when possible (e.g., "usa-swimming", "us-ski-snowboard", "usa-track-field"). \
-Return an empty array if no specific NGB is mentioned or can be inferred from the sport name.
+An array of NGB or sport organization identifiers mentioned or implied in the query.
+You MUST select ONLY from the following canonical IDs — do not invent, shorten, or otherwise modify these strings:
+
+${NGB_ID_LIST}
+
+Return an empty array if no specific NGB is mentioned or can be inferred.
+If uncertain, return an empty array rather than guessing.
+
+**Single-NGB rule**: Emit at most ONE NGB ID per turn unless the user explicitly asks
+to compare or contrast multiple NGBs (look for words like "compare", "difference between",
+"both", "versus", "vs"). When the user switches sports mid-conversation, emit only the
+new sport's NGB ID — do not carry forward the previous sport.
 
 ### queryIntent (required)
 One of the following:

--- a/packages/ingestion/src/transformers/metadataEnricher.ts
+++ b/packages/ingestion/src/transformers/metadataEnricher.ts
@@ -1,5 +1,8 @@
 import type { Document } from "@langchain/core/documents";
+import { NGB_ID_SET, logger } from "@usopc/shared";
 import type { IngestionSource } from "../pipeline.js";
+
+const log = logger.child({ service: "metadata-enricher" });
 
 /**
  * Enrich every chunk with metadata derived from the ingestion source
@@ -11,6 +14,16 @@ export function enrichMetadata(
   source: IngestionSource,
   options?: { s3Key?: string | undefined } | undefined,
 ): Document[] {
+  if (source.ngbId && !NGB_ID_SET.has(source.ngbId)) {
+    log.warn(
+      "Source has unrecognized ngbId — verify data/sport-organizations.json",
+      {
+        sourceId: source.id,
+        ngbId: source.ngbId,
+      },
+    );
+  }
+
   return chunks.map((chunk, index) => ({
     ...chunk,
     metadata: {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -116,6 +116,8 @@ export type {
   SportOrganization,
 } from "./types/sport-org.js";
 
+export { NGB_IDS, NGB_ID_SET, type NgbId } from "./ngbIds.js";
+
 export { normalizeUrl, urlToId } from "./url.js";
 
 export { getResource } from "./resources.js";

--- a/packages/shared/src/ngbIds.ts
+++ b/packages/shared/src/ngbIds.ts
@@ -1,0 +1,62 @@
+/**
+ * Canonical NGB IDs — matches the `id` field in data/sport-organizations.json.
+ *
+ * Inlined (not imported from JSON) to avoid path-resolution issues across
+ * Lambda, Next.js, and test contexts.
+ */
+export const NGB_IDS = [
+  // us- prefix
+  "us-equestrian",
+  "us-fencing",
+  "us-field-hockey",
+  "us-figure-skating",
+  "us-rowing",
+  "us-rugby",
+  "us-sailing",
+  "us-shooting",
+  "us-ski-snowboard",
+  "us-soccer",
+  "us-speedskating",
+  "us-squash",
+  // usa- prefix
+  "usa-archery",
+  "usa-badminton",
+  "usa-basketball",
+  "usa-biathlon",
+  "usa-bobsled-skeleton",
+  "usa-boxing",
+  "usa-canoe-kayak",
+  "usa-climbing",
+  "usa-cricket",
+  "usa-curling",
+  "usa-cycling",
+  "usa-diving",
+  "usa-flag-football",
+  "usa-golf",
+  "usa-gymnastics",
+  "usa-hockey",
+  "usa-judo",
+  "usa-karate",
+  "usa-lacrosse",
+  "usa-luge",
+  "usa-modern-pentathlon",
+  "usa-softball",
+  "usa-surfing",
+  "usa-swimming",
+  "usa-table-tennis",
+  "usa-taekwondo",
+  "usa-team-handball",
+  "usa-tennis",
+  "usa-track-field",
+  "usa-triathlon",
+  "usa-volleyball",
+  "usa-water-polo",
+  "usa-weightlifting",
+  "usa-wrestling",
+  // usopc- prefix
+  "usopc-breaking",
+  "usopc-skateboarding",
+] as const;
+
+export type NgbId = (typeof NGB_IDS)[number];
+export const NGB_ID_SET: ReadonlySet<string> = new Set(NGB_IDS);


### PR DESCRIPTION
## Summary

Fixes two retrieval bugs identified via LangSmith trace analysis (thread `86418736-b023-4eb4-95d8-77caca4e076b`):

- **NGB ID mismatch** — Haiku was emitting free-form strings (`"usa_swimming"`, `"us-speed-skating"`) that didn't match the database `ngbId` column, causing pgvector to return 0 matching docs and fall back to a fully unfiltered corpus-wide search. A speedskating query returned USA Swimming docs.
- **Multi-NGB scoping** — No rule prevented Haiku from emitting multiple NGB IDs when conversation history contained multiple sports. When a user switches sports, the retriever now scopes to the new sport only.

## Implementation

- **`packages/shared/src/ngbIds.ts`** (new) — Canonical list of 48 NGB IDs as `as const` array + `ReadonlySet` for O(1) lookup. Inlined (not JSON import) to avoid path-resolution issues across Lambda/Next.js/test contexts.
- **`packages/shared/src/index.ts`** — Export `NGB_IDS`, `NGB_ID_SET`, `NgbId`
- **`packages/core/src/prompts/classifier.ts`** — Embed canonical list in prompt; add single-NGB rule (emit at most one ID per turn unless user explicitly asks to compare)
- **`packages/core/src/agent/nodes/classifier.ts`** — Validate IDs against `NGB_ID_SET` in `parseClassifierResponse()`; unrecognized IDs are filtered out with a warning (never throws — degrades to unfiltered search)
- **`packages/core/src/agent/nodes/retriever.ts`** — Warn when NGB-filtered narrow search returns 0 results (observability only, no control-flow change)
- **`packages/ingestion/src/transformers/metadataEnricher.ts`** — Warn on unknown `ngbId` during ingestion

## Tests

- Fixed existing tests using underscore IDs (`"usa_swimming"`) → canonical hyphen IDs (`"usa-swimming"`)
- New `parseClassifierResponse` test: unknown IDs filtered, warnings emitted
- New node-level tests: sport-switch emits only new sport, explicit comparison allows two IDs
- New prompt tests: canonical list and single-NGB rule appear in `CLASSIFIER_PROMPT`
- Fixed `disclaimerGuard.test.ts` `vi.mock` to spread actual `@usopc/shared` so new `NGB_IDS` export is available

## Verification

All 769 core tests, 258 ingestion tests, and 298 shared tests pass. Full monorepo typecheck clean.

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)