### PR TITLE
fix(core): add query length limit for BM25 websearch_to_tsquery

### DIFF
--- a/packages/core/src/rag/bm25Search.test.ts
+++ b/packages/core/src/rag/bm25Search.test.ts
@@ -133,6 +133,27 @@ describe("bm25Search", () => {
     expect(params[params.length - 1]).toBe(5);
   });
 
+  it("truncates queries longer than 500 characters", async () => {
+    const pool = makeMockPool([]);
+    const longQuery = "a".repeat(1000);
+
+    await bm25Search(pool, { query: longQuery });
+
+    const call = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const params = call[1] as unknown[];
+    expect((params[0] as string).length).toBe(500);
+  });
+
+  it("passes short queries unchanged", async () => {
+    const pool = makeMockPool([]);
+
+    await bm25Search(pool, { query: "short query" });
+
+    const call = (pool.query as ReturnType<typeof vi.fn>).mock.calls[0]!;
+    const params = call[1] as unknown[];
+    expect(params[0]).toBe("short query");
+  });
+
   it("handles null metadata in rows", async () => {
     const pool = makeMockPool([
       { id: "chunk-1", content: "some content", metadata: null, rank: 0.5 },

--- a/packages/core/src/rag/bm25Search.ts
+++ b/packages/core/src/rag/bm25Search.ts
@@ -18,6 +18,9 @@ export interface Bm25SearchResult {
   textRank: number;
 }
 
+/** Max query length to prevent oversized tsquery trees in websearch_to_tsquery. */
+const MAX_QUERY_LENGTH = 500;
+
 /**
  * BM25-style full-text search using the `content_tsv` tsvector column
  * and GIN index on the `document_chunks` table.
@@ -32,10 +35,11 @@ export async function bm25Search(
   pool: Pool,
   options: Bm25SearchOptions,
 ): Promise<Bm25SearchResult[]> {
-  const { query, k = 20, filter } = options;
+  const { query: rawQuery, k = 20, filter } = options;
 
-  if (!query.trim()) return [];
+  if (!rawQuery.trim()) return [];
 
+  const query = rawQuery.slice(0, MAX_QUERY_LENGTH);
   const params: unknown[] = [query];
   const conditions: string[] = [
     "content_tsv @@ websearch_to_tsquery('english', $1)",


### PR DESCRIPTION
## Summary

- Truncate queries to 500 chars before passing to `websearch_to_tsquery` in `bm25Search()` to prevent oversized tsquery trees that cause 500ms+ latency on long user inputs
- Add `MAX_QUERY_LENGTH` constant (500) for easy tuning
- Add 2 test cases: long query truncation and short query passthrough

## Context

Resolves code review finding PERF-5 (Medium). User queries up to 10,000 chars + 200 chars context were passed directly to `websearch_to_tsquery`, creating large tsquery trees with 500ms+ latency vs typical 10-50ms.

Closes #526

## Test plan

- [x] All 11 `bm25Search.test.ts` tests pass (2 new)
- [x] Full monorepo typecheck passes
- [x] Prettier formatting verified