### PR TITLE
fix(web): duplicate messages in multi-turn conversations (#513)

### DIFF
--- a/apps/web/app/api/chat/route.test.ts
+++ b/apps/web/app/api/chat/route.test.ts
@@ -432,6 +432,70 @@ describe("authentication (SEC-04)", () => {
   });
 });
 
+describe("duplicate message prevention (#513)", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    shouldFailInit = false;
+    initCallCount = 0;
+    vi.resetModules();
+  });
+
+  function makeReq(body: Record<string, unknown>) {
+    return new Request("http://localhost/api/chat", {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const validUuid = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+  it("sends only the last message when conversationId is present", async () => {
+    const { POST } = await importRoute();
+    const { AgentRunner } = await import("@usopc/core");
+    const convertMessages = vi.mocked(AgentRunner.convertMessages);
+
+    await POST(
+      makeReq({
+        messages: [
+          { role: "user", parts: [{ type: "text", text: "First" }] },
+          { role: "assistant", parts: [{ type: "text", text: "Reply" }] },
+          { role: "user", parts: [{ type: "text", text: "Second" }] },
+        ],
+        conversationId: validUuid,
+      }),
+    );
+
+    // Should only receive the last message (slice(-1))
+    expect(convertMessages).toHaveBeenCalledWith([
+      { role: "user", content: "Second" },
+    ]);
+  });
+
+  it("sends all messages when conversationId is absent", async () => {
+    const { POST } = await importRoute();
+    const { AgentRunner } = await import("@usopc/core");
+    const convertMessages = vi.mocked(AgentRunner.convertMessages);
+
+    await POST(
+      makeReq({
+        messages: [
+          { role: "user", parts: [{ type: "text", text: "First" }] },
+          { role: "assistant", parts: [{ type: "text", text: "Reply" }] },
+          { role: "user", parts: [{ type: "text", text: "Second" }] },
+        ],
+      }),
+    );
+
+    // Should receive all messages
+    expect(convertMessages).toHaveBeenCalledWith([
+      { role: "user", content: "First" },
+      { role: "assistant", content: "Reply" },
+      { role: "user", content: "Second" },
+    ]);
+  });
+});
+
 describe("conversation summary loading (TEST-02)", () => {
   beforeEach(async () => {
     vi.clearAllMocks();

--- a/apps/web/app/api/chat/route.ts
+++ b/apps/web/app/api/chat/route.ts
@@ -94,7 +94,11 @@ export async function POST(req: Request) {
       role: m.role,
       content: getTextFromParts(m.parts),
     }));
-    const langchainMessages = AgentRunner.convertMessages(plainMessages);
+    // When continuing a conversation, only send the new message —
+    // the checkpoint already has the full history via thread_id.
+    const langchainMessages = conversationId
+      ? AgentRunner.convertMessages(plainMessages.slice(-1))
+      : AgentRunner.convertMessages(plainMessages);
     const stateStream = runner.stream({
       messages: langchainMessages,
       userSport,


### PR DESCRIPTION
## Summary

- Multi-turn conversations accumulated duplicate messages because the web client sent full history AND LangGraph loaded it from the checkpoint — the `add-messages` reducer appended both
- When continuing a conversation (`conversationId` is set), only the last message is now sent to the runner — the checkpoint already has the full history via `thread_id`
- Slack was not affected (already sends only a single message per turn)

Part of #509.

## Confidence

**90%** — The fix is surgical (one conditional on a single line), the root cause is clearly documented in the issue, and the behavior matches the Slack client which already works correctly. Two new tests verify both branches of the conditional. Residual uncertainty: no end-to-end test with a real LangGraph checkpoint to confirm deduplication in production.

## Test plan

- [x] Existing tests pass (26/26)
- [x] New tests cover: sends only last message when conversationId present, sends all messages when absent
- [x] Full monorepo typecheck passes

Closes #513