### PR TITLE
fix(shared): harden database connection pool for Lambda

### DIFF
--- a/packages/core/src/agent/checkpointer.test.ts
+++ b/packages/core/src/agent/checkpointer.test.ts
@@ -1,48 +1,47 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockFromConnString, mockSetup, MockMemorySaver } = vi.hoisted(() => {
+const { MockPostgresSaver, mockSetup, MockMemorySaver } = vi.hoisted(() => {
   const mockSetup = vi.fn().mockResolvedValue(undefined);
-  const mockFromConnString = vi.fn().mockReturnValue({ setup: mockSetup });
+  const MockPostgresSaver = vi.fn().mockReturnValue({ setup: mockSetup });
   const MockMemorySaver = vi.fn();
-  return { mockFromConnString, mockSetup, MockMemorySaver };
+  return { MockPostgresSaver, mockSetup, MockMemorySaver };
 });
 
 vi.mock("@langchain/langgraph-checkpoint-postgres", () => ({
-  PostgresSaver: { fromConnString: mockFromConnString },
+  PostgresSaver: MockPostgresSaver,
 }));
 
 vi.mock("@langchain/langgraph", () => ({
   MemorySaver: MockMemorySaver,
 }));
 
+import type { Pool } from "pg";
 import {
   createPostgresCheckpointer,
   createMemoryCheckpointer,
 } from "./checkpointer.js";
 
 describe("createPostgresCheckpointer", () => {
+  const fakePool = { query: vi.fn() } as unknown as Pool;
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("calls PostgresSaver.fromConnString with the connection string", async () => {
-    await createPostgresCheckpointer("postgresql://localhost:5432/test");
+  it("constructs PostgresSaver with the provided pool", async () => {
+    await createPostgresCheckpointer(fakePool);
 
-    expect(mockFromConnString).toHaveBeenCalledWith(
-      "postgresql://localhost:5432/test",
-    );
+    expect(MockPostgresSaver).toHaveBeenCalledWith(fakePool);
   });
 
   it("calls setup() on the saver", async () => {
-    await createPostgresCheckpointer("postgresql://localhost:5432/test");
+    await createPostgresCheckpointer(fakePool);
 
     expect(mockSetup).toHaveBeenCalledOnce();
   });
 
   it("returns the saver instance", async () => {
-    const result = await createPostgresCheckpointer(
-      "postgresql://localhost:5432/test",
-    );
+    const result = await createPostgresCheckpointer(fakePool);
 
     expect(result).toEqual({ setup: mockSetup });
   });

--- a/packages/core/src/agent/checkpointer.ts
+++ b/packages/core/src/agent/checkpointer.ts
@@ -1,15 +1,20 @@
 import { PostgresSaver } from "@langchain/langgraph-checkpoint-postgres";
 import { MemorySaver } from "@langchain/langgraph";
 import type { BaseCheckpointSaver } from "@langchain/langgraph-checkpoint";
+import type { Pool } from "pg";
 
 /**
- * Creates a PostgresSaver checkpointer from a connection string.
+ * Creates a PostgresSaver checkpointer using an existing pool.
  * Calls `setup()` to ensure checkpoint tables exist (idempotent DDL).
+ *
+ * IMPORTANT: The returned checkpointer shares the provided pool.
+ * Do NOT call `checkpointer.end()` — it would destroy the shared pool.
+ * Pool lifecycle is managed by `closePool()` in `@usopc/shared`.
  */
 export async function createPostgresCheckpointer(
-  connString: string,
+  pool: Pool,
 ): Promise<BaseCheckpointSaver> {
-  const saver = PostgresSaver.fromConnString(connString);
+  const saver = new PostgresSaver(pool);
   await saver.setup();
   return saver;
 }

--- a/packages/core/src/agent/nodes/retrievalExpander.test.ts
+++ b/packages/core/src/agent/nodes/retrievalExpander.test.ts
@@ -338,4 +338,30 @@ describe("createRetrievalExpanderNode", () => {
     // Score is now an RRF fused score, not raw cosine distance
     expect(newDoc!.score).toBeGreaterThan(0);
   });
+
+  it("limits concurrent searches to avoid pool exhaustion (PERF-1)", async () => {
+    const queries = ["q1", "q2", "q3"];
+    setupMockModel(JSON.stringify(queries));
+
+    let concurrent = 0;
+    let maxConcurrent = 0;
+
+    const store: VectorStoreLike = {
+      similaritySearchWithScore: vi.fn().mockImplementation(async () => {
+        concurrent++;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        await new Promise((r) => setTimeout(r, 20));
+        concurrent--;
+        return [];
+      }),
+    };
+
+    const node = createRetrievalExpanderNode(store, mockModel, mockPool);
+    await node(makeState());
+
+    // MAX_CONCURRENT_SEARCHES = 2, so at most 2 vector searches at once
+    expect(maxConcurrent).toBeLessThanOrEqual(2);
+    // All 3 queries should still be executed
+    expect(store.similaritySearchWithScore).toHaveBeenCalledTimes(3);
+  });
 });

--- a/packages/core/src/agent/nodes/retrievalExpander.ts
+++ b/packages/core/src/agent/nodes/retrievalExpander.ts
@@ -26,6 +26,13 @@ const log = logger.child({ service: "retrieval-expander-node" });
 const RRF_K = 60;
 
 /**
+ * Max hybrid searches to run concurrently. Each search uses 2 pool
+ * connections (vector + BM25 in parallel), so this caps concurrent
+ * DB connections from the expander at MAX_CONCURRENT_SEARCHES * 2.
+ */
+const MAX_CONCURRENT_SEARCHES = 2;
+
+/**
  * Parses the JSON array of reformulated queries from the model response.
  * Returns an empty array if parsing fails.
  */
@@ -158,7 +165,9 @@ export function createRetrievalExpanderNode(
       const filter = buildFilter(state);
       const sqlFilter = buildSqlFilter(state);
 
-      const searchPromises = reformulatedQueries.map(async (query) => {
+      // Build search thunks (deferred execution) so we can limit concurrency.
+      // Each thunk uses 2 pool connections (vector + BM25 in parallel).
+      const searchThunks = reformulatedQueries.map((query) => async () => {
         const [vectorResults, textResults] = await Promise.all([
           vectorStoreSearch(
             () => vectorStore.similaritySearchWithScore(query, 5, filter),
@@ -185,7 +194,13 @@ export function createRetrievalExpanderNode(
         });
       });
 
-      const searchResults = await Promise.all(searchPromises);
+      // Execute with concurrency limit to avoid pool exhaustion (PERF-1).
+      const searchResults: Awaited<ReturnType<(typeof searchThunks)[0]>>[] = [];
+      for (let i = 0; i < searchThunks.length; i += MAX_CONCURRENT_SEARCHES) {
+        const batch = searchThunks.slice(i, i + MAX_CONCURRENT_SEARCHES);
+        const batchResults = await Promise.all(batch.map((fn) => fn()));
+        searchResults.push(...batchResults);
+      }
 
       // Merge with existing documents, deduplicating by content
       const seen = new Set(state.retrievedDocuments.map((d) => d.content));

--- a/packages/core/src/agent/runner.test.ts
+++ b/packages/core/src/agent/runner.test.ts
@@ -195,11 +195,11 @@ describe("AgentRunner", () => {
       expect(mockCreateAgentModels).toHaveBeenCalledOnce();
     });
 
-    it("creates Postgres checkpointer with databaseUrl", async () => {
+    it("creates Postgres checkpointer with shared pool", async () => {
       await AgentRunner.create(defaultConfig);
 
       expect(mockCreatePostgresCheckpointer).toHaveBeenCalledWith(
-        "postgresql://localhost:5432/test",
+        expect.objectContaining({ query: expect.any(Function) }),
       );
     });
 
@@ -549,7 +549,7 @@ describe("AgentRunner", () => {
       expect(mockEnd).toHaveBeenCalledOnce();
     });
 
-    it("closes checkpointer pool when it has an end() method", async () => {
+    it("does NOT close checkpointer pool (shared pool managed separately)", async () => {
       const mockCheckpointerEnd = vi.fn().mockResolvedValue(undefined);
       mockCreatePostgresCheckpointer.mockResolvedValue({
         end: mockCheckpointerEnd,
@@ -558,7 +558,7 @@ describe("AgentRunner", () => {
       const runner = await AgentRunner.create(defaultConfig);
       await runner.close();
 
-      expect(mockCheckpointerEnd).toHaveBeenCalledOnce();
+      expect(mockCheckpointerEnd).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/agent/runner.ts
+++ b/packages/core/src/agent/runner.ts
@@ -12,7 +12,7 @@ import { createPostgresCheckpointer } from "./checkpointer.js";
 import { GRAPH_CONFIG, createAgentModels } from "../config/index.js";
 import { withTimeout, TimeoutError } from "../utils/withTimeout.js";
 import { nodeMetrics } from "./nodeMetrics.js";
-import type { BaseCheckpointSaver } from "@langchain/langgraph-checkpoint";
+
 import type { Citation, EscalationInfo } from "../types/index.js";
 import type { AgentState } from "./state.js";
 
@@ -77,16 +77,13 @@ export function convertMessages(
 export class AgentRunner {
   private graph: ReturnType<typeof createAgentGraph>;
   private vectorStore: PGVectorStore;
-  private checkpointer: BaseCheckpointSaver | undefined;
 
   private constructor(
     graph: ReturnType<typeof createAgentGraph>,
     vectorStore: PGVectorStore,
-    checkpointer?: BaseCheckpointSaver,
   ) {
     this.graph = graph;
     this.vectorStore = vectorStore;
-    this.checkpointer = checkpointer;
   }
 
   /**
@@ -119,8 +116,9 @@ export class AgentRunner {
 
     log.info("Agent models constructed");
 
-    // Create checkpointer for graph state persistence (idempotent DDL)
-    const checkpointer = await createPostgresCheckpointer(config.databaseUrl);
+    // Create checkpointer using the shared pool (PERF-3: avoids a second
+    // unmanaged pool that would double connection usage per Lambda container)
+    const checkpointer = await createPostgresCheckpointer(getPool());
     log.info("Postgres checkpointer initialized");
 
     const graph = createAgentGraph(
@@ -134,18 +132,17 @@ export class AgentRunner {
       { checkpointer },
     );
 
-    return new AgentRunner(graph, vectorStore, checkpointer);
+    return new AgentRunner(graph, vectorStore);
   }
 
   /**
-   * Close the underlying connection pools (vector store + checkpointer).
-   * Call this when the runner is no longer needed to prevent connection leaks.
+   * Close the underlying vector store connection.
+   * The checkpointer shares the singleton pool (managed by closePool() in
+   * @usopc/shared), so we intentionally skip checkpointer.end() — calling
+   * it would destroy the shared pool for all consumers.
    */
   async close(): Promise<void> {
     await this.vectorStore.end();
-    if (this.checkpointer && "end" in this.checkpointer) {
-      await (this.checkpointer as { end: () => Promise<void> }).end();
-    }
   }
 
   /**

--- a/packages/shared/src/pool.test.ts
+++ b/packages/shared/src/pool.test.ts
@@ -6,6 +6,7 @@ vi.mock("pg", () => {
     idleCount: 2,
     waitingCount: 0,
     end: vi.fn(),
+    on: vi.fn(),
   };
   return { Pool: vi.fn(() => mockPool) };
 });
@@ -14,9 +15,19 @@ vi.mock("./env.js", () => ({
   getDatabaseUrl: vi.fn(() => "postgres://localhost/test"),
 }));
 
+vi.mock("./logger.js", () => ({
+  logger: {
+    error: vi.fn(),
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
 import { Pool } from "pg";
 import { getPool, closePool, getPoolStatus } from "./pool.js";
 import { getDatabaseUrl } from "./env.js";
+import { logger } from "./logger.js";
 
 const MockPool = vi.mocked(Pool);
 const mockGetDatabaseUrl = vi.mocked(getDatabaseUrl);
@@ -40,6 +51,40 @@ describe("pool", () => {
         idleConnections: 2,
         waitingRequests: 0,
       });
+    });
+  });
+
+  describe("pool size (PERF-1)", () => {
+    it("creates pool with max 10 connections", () => {
+      getPool();
+      expect(MockPool).toHaveBeenCalledWith(
+        expect.objectContaining({ max: 10 }),
+      );
+    });
+  });
+
+  describe("pool error handler (SEC-1)", () => {
+    it("registers an error handler on pool creation", () => {
+      getPool();
+      const mockPool = MockPool.mock.results[0]?.value;
+      expect(mockPool.on).toHaveBeenCalledWith("error", expect.any(Function));
+    });
+
+    it("logs error without crashing when idle connection fails", () => {
+      getPool();
+      const mockPool = MockPool.mock.results[0]?.value;
+      const errorHandler = (
+        mockPool.on.mock.calls as [string, (err: Error) => void][]
+      ).find((c) => c[0] === "error")?.[1];
+
+      expect(errorHandler).toBeDefined();
+      // Should not throw
+      errorHandler!(new Error("connection reset by peer"));
+
+      expect(logger.error).toHaveBeenCalledWith(
+        "Idle pool connection error (non-fatal)",
+        expect.objectContaining({ message: "connection reset by peer" }),
+      );
     });
   });
 

--- a/packages/shared/src/pool.ts
+++ b/packages/shared/src/pool.ts
@@ -1,5 +1,6 @@
 import { Pool } from "pg";
 import { getDatabaseUrl } from "./env.js";
+import { logger } from "./logger.js";
 
 let pool: Pool | null = null;
 
@@ -23,11 +24,21 @@ export function getPool(): Pool {
       connectionString.includes("sslmode=require");
     pool = new Pool({
       connectionString,
-      max: 5,
+      max: 10,
       idleTimeoutMillis: 30000,
       connectionTimeoutMillis: 5000,
       allowExitOnIdle: true,
       ...(needsSsl ? { ssl: true } : {}),
+    });
+
+    // Prevent process crash on idle connection backend errors (SEC-1).
+    // When Neon suspends compute or a network blip occurs, idle connections
+    // emit 'error' events. Without a handler Node treats these as uncaught
+    // exceptions. The pool automatically removes dead connections.
+    pool.on("error", (err) => {
+      logger.error("Idle pool connection error (non-fatal)", {
+        message: err.message,
+      });
     });
   }
   return pool;


### PR DESCRIPTION
## Summary

Addresses three related connection pool management issues identified in the comprehensive code review (SEC-1, PERF-1, PERF-3):

- **SEC-1 (High, CVSS 7.5)**: Add `pool.on('error')` handler to prevent Lambda crashes on idle connection backend errors (Neon suspends, network blips)
- **PERF-1 (High)**: Increase pool `max` from 5 to 10 to handle parallel hybrid search without connection exhaustion
- **PERF-3 (High)**: Share singleton pool with PostgresSaver checkpointer instead of creating a second unmanaged pool — eliminates 10 extra connections per Lambda container
- **PERF-1 complement**: Add concurrency limit (`MAX_CONCURRENT_SEARCHES=2`) to retrieval expander, capping fan-out at 4 concurrent DB connections

### Key design decision

`PostgresSaver.end()` calls `pool.end()` internally. Since the checkpointer now shares the singleton pool, `runner.close()` no longer calls `checkpointer.end()` — pool lifecycle is managed by `closePool()` in `@usopc/shared`.

## Test plan

- [x] `pnpm --filter @usopc/shared test` — pool error handler and size tests pass (294 tests)
- [x] `pnpm --filter @usopc/core test` — checkpointer, runner, and retrieval expander tests pass (751 tests)
- [x] `pnpm typecheck` — full monorepo type-checks clean
- [x] Verified no other call site passes a string to `createPostgresCheckpointer`

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)