### PR TITLE
chore(core): lower recursionLimit from 50 to 30

### DIFF
--- a/packages/core/src/agent/runner.test.ts
+++ b/packages/core/src/agent/runner.test.ts
@@ -64,7 +64,7 @@ vi.mock("../config/index.js", () => ({
   GRAPH_CONFIG: {
     invokeTimeoutMs: 90_000,
     streamTimeoutMs: 120_000,
-    recursionLimit: 50,
+    recursionLimit: 30,
   },
 }));
 
@@ -279,7 +279,7 @@ describe("AgentRunner", () => {
           conversationId: "conv-123",
         }),
         expect.objectContaining({
-          recursionLimit: 50,
+          recursionLimit: 30,
           configurable: { thread_id: "conv-123" },
           metadata: { session_id: "conv-123" },
         }),
@@ -299,7 +299,7 @@ describe("AgentRunner", () => {
       expect(graph.invoke).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
-          recursionLimit: 50,
+          recursionLimit: 30,
           configurable: { thread_id: "conv-abc" },
           metadata: { session_id: "conv-abc" },
         }),
@@ -318,7 +318,7 @@ describe("AgentRunner", () => {
       expect(graph.invoke).toHaveBeenCalledWith(
         expect.objectContaining({ conversationId: undefined }),
         expect.objectContaining({
-          recursionLimit: 50,
+          recursionLimit: 30,
           configurable: { thread_id: expect.any(String) },
         }),
       );
@@ -341,7 +341,7 @@ describe("AgentRunner", () => {
       expect(graph.invoke).toHaveBeenCalledWith(
         expect.objectContaining({ conversationId: undefined }),
         expect.objectContaining({
-          recursionLimit: 50,
+          recursionLimit: 30,
           configurable: { thread_id: expect.any(String) },
         }),
       );
@@ -411,7 +411,7 @@ describe("AgentRunner", () => {
         }),
         expect.objectContaining({
           streamMode: ["values", "messages"],
-          recursionLimit: 50,
+          recursionLimit: 30,
           configurable: { thread_id: expect.any(String) },
         }),
       );
@@ -434,7 +434,7 @@ describe("AgentRunner", () => {
         expect.objectContaining({ conversationId: "conv-456" }),
         expect.objectContaining({
           streamMode: ["values", "messages"],
-          recursionLimit: 50,
+          recursionLimit: 30,
           configurable: { thread_id: "conv-456" },
           metadata: { session_id: "conv-456" },
         }),
@@ -457,7 +457,7 @@ describe("AgentRunner", () => {
         expect.objectContaining({ conversationId: undefined }),
         expect.objectContaining({
           streamMode: ["values", "messages"],
-          recursionLimit: 50,
+          recursionLimit: 30,
           configurable: { thread_id: expect.any(String) },
         }),
       );

--- a/packages/core/src/config/settings.ts
+++ b/packages/core/src/config/settings.ts
@@ -18,8 +18,8 @@ export const GRAPH_CONFIG = {
   invokeTimeoutMs: 90_000,
   /** Maximum time (ms) for streaming graph execution. */
   streamTimeoutMs: 120_000,
-  /** Maximum graph recursion depth. 12-node graph with quality-check retry loop; 50 provides headroom. */
-  recursionLimit: 50,
+  /** Maximum graph recursion depth. ~15 node visits worst-case; 30 provides headroom. */
+  recursionLimit: 30,
 } as const;
 
 export const TRUSTED_DOMAINS = [


### PR DESCRIPTION
## Summary

- Lower `GRAPH_CONFIG.recursionLimit` from 50 to 30
- ~15 node visits worst-case with both retry loops firing; 30 provides sufficient headroom
- Update test assertions to match

## Test plan

- [x] `pnpm --filter @usopc/core test -- --run src/agent/runner.test.ts` — 32 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)