### PR TITLE
fix(ingestion): add parser.destroy() cleanup to PDF loader

### DIFF
--- a/packages/ingestion/src/loaders/pdfLoader.test.ts
+++ b/packages/ingestion/src/loaders/pdfLoader.test.ts
@@ -30,14 +30,18 @@ vi.mock("./fetchWithRetry.js", () => ({
   },
 }));
 
-// pdf-parse v2 API: PDFParse class with getText() method.
+// pdf-parse v2 API: PDFParse class with getText() and destroy() methods.
 // getText() returns { text: string, total: number } where total is page count.
 const mockGetText = vi.fn();
+const mockDestroy = vi.fn();
 vi.mock("pdf-parse", () => ({
   PDFParse: class {
     constructor(public opts: { data: Buffer }) {}
     getText() {
       return mockGetText();
+    }
+    destroy() {
+      return mockDestroy();
     }
   },
 }));
@@ -208,6 +212,55 @@ describe("loadPdf", () => {
 
       expect(mockFetchWithRetry).toHaveBeenCalledTimes(1);
       expect(docs[0]!.pageContent).toBe("Content after retry");
+    });
+  });
+
+  describe("parser cleanup", () => {
+    it("calls parser.destroy() after successful parse", async () => {
+      const pdfBuffer = Buffer.from("fake pdf content");
+      mockReadFile.mockResolvedValueOnce(pdfBuffer);
+      mockDestroy.mockResolvedValueOnce(undefined);
+      mockGetText.mockResolvedValueOnce({
+        text: "Parsed content",
+        total: 2,
+      });
+
+      await loadPdf("/path/to/valid.pdf");
+
+      expect(mockDestroy).toHaveBeenCalledOnce();
+    });
+
+    it("calls parser.destroy() even when parsing throws", async () => {
+      const pdfContent = new ArrayBuffer(100);
+      mockFetchWithRetry.mockResolvedValueOnce(
+        createMockPdfResponse(pdfContent),
+      );
+      mockDestroy.mockResolvedValueOnce(undefined);
+      mockGetText.mockRejectedValueOnce(new Error("Invalid PDF structure"));
+
+      await expect(loadPdf("https://example.com/doc.pdf")).rejects.toThrow(
+        "Invalid PDF structure",
+      );
+
+      expect(mockDestroy).toHaveBeenCalledOnce();
+    });
+
+    it("calls parser.destroy() even when text is empty", async () => {
+      const pdfContent = new ArrayBuffer(100);
+      mockFetchWithRetry.mockResolvedValueOnce(
+        createMockPdfResponse(pdfContent),
+      );
+      mockDestroy.mockResolvedValueOnce(undefined);
+      mockGetText.mockResolvedValueOnce({
+        text: "",
+        total: 1,
+      });
+
+      await expect(loadPdf("https://example.com/doc.pdf")).rejects.toThrow(
+        "no extractable text",
+      );
+
+      expect(mockDestroy).toHaveBeenCalledOnce();
     });
   });
 

--- a/packages/ingestion/src/loaders/pdfLoader.ts
+++ b/packages/ingestion/src/loaders/pdfLoader.ts
@@ -75,20 +75,24 @@ export async function loadPdf(
   }
 
   const parser = new PDFParse({ data: buffer });
-  const parsed = await withParseTimeout(parser.getText(), 60_000, source);
+  try {
+    const parsed = await withParseTimeout(parser.getText(), 60_000, source);
 
-  if (!parsed.text || parsed.text.trim().length === 0) {
-    throw new Error(`PDF at ${source} produced no extractable text`);
+    if (!parsed.text || parsed.text.trim().length === 0) {
+      throw new Error(`PDF at ${source} produced no extractable text`);
+    }
+
+    return [
+      new Document({
+        pageContent: parsed.text,
+        metadata: {
+          source,
+          format: "pdf",
+          pages: parsed.total,
+        },
+      }),
+    ];
+  } finally {
+    await parser.destroy();
   }
-
-  return [
-    new Document({
-      pageContent: parsed.text,
-      metadata: {
-        source,
-        format: "pdf",
-        pages: parsed.total,
-      },
-    }),
-  ];
 }


### PR DESCRIPTION
## Summary

- Wrap pdf-parse `getText()` call in `try/finally` to ensure `parser.destroy()` is always called, preventing resource leaks
- Inspired by [langchain-ai/langchainjs#10251](https://github.com/langchain-ai/langchainjs/pull/10251) which adds the same cleanup to LangChain's `PDFLoader`
- Add 3 tests verifying `destroy()` is called on success, parse error, and empty-text error

Closes #497

## Test plan

- [x] All 22 pdfLoader tests pass (`pnpm --filter @usopc/ingestion test`)
- [x] Full monorepo typecheck passes (`pnpm typecheck`)
- [x] Prettier formatting verified