### PR TITLE
perf(ingestion): adaptive rate limiting for embedding pipeline

### DIFF
--- a/packages/ingestion/src/pipeline.test.ts
+++ b/packages/ingestion/src/pipeline.test.ts
@@ -71,7 +71,12 @@ vi.mock("./transformers/metadataEnricher.js", () => ({
 // Now import the module under test
 import {
   QuotaExhaustedError,
+  TokenRateLimiter,
+  TPM_LIMIT,
+  TPM_HEADROOM,
+  RATE_WINDOW_MS,
   ingestSource,
+  ingestAll,
   type IngestionSource,
 } from "./pipeline.js";
 import { loadPdf } from "./loaders/pdfLoader.js";
@@ -266,5 +271,89 @@ describe("ingestSource", () => {
     expect(result.status).toBe("failed");
     expect(result.error).toBe("timeout");
     expect(mockAddVectors).toHaveBeenCalledTimes(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TokenRateLimiter
+// ---------------------------------------------------------------------------
+
+describe("TokenRateLimiter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("skips sleep when token budget has headroom", async () => {
+    const limiter = new TokenRateLimiter();
+    const sleepSpy = vi.spyOn(globalThis, "setTimeout");
+
+    // Small batch well under the 32K effective budget
+    await limiter.waitIfNeeded(1_000);
+
+    // setTimeout is only called by sleep() when waiting — no rate-limit
+    // sleep should have been triggered (setTimeout may be called by other
+    // internals, but not with a delay > 1s).
+    const rateLimitCalls = sleepSpy.mock.calls.filter(
+      (call) => typeof call[1] === "number" && call[1] > 1_000,
+    );
+    expect(rateLimitCalls).toHaveLength(0);
+
+    sleepSpy.mockRestore();
+  });
+
+  it("waits when approaching TPM limit", async () => {
+    const limiter = new TokenRateLimiter();
+    const budget = TPM_LIMIT * TPM_HEADROOM; // 32_000
+
+    // Pre-fill the limiter near the budget
+    limiter.record(budget - 1_000);
+
+    // Next batch of 5_000 tokens exceeds the budget — should trigger a wait
+    const promise = limiter.waitIfNeeded(5_000);
+    // Advance past the rate window + buffer so the sleep resolves
+    await vi.advanceTimersByTimeAsync(RATE_WINDOW_MS + 1_000);
+    await promise;
+
+    // If we get here without hanging, the limiter correctly waited and resumed
+    expect(true).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ingestAll — shared rate limiter
+// ---------------------------------------------------------------------------
+
+describe("ingestAll", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mockEmbedDocuments.mockResolvedValue([new Array(1536).fill(0)]);
+    mockAddVectors.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("shares rate limiter across sources without fixed 15s gaps", async () => {
+    const sources: IngestionSource[] = [
+      { ...SOURCE, id: "source-1" },
+      { ...SOURCE, id: "source-2" },
+    ];
+
+    const start = Date.now();
+    const result = await ingestAll(sources, OPTIONS);
+    const elapsed = Date.now() - start;
+
+    expect(result).toHaveLength(2);
+    expect(result[0]!.status).toBe("completed");
+    expect(result[1]!.status).toBe("completed");
+    // With small documents there's plenty of TPM headroom — no 15s sleep
+    // should occur between sources. Allow up to 1s for test overhead.
+    expect(elapsed).toBeLessThan(1_000);
   });
 });

--- a/packages/ingestion/src/pipeline.ts
+++ b/packages/ingestion/src/pipeline.ts
@@ -136,6 +136,42 @@ function batchByTokenBudget(docs: Document[], maxTokens: number): Document[][] {
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+// ---------------------------------------------------------------------------
+// Adaptive rate limiting
+// ---------------------------------------------------------------------------
+
+export const TPM_LIMIT = 40_000;
+export const TPM_HEADROOM = 0.8; // use 80% of limit = 32K effective
+export const RATE_WINDOW_MS = 60_000;
+
+export class TokenRateLimiter {
+  private log: { time: number; tokens: number }[] = [];
+
+  record(tokens: number): void {
+    this.log.push({ time: Date.now(), tokens });
+  }
+
+  async waitIfNeeded(nextTokens: number): Promise<void> {
+    const now = Date.now();
+    this.log = this.log.filter((e) => now - e.time < RATE_WINDOW_MS);
+    const consumed = this.log.reduce((sum, e) => sum + e.tokens, 0);
+    const budget = TPM_LIMIT * TPM_HEADROOM;
+
+    if (consumed + nextTokens > budget) {
+      const oldest = this.log[0]!.time;
+      const waitMs = RATE_WINDOW_MS - (now - oldest) + 500;
+      if (waitMs > 0) {
+        logger.info(`Rate limiter: waiting ${(waitMs / 1000).toFixed(1)}s ...`);
+        await sleep(waitMs);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Embedding helpers
+// ---------------------------------------------------------------------------
+
 const EMBED_BATCH_MAX_RETRIES = 2;
 const EMBED_BATCH_RETRY_DELAY_MS = 30_000;
 
@@ -223,6 +259,7 @@ export async function ingestSource(
     s3Key?: string | undefined;
     content?: Buffer | undefined;
     vectorStore?: Awaited<ReturnType<typeof createVectorStore>> | undefined;
+    rateLimiter?: TokenRateLimiter | undefined;
   },
 ): Promise<IngestionResult> {
   logger.info(`Starting ingestion for source: ${source.id}`, {
@@ -272,21 +309,20 @@ export async function ingestSource(
       options.vectorStore ?? (await createVectorStore(embeddings));
 
     // Use small batches (~8K tokens) to avoid OpenAI 500 errors on large
-    // payloads, with a 15s inter-batch delay to stay under the 40K TPM limit
-    // (8K per 15s ≈ 32K/min, leaving headroom).
+    // payloads. Adaptive rate limiting sleeps only when approaching the TPM cap.
     const batches = batchByTokenBudget(enriched, 8_000);
+    const limiter = options.rateLimiter ?? new TokenRateLimiter();
     logger.info(
       `Embedding ${enriched.length} chunks in ${batches.length} batch(es)`,
       { sourceId: source.id },
     );
 
     for (let i = 0; i < batches.length; i++) {
-      if (i > 0) {
-        logger.info(`Waiting 15s before batch ${i + 1}/${batches.length}...`, {
-          sourceId: source.id,
-        });
-        await sleep(15_000);
-      }
+      const batchTokens = batches[i]!.reduce(
+        (sum, doc) => sum + estimateTokens(doc.pageContent),
+        0,
+      );
+      await limiter.waitIfNeeded(batchTokens);
       await embedBatchWithRetry(
         vectorStore,
         embeddings,
@@ -296,6 +332,7 @@ export async function ingestSource(
         i,
         batches.length,
       );
+      limiter.record(batchTokens);
       logger.info(
         `Batch ${i + 1}/${batches.length} complete (${batches[i]!.length} chunks)`,
         { sourceId: source.id },
@@ -348,17 +385,16 @@ export async function ingestAll(
   const embeddings = createRawEmbeddings(options.openaiApiKey);
   const vectorStore = await createVectorStore(embeddings);
 
+  // Shared rate limiter tracks token consumption across all sources so
+  // inter-source gaps are only as long as actually needed.
+  const rateLimiter = new TokenRateLimiter();
+
   const results: IngestionResult[] = [];
   for (let i = 0; i < sources.length; i++) {
-    // Wait between sources to avoid TPM overlap from the previous source's
-    // last batch. Skip the delay for the first source.
-    if (i > 0 && results[i - 1]!.status === "completed") {
-      logger.info("Waiting 15s between sources for TPM window reset...");
-      await sleep(15_000);
-    }
     const result = await ingestSource(sources[i]!, {
       openaiApiKey: options.openaiApiKey,
       vectorStore,
+      rateLimiter,
     });
     results.push(result);
   }


### PR DESCRIPTION
## Summary

- Replace fixed 15-second inter-batch and inter-source sleeps with a `TokenRateLimiter` class that tracks token consumption over a sliding 60-second window
- Only sleeps when actually approaching the 40K TPM limit (80% headroom = 32K effective), significantly reducing total pipeline runtime for multi-source ingestion
- Shared rate limiter instance across sources in `ingestAll` eliminates redundant inter-source delays

## Test plan

- [x] `pnpm --filter @usopc/ingestion test` — 282 tests pass (3 new rate limiter tests)
- [x] `pnpm typecheck` — clean across all 6 packages
- [x] `npx prettier --write` — no formatting changes needed
- [ ] Verify in staging that multi-source ingestion completes faster without hitting TPM errors

Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)