### PR TITLE
Replace backfill with generated columns for denormalized fields

### DIFF
--- a/packages/ingestion/src/pipeline.test.ts
+++ b/packages/ingestion/src/pipeline.test.ts
@@ -5,8 +5,6 @@ import type { Document } from "@langchain/core/documents";
 // Mocks — must be before importing the module under test
 // ---------------------------------------------------------------------------
 
-const mockPoolQuery = vi.fn().mockResolvedValue({ rowCount: 0 });
-
 vi.mock("@usopc/shared", () => ({
   createLogger: () => ({
     info: vi.fn(),
@@ -14,9 +12,6 @@ vi.mock("@usopc/shared", () => ({
     error: vi.fn(),
     debug: vi.fn(),
     child: vi.fn(),
-  }),
-  getPool: () => ({
-    query: mockPoolQuery,
   }),
 }));
 
@@ -79,7 +74,6 @@ vi.mock("./transformers/sectionExtractor.js", () => ({
 // Now import the module under test
 import {
   QuotaExhaustedError,
-  backfillDenormalizedColumns,
   ingestSource,
   type IngestionSource,
 } from "./pipeline.js";
@@ -152,16 +146,6 @@ describe("ingestSource", () => {
       status: "completed",
       chunksCount: 1,
     });
-  });
-
-  it("runs backfill after embedding using shared pool", async () => {
-    mockPoolQuery.mockResolvedValueOnce({ rowCount: 5 });
-
-    await ingestSource(SOURCE, OPTIONS);
-
-    expect(mockPoolQuery).toHaveBeenCalledWith(
-      expect.stringContaining("UPDATE document_chunks"),
-    );
   });
 
   it("throws QuotaExhaustedError for 'insufficient_quota' errors", async () => {
@@ -285,39 +269,5 @@ describe("ingestSource", () => {
     expect(result.status).toBe("failed");
     expect(result.error).toBe("timeout");
     expect(mockAddVectors).toHaveBeenCalledTimes(3);
-  });
-});
-
-describe("backfillDenormalizedColumns", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("runs UPDATE using the shared pool", async () => {
-    mockPoolQuery.mockResolvedValueOnce({ rowCount: 3 });
-
-    const updated = await backfillDenormalizedColumns();
-
-    expect(mockPoolQuery).toHaveBeenCalledWith(
-      expect.stringContaining("UPDATE document_chunks"),
-    );
-    expect(mockPoolQuery).toHaveBeenCalledWith(
-      expect.stringContaining("source_url IS NULL"),
-    );
-    expect(updated).toBe(3);
-  });
-
-  it("returns 0 when no rows need backfilling", async () => {
-    mockPoolQuery.mockResolvedValueOnce({ rowCount: 0 });
-
-    const updated = await backfillDenormalizedColumns();
-
-    expect(updated).toBe(0);
-  });
-
-  it("propagates query errors", async () => {
-    mockPoolQuery.mockRejectedValueOnce(new Error("db error"));
-
-    await expect(backfillDenormalizedColumns()).rejects.toThrow("db error");
   });
 });

--- a/packages/ingestion/src/pipeline.ts
+++ b/packages/ingestion/src/pipeline.ts
@@ -1,5 +1,5 @@
 import type { Document } from "@langchain/core/documents";
-import { createLogger, getPool, type AuthorityLevel } from "@usopc/shared";
+import { createLogger, type AuthorityLevel } from "@usopc/shared";
 import {
   MODEL_CONFIG,
   createRawEmbeddings,
@@ -210,28 +210,6 @@ async function embedBatchWithRetry(
   }
 }
 
-/**
- * Backfill denormalized text columns from the JSONB metadata column.
- * LangChain's PGVectorStore only writes id, content, embedding, and metadata —
- * the dedicated columns (source_url, document_title, etc.) are left NULL.
- */
-export async function backfillDenormalizedColumns(): Promise<number> {
-  const result = await getPool().query(`
-    UPDATE document_chunks
-    SET
-      source_url      = metadata->>'sourceUrl',
-      document_title  = metadata->>'documentTitle',
-      document_type   = metadata->>'documentType',
-      ngb_id          = metadata->>'ngbId',
-      topic_domain    = metadata->>'topicDomain',
-      authority_level  = metadata->>'authorityLevel',
-      section_title   = metadata->>'sectionTitle'
-    WHERE source_url IS NULL
-      AND metadata->>'sourceUrl' IS NOT NULL
-  `);
-  return result.rowCount ?? 0;
-}
-
 // ---------------------------------------------------------------------------
 // Pipeline entry points
 // ---------------------------------------------------------------------------
@@ -327,13 +305,6 @@ export async function ingestSource(
         { sourceId: source.id },
       );
     }
-
-    // 7. Backfill denormalized columns from JSONB metadata
-    const backfilled = await backfillDenormalizedColumns();
-    logger.info(
-      `Backfilled ${backfilled} row(s) with denormalized column values`,
-      { sourceId: source.id },
-    );
 
     logger.info(
       `Successfully ingested ${withSections.length} chunks for ${source.id}`,

--- a/scripts/init-db.sql
+++ b/scripts/init-db.sql
@@ -7,19 +7,29 @@ CREATE EXTENSION IF NOT EXISTS vector;
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 -- Document chunks table with pgvector
+-- Denormalized text columns are GENERATED ALWAYS AS ... STORED so PostgreSQL
+-- auto-populates them from the JSONB metadata on INSERT (no backfill needed).
 CREATE TABLE IF NOT EXISTS document_chunks (
   id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
   content TEXT NOT NULL,
   embedding vector(1536),
   metadata JSONB NOT NULL DEFAULT '{}',
-  ngb_id TEXT,
-  topic_domain TEXT,
-  document_type TEXT,
-  source_url TEXT,
-  document_title TEXT,
-  section_title TEXT,
+  ngb_id          TEXT GENERATED ALWAYS AS (metadata->>'ngbId') STORED,
+  topic_domain    TEXT GENERATED ALWAYS AS (metadata->>'topicDomain') STORED,
+  document_type   TEXT GENERATED ALWAYS AS (metadata->>'documentType') STORED,
+  source_url      TEXT GENERATED ALWAYS AS (metadata->>'sourceUrl') STORED,
+  document_title  TEXT GENERATED ALWAYS AS (metadata->>'documentTitle') STORED,
+  section_title   TEXT GENERATED ALWAYS AS (metadata->>'sectionTitle') STORED,
   effective_date TIMESTAMPTZ,
-  authority_level TEXT,
+  authority_level TEXT GENERATED ALWAYS AS (metadata->>'authorityLevel') STORED,
+  -- content_tsv references metadata directly (not the generated columns above)
+  -- because PostgreSQL does not allow generated columns to reference other
+  -- generated columns.
+  content_tsv tsvector GENERATED ALWAYS AS (
+    setweight(to_tsvector('english', coalesce(metadata->>'documentTitle', '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(metadata->>'sectionTitle', '')), 'B') ||
+    setweight(to_tsvector('english', content), 'C')
+  ) STORED,
   ingested_at TIMESTAMPTZ DEFAULT NOW(),
   created_at TIMESTAMPTZ DEFAULT NOW()
 );
@@ -36,6 +46,7 @@ CREATE INDEX IF NOT EXISTS idx_chunks_document_type ON document_chunks (document
 CREATE INDEX IF NOT EXISTS idx_chunks_authority_level ON document_chunks (authority_level);
 CREATE INDEX IF NOT EXISTS idx_chunks_metadata ON document_chunks USING gin (metadata);
 CREATE INDEX IF NOT EXISTS idx_chunks_source_id ON document_chunks ((metadata->>'sourceId'));
+CREATE INDEX IF NOT EXISTS idx_chunks_content_tsv ON document_chunks USING gin (content_tsv);
 
 -- Conversations table
 CREATE TABLE IF NOT EXISTS conversations (


### PR DESCRIPTION
## Summary
- Convert 7 denormalized text columns (`ngb_id`, `topic_domain`, `document_type`, `source_url`, `document_title`, `section_title`, `authority_level`) to `GENERATED ALWAYS AS ... STORED` columns that auto-populate from JSONB `metadata` on INSERT
- Move `content_tsv` into `init-db.sql`, rewritten to reference `metadata` directly (PostgreSQL does not allow generated columns to reference other generated columns)
- Delete `backfillDenormalizedColumns()` function, its call site in `ingestSource()`, and all 3 backfill tests

Closes #470

## Test plan
- [x] `pnpm --filter @usopc/ingestion test` — 260 tests pass (14 pipeline tests, 3 backfill tests removed)
- [x] `pnpm typecheck` — all 6 packages pass
- [ ] `pnpm db:down && pnpm db:up` — verify schema creates cleanly with generated columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)