### PR TITLE
fix(core): prevent clarification loop and default to Olympics (#508)

### DIFF
--- a/packages/core/src/agent/nodes/classifier.test.ts
+++ b/packages/core/src/agent/nodes/classifier.test.ts
@@ -565,6 +565,113 @@ describe("classifierNode", () => {
       expect(result.needsClarification).toBe(false);
       expect(result.topicDomain).toBe("athlete_rights");
     });
+
+    it("suppresses re-clarification after user answers a clarification question", async () => {
+      // LLM incorrectly returns needsClarification=true even though user just answered
+      mockInvoke.mockResolvedValueOnce(
+        classifierResponse({
+          topicDomain: "team_selection",
+          detectedNgbIds: ["us-ski-snowboard"],
+          queryIntent: "procedural",
+          hasTimeConstraint: false,
+          shouldEscalate: false,
+          needsClarification: true,
+          clarificationQuestion:
+            "Which competition are you asking about — the Olympics, World Championships, or something else?",
+        }),
+      );
+
+      const state = makeState({
+        messages: [
+          new HumanMessage("How does team selection for super g downhill?"),
+          new AIMessage(
+            "Which competition are you asking about — the Olympics, World Championships, or something else?",
+          ),
+          new HumanMessage("Olympic games"),
+        ],
+      });
+
+      const result = await classifierNode(state);
+      // Guard A should suppress re-clarification
+      expect(result.needsClarification).toBe(false);
+      expect(result.clarificationQuestion).toBeUndefined();
+    });
+
+    it("defaults team_selection to Olympics when competition not specified", async () => {
+      // LLM asks which competition for a team_selection query — Guard B defaults to Olympics
+      mockInvoke.mockResolvedValueOnce(
+        classifierResponse({
+          topicDomain: "team_selection",
+          detectedNgbIds: ["us-ski-snowboard"],
+          queryIntent: "procedural",
+          hasTimeConstraint: false,
+          shouldEscalate: false,
+          needsClarification: true,
+          clarificationQuestion:
+            "Which competition are you asking about — the Olympics, World Championships, or something else?",
+        }),
+      );
+
+      const state = makeState({
+        messages: [
+          new HumanMessage("How does team selection for super g downhill?"),
+        ],
+      });
+
+      const result = await classifierNode(state);
+      // Guard B should suppress competition clarification for team_selection
+      expect(result.needsClarification).toBe(false);
+      expect(result.clarificationQuestion).toBeUndefined();
+    });
+
+    it("does NOT suppress when clarification is about sport, not competition", async () => {
+      mockInvoke.mockResolvedValueOnce(
+        classifierResponse({
+          topicDomain: "team_selection",
+          detectedNgbIds: [],
+          queryIntent: "factual",
+          hasTimeConstraint: false,
+          shouldEscalate: false,
+          needsClarification: true,
+          clarificationQuestion:
+            "That's a great question — which sport is this about?",
+        }),
+      );
+
+      const state = makeState({
+        messages: [new HumanMessage("What are the selection criteria?")],
+      });
+
+      const result = await classifierNode(state);
+      // Sport clarification should NOT be suppressed
+      expect(result.needsClarification).toBe(true);
+      expect(result.clarificationQuestion).toBe(
+        "That's a great question — which sport is this about?",
+      );
+    });
+
+    it("does NOT suppress clarification on first turn with no prior AI message", async () => {
+      mockInvoke.mockResolvedValueOnce(
+        classifierResponse({
+          topicDomain: "eligibility",
+          detectedNgbIds: [],
+          queryIntent: "factual",
+          hasTimeConstraint: false,
+          shouldEscalate: false,
+          needsClarification: true,
+          clarificationQuestion:
+            "Happy to help with that. Which sport are you asking about?",
+        }),
+      );
+
+      const state = makeState({
+        messages: [new HumanMessage("What are the age requirements?")],
+      });
+
+      const result = await classifierNode(state);
+      // First turn, no prior AI message → Guard A should not fire
+      expect(result.needsClarification).toBe(true);
+    });
   });
 
   describe("universal framework questions do not request clarification", () => {

--- a/packages/core/src/agent/nodes/classifier.ts
+++ b/packages/core/src/agent/nodes/classifier.ts
@@ -13,6 +13,7 @@ import {
 } from "../../services/llmService.js";
 import {
   buildContextualQuery,
+  wasFollowUpToClarification,
   stateContext,
   parseLlmJson,
 } from "../../utils/index.js";
@@ -159,6 +160,27 @@ export function parseClassifierResponse(raw: string): ParseResult {
 }
 
 /**
+ * Keywords that indicate a clarification question is asking about which
+ * competition (Olympic vs World Championships vs etc). Used by Guard B
+ * to default team_selection queries to the upcoming Olympic/Paralympic Games.
+ */
+const COMPETITION_KEYWORDS = [
+  "competition",
+  "event",
+  "olympic",
+  "paralympic",
+  "games",
+  "world championships",
+  "which team",
+];
+
+function isCompetitionClarification(question: string | undefined): boolean {
+  if (!question) return false;
+  const lower = question.toLowerCase();
+  return COMPETITION_KEYWORDS.some((kw) => lower.includes(kw));
+}
+
+/**
  * CLASSIFIER node.
  *
  * Analyzes the latest user message using Claude Haiku to extract:
@@ -205,6 +227,35 @@ export function createClassifierNode(model: BaseChatModel) {
           warnings,
           ...stateContext(state),
         });
+      }
+
+      // Guard A — Loop prevention: if the user just answered a clarification,
+      // never re-ask. The LLM sometimes ignores the "do not re-ask" prompt.
+      if (
+        result.needsClarification &&
+        wasFollowUpToClarification(state.messages)
+      ) {
+        log.info("Suppressed re-clarification (loop prevention guard)", {
+          ...stateContext(state),
+        });
+        result.needsClarification = false;
+        result.clarificationQuestion = undefined;
+      }
+
+      // Guard B — Olympic/Paralympic default: when a team_selection query
+      // triggers a competition clarification, default to the upcoming
+      // Olympic/Paralympic Games instead of asking.
+      if (
+        result.needsClarification &&
+        result.topicDomain === "team_selection" &&
+        isCompetitionClarification(result.clarificationQuestion)
+      ) {
+        log.info(
+          "Suppressed competition clarification (Olympic/Paralympic default)",
+          { ...stateContext(state) },
+        );
+        result.needsClarification = false;
+        result.clarificationQuestion = undefined;
       }
 
       log.info("Classification complete", {

--- a/packages/core/src/prompts/classifier.ts
+++ b/packages/core/src/prompts/classifier.ts
@@ -65,7 +65,7 @@ This distinction helps downstream responses include appropriate guidance (e.g., 
 
 ### needsClarification (required)
 Boolean. True if the query is too ambiguous to answer accurately. Set this to true when:
-- The query mentions "selection" without specifying which team or competition (e.g., Olympic Games, Paralympic Games, World Championships, World Cup, World Series, Grand Prix, Pan American Games, Continental Championships, etc.)
+- When a team_selection query specifies a sport but not a competition, default to the upcoming Olympic/Paralympic Games — do NOT ask which competition. Only ask if neither sport nor competition is specified and the query is genuinely too vague.
 - Multiple NGBs could apply and it's unclear which one (e.g., "swimming" could be USA Swimming or US Paralympics Swimming)
 - The timeframe is ambiguous (e.g., "upcoming games" without specifying which)
 - The query is too vague to retrieve relevant documents (e.g., "What are the rules?")
@@ -193,6 +193,8 @@ Use this context from prior exchanges to inform your classification:
 3. **Respect general framing**: If the conversation has been general (no specific sport/NGB), the user likely wants general information. Provide general answers rather than demanding specificity. You may note that details vary by sport, but do not block the response.
 
 4. **Build progressively**: In follow-up questions, provide the best answer you can with the context available. If additional specificity would help, mention it in your response — but do not gate the response behind a clarification question.
+
+5. **Never re-ask after a clarification response**: If the previous assistant message was a clarification question and the user has now responded, treat the response as the answer. Do NOT set needsClarification=true — proceed with classification using the information provided.
 
 ${conversationHistory}
 

--- a/packages/core/src/utils/conversationContext.test.ts
+++ b/packages/core/src/utils/conversationContext.test.ts
@@ -5,6 +5,7 @@ import {
   formatConversationHistory,
   buildContextualQuery,
   getMaxTurns,
+  wasFollowUpToClarification,
 } from "./conversationContext.js";
 
 describe("conversationContext", () => {
@@ -132,6 +133,53 @@ describe("conversationContext", () => {
       // Should truncate to ~500 chars with ellipsis
       expect(result.length).toBeLessThan(longMessage.length);
       expect(result).toContain("...");
+    });
+  });
+
+  describe("wasFollowUpToClarification", () => {
+    it("returns false for fewer than 3 messages", () => {
+      const messages = [
+        new HumanMessage("Hello"),
+        new AIMessage("Which sport?"),
+      ];
+      expect(wasFollowUpToClarification(messages)).toBe(false);
+    });
+
+    it("returns false when previous message is HumanMessage", () => {
+      const messages = [
+        new HumanMessage("Hello"),
+        new HumanMessage("Olympic games"),
+        new HumanMessage("Another question"),
+      ];
+      expect(wasFollowUpToClarification(messages)).toBe(false);
+    });
+
+    it("returns true when previous AIMessage is short and ends with ?", () => {
+      const messages = [
+        new HumanMessage("How does team selection work for super g?"),
+        new AIMessage("Which competition are you asking about?"),
+        new HumanMessage("Olympic games"),
+      ];
+      expect(wasFollowUpToClarification(messages)).toBe(true);
+    });
+
+    it("returns false when previous AIMessage is long (>300 chars)", () => {
+      const longAnswer = "A".repeat(301) + "?";
+      const messages = [
+        new HumanMessage("How does team selection work?"),
+        new AIMessage(longAnswer),
+        new HumanMessage("Tell me more"),
+      ];
+      expect(wasFollowUpToClarification(messages)).toBe(false);
+    });
+
+    it("returns false when previous AIMessage does not end with ?", () => {
+      const messages = [
+        new HumanMessage("How does team selection work?"),
+        new AIMessage("Here is how team selection works."),
+        new HumanMessage("Thanks"),
+      ];
+      expect(wasFollowUpToClarification(messages)).toBe(false);
     });
   });
 

--- a/packages/core/src/utils/conversationContext.ts
+++ b/packages/core/src/utils/conversationContext.ts
@@ -122,6 +122,23 @@ export interface ContextualQuery {
  * @param options - Formatting options
  * @returns Object with currentMessage and conversationContext
  */
+/**
+ * Detects if the current message is a follow-up to a prior clarification question.
+ * Used as a programmatic guard to prevent clarification loops — if the agent
+ * just asked a clarification question and the user responded, we should never
+ * re-ask for clarification.
+ */
+export function wasFollowUpToClarification(messages: BaseMessage[]): boolean {
+  // Need at least 3 messages: original question, AI clarification, user follow-up
+  if (messages.length < 3) return false;
+  const prev = messages[messages.length - 2];
+  if (!prev || prev._getType() !== "ai") return false;
+  const content = typeof prev.content === "string" ? prev.content : "";
+  // Clarification messages are short (<300 chars) and end with "?"
+  // Normal synthesized answers are much longer with citations/disclaimers
+  return content.length < 300 && content.trimEnd().endsWith("?");
+}
+
 export function buildContextualQuery(
   messages: BaseMessage[],
   options?: FormatHistoryOptions,

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -2,6 +2,7 @@ export {
   formatConversationHistory,
   buildContextualQuery,
   getMaxTurns,
+  wasFollowUpToClarification,
   type FormatHistoryOptions,
   type ContextualQuery,
 } from "./conversationContext.js";


### PR DESCRIPTION
## Summary

Fixes #508 — the agent would repeat the same clarification question after the user already answered it, and unnecessarily asked which competition for team selection queries.

- **Guard A (loop prevention)**: When the previous AI message was a clarification question (short + ends with `?`) and the user responded, force `needsClarification = false` — never re-ask
- **Guard B (Olympic/Paralympic default)**: When a `team_selection` query triggers a competition clarification (keyword match on "competition", "olympic", "games", etc.), suppress it and default to the upcoming Olympic/Paralympic Games
- **Prompt updates**: Narrowed the `needsClarification` rule for team selection to default to Olympics, added rule 5 ("never re-ask after a clarification response") to the conversation history section
- **`wasFollowUpToClarification()` helper**: Detects if the current message follows a prior clarification question, exported from `utils/`

## Files changed

| File | Change |
|------|--------|
| `packages/core/src/utils/conversationContext.ts` | Added `wasFollowUpToClarification()` |
| `packages/core/src/utils/index.ts` | Export new helper |
| `packages/core/src/agent/nodes/classifier.ts` | Added Guards A & B + `isCompetitionClarification` helper |
| `packages/core/src/prompts/classifier.ts` | Updated needsClarification rules + added history rule 5 |
| `packages/core/src/utils/conversationContext.test.ts` | 5 tests for `wasFollowUpToClarification` |
| `packages/core/src/agent/nodes/classifier.test.ts` | 4 tests for guard behavior |

## Test plan

- [x] `pnpm --filter @usopc/core test` — 787 tests pass
- [x] `pnpm typecheck` — full monorepo passes
- [x] `npx prettier --write` — all files formatted
- [ ] Manual test: ask "how does team selection for super g downhill?" → should answer assuming Olympics, no competition clarification
- [ ] Manual test: after clarification question, reply "Olympic games" → should proceed, not re-ask

🤖 Generated with [Claude Code](https://claude.com/claude-code)