### PR TITLE
perf(core): switch BM25 to websearch_to_tsquery

### DIFF
--- a/packages/core/src/rag/bm25Search.test.ts
+++ b/packages/core/src/rag/bm25Search.test.ts
@@ -41,7 +41,7 @@ describe("bm25Search", () => {
 
     const call = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0]!;
     const sql = call[0] as string;
-    expect(sql).toContain("plainto_tsquery");
+    expect(sql).toContain("websearch_to_tsquery");
     expect(sql).toContain("ts_rank_cd");
   });
 

--- a/packages/core/src/rag/bm25Search.ts
+++ b/packages/core/src/rag/bm25Search.ts
@@ -22,8 +22,8 @@ export interface Bm25SearchResult {
  * BM25-style full-text search using the `content_tsv` tsvector column
  * and GIN index on the `document_chunks` table.
  *
- * Uses `plainto_tsquery` for safe handling of user input (no syntax errors
- * from boolean operators).
+ * Uses `websearch_to_tsquery` which preserves quoted phrase matching and
+ * OR operators while safely handling user input (PostgreSQL 11+).
  *
  * Filters use the denormalized `ngb_id` and `topic_domain` columns which
  * have B-tree indexes.
@@ -38,7 +38,7 @@ export async function bm25Search(
 
   const params: unknown[] = [query];
   const conditions: string[] = [
-    "content_tsv @@ plainto_tsquery('english', $1)",
+    "content_tsv @@ websearch_to_tsquery('english', $1)",
   ];
 
   let paramIndex = 2;
@@ -59,7 +59,7 @@ export async function bm25Search(
 
   const sql = `
     SELECT id, content, metadata,
-           ts_rank_cd(content_tsv, plainto_tsquery('english', $1)) AS rank
+           ts_rank_cd(content_tsv, websearch_to_tsquery('english', $1)) AS rank
     FROM document_chunks
     WHERE ${conditions.join(" AND ")}
     ORDER BY rank DESC


### PR DESCRIPTION
## Summary

- Switch `plainto_tsquery('english', ...)` to `websearch_to_tsquery('english', ...)` in BM25 search
- Preserves quoted phrase matching (e.g., `"team selection committee"`) and OR operators
- Unquoted terms retain AND semantics (same as before)
- No schema or index changes — uses the same `content_tsv` GIN index
- Available in PostgreSQL 11+ (RDS Aurora runs 15+)

## Test plan

- [x] All 9 existing `bm25Search` tests pass with updated assertion
- [x] Full monorepo typecheck passes
- [x] Prettier formatting verified

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)