### PR TITLE
fix(core): use shared TOPIC_DOMAINS in classifier and queryPlanner

### DIFF
--- a/packages/core/src/agent/nodes/classifier.ts
+++ b/packages/core/src/agent/nodes/classifier.ts
@@ -1,6 +1,11 @@
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { HumanMessage } from "@langchain/core/messages";
-import { logger, CircuitBreakerError, NGB_ID_SET } from "@usopc/shared";
+import {
+  logger,
+  CircuitBreakerError,
+  NGB_ID_SET,
+  TOPIC_DOMAINS,
+} from "@usopc/shared";
 import { buildClassifierPromptWithHistory } from "../../prompts/index.js";
 import {
   invokeLlm,
@@ -22,20 +27,9 @@ const log = logger.child({ service: "classifier-node" });
 
 /**
  * Valid topic domains for guard-checking the classifier output.
- * Must be kept in sync with the TopicDomain type in packages/core/src/types/agent.ts
- * and the TOPIC_DOMAINS constant in packages/shared/src/validation.ts.
+ * Single source of truth: TOPIC_DOMAINS from @usopc/shared.
  */
-const VALID_DOMAINS: TopicDomain[] = [
-  "team_selection",
-  "dispute_resolution",
-  "safesport",
-  "anti_doping",
-  "eligibility",
-  "governance",
-  "athlete_rights",
-  "athlete_safety",
-  "financial_assistance",
-];
+const VALID_DOMAINS: readonly string[] = TOPIC_DOMAINS;
 
 /**
  * Valid query intents for guard-checking the classifier output.

--- a/packages/core/src/agent/nodes/queryPlanner.test.ts
+++ b/packages/core/src/agent/nodes/queryPlanner.test.ts
@@ -411,6 +411,34 @@ describe("parseQueryPlannerResponse", () => {
     expect(warnings.length).toBeGreaterThan(0);
   });
 
+  it("accepts athlete_safety and financial_assistance domains", () => {
+    const { output, warnings } = parseQueryPlannerResponse(
+      JSON.stringify({
+        isComplex: true,
+        subQueries: [
+          {
+            query: "What SafeSport protections exist for athlete safety?",
+            domain: "athlete_safety",
+            intent: "factual",
+            ngbIds: [],
+          },
+          {
+            query: "What financial assistance is available?",
+            domain: "financial_assistance",
+            intent: "procedural",
+            ngbIds: [],
+          },
+        ],
+      }),
+    );
+
+    expect(output.isComplex).toBe(true);
+    expect(output.subQueries).toHaveLength(2);
+    expect(output.subQueries[0]!.domain).toBe("athlete_safety");
+    expect(output.subQueries[1]!.domain).toBe("financial_assistance");
+    expect(warnings).toHaveLength(0);
+  });
+
   it("filters out invalid NGB IDs", () => {
     const { output } = parseQueryPlannerResponse(
       JSON.stringify({

--- a/packages/core/src/agent/nodes/queryPlanner.ts
+++ b/packages/core/src/agent/nodes/queryPlanner.ts
@@ -1,6 +1,6 @@
 import type { BaseChatModel } from "@langchain/core/language_models/chat_models";
 import { HumanMessage } from "@langchain/core/messages";
-import { logger, CircuitBreakerError } from "@usopc/shared";
+import { logger, CircuitBreakerError, TOPIC_DOMAINS } from "@usopc/shared";
 import { buildQueryPlannerPrompt } from "../../prompts/index.js";
 import {
   invokeLlm,
@@ -18,15 +18,7 @@ const log = logger.child({ service: "query-planner-node" });
 
 const MAX_SUB_QUERIES = 4;
 
-const VALID_DOMAINS: TopicDomain[] = [
-  "team_selection",
-  "dispute_resolution",
-  "safesport",
-  "anti_doping",
-  "eligibility",
-  "governance",
-  "athlete_rights",
-];
+const VALID_DOMAINS: readonly string[] = TOPIC_DOMAINS;
 
 const VALID_INTENTS: QueryIntent[] = [
   "factual",


### PR DESCRIPTION
## Summary

- Replace duplicate `VALID_DOMAINS` arrays in `classifier.ts` and `queryPlanner.ts` with the single `TOPIC_DOMAINS` constant from `@usopc/shared`
- Fixes the queryPlanner silently rejecting `athlete_safety` and `financial_assistance` sub-queries (#437)
- Eliminates future domain drift between classifier and queryPlanner (#439)
- Adds test case verifying both previously-missing domains are accepted

## Changes

| File | Change |
|------|--------|
| `packages/core/src/agent/nodes/queryPlanner.ts` | Import `TOPIC_DOMAINS` from shared, replace local array |
| `packages/core/src/agent/nodes/classifier.ts` | Import `TOPIC_DOMAINS` from shared, replace local array |
| `packages/core/src/agent/nodes/queryPlanner.test.ts` | Add test for `athlete_safety` and `financial_assistance` domains |

## Test plan

- [x] `pnpm --filter @usopc/core test` — 783 tests pass
- [x] `pnpm typecheck` — clean across all 6 packages
- [x] `npx prettier --write` — no formatting changes needed

Closes #437
Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)