### PR TITLE
fix(core): overly aggressive Ombuds disclaimer on team_selection (#514)

### DIFF
--- a/packages/core/src/prompts/disclaimer.test.ts
+++ b/packages/core/src/prompts/disclaimer.test.ts
@@ -33,6 +33,18 @@ describe("getDisclaimer", () => {
     });
   }
 
+  it("team_selection disclaimer does not contain dispute language", () => {
+    const disclaimer = getDisclaimer("team_selection");
+    expect(disclaimer).not.toContain("made in error");
+    expect(disclaimer).not.toContain("ombudsman@usathlete.org");
+  });
+
+  it("dispute_resolution disclaimer still contains Ombuds contact info", () => {
+    const disclaimer = getDisclaimer("dispute_resolution");
+    expect(disclaimer).toContain("ombudsman@usathlete.org");
+    expect(disclaimer).toContain("719-866-5000");
+  });
+
   it("all domain disclaimers include the general not-legal-advice text", () => {
     const domains: TopicDomain[] = [
       "team_selection",

--- a/packages/core/src/prompts/disclaimer.ts
+++ b/packages/core/src/prompts/disclaimer.ts
@@ -47,9 +47,7 @@ const ATHLETE_RIGHTS_DISCLAIMER =
 const TEAM_SELECTION_DISCLAIMER =
   GENERAL_DISCLAIMER +
   "\n\nTeam selection procedures vary by sport and event. Always refer to the specific " +
-  "NGB's published selection procedures for the competition in question. " +
-  "If you believe a selection decision was made in error, contact the Athlete Ombuds " +
-  "at ombudsman@usathlete.org or 719-866-5000 for guidance on your options.";
+  "NGB's published selection procedures for the competition in question.";
 
 const ELIGIBILITY_DISCLAIMER =
   GENERAL_DISCLAIMER +


### PR DESCRIPTION
## Summary

- `TEAM_SELECTION_DISCLAIMER` unconditionally included dispute-specific language ("If you believe a selection decision was made in error, contact the Athlete Ombuds...") on every team_selection response, even purely informational queries
- Removed the dispute-specific sentence from `TEAM_SELECTION_DISCLAIMER` — the `dispute_resolution` domain already has its own disclaimer with full Ombuds contact info, so no information is lost
- Added 2 tests: one asserting team_selection no longer contains dispute language, one asserting dispute_resolution still contains Ombuds contact info

## Confidence

**95%** — The fix is a straightforward string removal in a single constant. The dispute_resolution disclaimer independently provides full Ombuds contact info, so no user-facing information is lost. All 789 existing tests pass, full monorepo typecheck is clean, and 2 new tests guard the boundary between these two domains.

## Test plan

- [x] Existing tests pass (789/789)
- [x] New tests cover the fixed behavior (team_selection lacks dispute language, dispute_resolution retains Ombuds info)
- [x] Full typecheck passes

Closes #514
Related to #509

Generated with [Claude Code](https://claude.ai/claude-code)