### PR TITLE
fix(deps): bump hono and @hono/node-server for high-severity CVEs

### DIFF
--- a/apps/slack/package.json
+++ b/apps/slack/package.json
@@ -12,12 +12,12 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@hono/node-server": "^1.13.7",
+    "@hono/node-server": "^1.19.10",
     "@slack/bolt": "^4.1.1",
     "@slack/web-api": "^7.14.1",
     "@usopc/core": "workspace:*",
     "@usopc/shared": "workspace:*",
-    "hono": "^4.12.2",
+    "hono": "^4.12.4",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "overrides": {
       "zod-to-json-schema": "3.24.1",
       "@langchain/openai": "^1.2.8",
-      "hono": ">=4.11.4",
+      "hono": ">=4.12.4",
       "@modelcontextprotocol/sdk": ">=1.25.2",
       "h3": ">=1.15.5",
       "axios": ">=1.13.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   zod-to-json-schema: 3.24.1
   '@langchain/openai': ^1.2.8
-  hono: '>=4.11.4'
+  hono: '>=4.12.4'
   '@modelcontextprotocol/sdk': '>=1.25.2'
   h3: '>=1.15.5'
   axios: '>=1.13.5'
@@ -42,8 +42,8 @@ importers:
   apps/slack:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.13.7
-        version: 1.19.9(hono@4.12.2)
+        specifier: ^1.19.10
+        version: 1.19.10(hono@4.12.5)
       '@slack/bolt':
         specifier: ^4.1.1
         version: 4.6.0(@types/express@5.0.6)
@@ -57,8 +57,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       hono:
-        specifier: '>=4.11.4'
-        version: 4.12.2
+        specifier: '>=4.12.4'
+        version: 4.12.5
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1144,11 +1144,11 @@ packages:
     resolution: {integrity: sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==}
     engines: {node: '>=18.0.0'}
 
-  '@hono/node-server@1.19.9':
-    resolution: {integrity: sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==}
+  '@hono/node-server@1.19.10':
+    resolution: {integrity: sha512-hZ7nOssGqRgyV3FVVQdfi+U4q02uB23bpnYpdvNXkYTRRyWx84b7yf1ans+dnJ/7h41sGL3CeQTfO+ZGxuO+Iw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.11.4'
+      hono: '>=4.12.4'
 
   '@ibm-cloud/watsonx-ai@1.7.8':
     resolution: {integrity: sha512-UpU/hTHRrCwzkqV1+H/CGbHIGRKty6SX1Aea2CBbyRonsEPIPQtFfhz8FHhs+o6Ca/TCupHNlcLAQUFektZmEQ==}
@@ -3230,8 +3230,8 @@ packages:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
 
-  hono@4.12.2:
-    resolution: {integrity: sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==}
+  hono@4.12.5:
+    resolution: {integrity: sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -5956,9 +5956,9 @@ snapshots:
 
   '@google/generative-ai@0.24.1': {}
 
-  '@hono/node-server@1.19.9(hono@4.12.2)':
+  '@hono/node-server@1.19.10(hono@4.12.5)':
     dependencies:
-      hono: 4.12.2
+      hono: 4.12.5
 
   '@ibm-cloud/watsonx-ai@1.7.8':
     dependencies:
@@ -6248,7 +6248,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(@cfworker/json-schema@4.1.1)(zod@3.24.2)':
     dependencies:
-      '@hono/node-server': 1.19.9(hono@4.12.2)
+      '@hono/node-server': 1.19.10(hono@4.12.5)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -6258,7 +6258,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.2.1(express@5.2.1)
-      hono: 4.12.2
+      hono: 4.12.5
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -7908,7 +7908,7 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
-  hono@4.12.2: {}
+  hono@4.12.5: {}
 
   html-encoding-sniffer@6.0.0:
     dependencies:
@@ -8784,7 +8784,7 @@ snapshots:
     dependencies:
       '@modelcontextprotocol/sdk': 1.27.1(@cfworker/json-schema@4.1.1)(zod@3.24.2)
       '@tsconfig/bun': 1.0.7
-      hono: 4.12.2
+      hono: 4.12.5
       zod: 3.24.2
       zod-to-json-schema: 3.24.1(zod@3.24.2)
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- Bumps `hono` override from `>=4.11.4` to `>=4.12.4` and direct dep from `^4.12.2` to `^4.12.4`
- Bumps `@hono/node-server` from `^1.13.7` to `^1.19.10`
- Resolves two high-severity `pnpm audit` findings:
  - [GHSA-q5qw-h33p-qvwr](https://github.com/advisories/GHSA-q5qw-h33p-qvwr) — arbitrary file access via `serveStatic`
  - [GHSA-wc8c-qw6v-h7f6](https://github.com/advisories/GHSA-wc8c-qw6v-h7f6) — auth bypass via encoded slashes

## Test plan

- [x] `pnpm audit` no longer reports hono/node-server vulnerabilities
- [x] Slack package tests pass (69/69)
- [x] Full monorepo typecheck passes

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)