### PR TITLE
fix(shared): robust SSL detection for database connections [SEC-2]

### DIFF
--- a/packages/shared/src/pool.test.ts
+++ b/packages/shared/src/pool.test.ts
@@ -25,7 +25,7 @@ vi.mock("./logger.js", () => ({
 }));
 
 import { Pool } from "pg";
-import { getPool, closePool, getPoolStatus } from "./pool.js";
+import { getPool, closePool, getPoolStatus, needsSsl } from "./pool.js";
 import { getDatabaseUrl } from "./env.js";
 import { logger } from "./logger.js";
 
@@ -88,8 +88,8 @@ describe("pool", () => {
     });
   });
 
-  describe("SSL configuration (SEC-01)", () => {
-    it("enables SSL with default CA validation for Neon connections", () => {
+  describe("SSL configuration (SEC-2)", () => {
+    it("enables SSL for remote host", () => {
       mockGetDatabaseUrl.mockReturnValue(
         "postgres://user:pass@ep-example.us-east-1.aws.neon.tech/db",
       );
@@ -99,23 +99,70 @@ describe("pool", () => {
       );
     });
 
-    it("does not set rejectUnauthorized: false", () => {
+    it("enables SSL for any non-local host", () => {
       mockGetDatabaseUrl.mockReturnValue(
-        "postgres://user:pass@ep-example.us-east-1.aws.neon.tech/db",
+        "postgres://user:pass@my-rds-instance.amazonaws.com/db",
       );
       getPool();
-      const poolConfig = MockPool.mock.calls[0]?.[0] as Record<string, unknown>;
-      expect(poolConfig.ssl).toBe(true);
-      expect(poolConfig.ssl).not.toEqual(
-        expect.objectContaining({ rejectUnauthorized: false }),
+      expect(MockPool).toHaveBeenCalledWith(
+        expect.objectContaining({ ssl: true }),
       );
     });
 
-    it("skips SSL for non-Neon local connections", () => {
+    it("skips SSL for localhost", () => {
       mockGetDatabaseUrl.mockReturnValue("postgres://localhost/test");
       getPool();
       const poolConfig = MockPool.mock.calls[0]?.[0] as Record<string, unknown>;
       expect(poolConfig.ssl).toBeUndefined();
+    });
+
+    it("skips SSL for 127.0.0.1", () => {
+      mockGetDatabaseUrl.mockReturnValue("postgres://127.0.0.1/test");
+      getPool();
+      const poolConfig = MockPool.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(poolConfig.ssl).toBeUndefined();
+    });
+  });
+
+  describe("needsSsl", () => {
+    it("returns true for remote hosts", () => {
+      expect(needsSsl("postgres://user:pass@db.neon.tech/mydb")).toBe(true);
+      expect(needsSsl("postgres://user:pass@rds.amazonaws.com/mydb")).toBe(
+        true,
+      );
+    });
+
+    it("returns false for localhost", () => {
+      expect(needsSsl("postgres://localhost/test")).toBe(false);
+      expect(needsSsl("postgres://localhost:5432/test")).toBe(false);
+    });
+
+    it("returns false for 127.0.0.1", () => {
+      expect(needsSsl("postgres://127.0.0.1/test")).toBe(false);
+    });
+
+    it("returns false for ::1", () => {
+      expect(needsSsl("postgres://[::1]/test")).toBe(false);
+    });
+
+    it("respects sslmode=require", () => {
+      expect(needsSsl("postgres://localhost/test?sslmode=require")).toBe(true);
+    });
+
+    it("respects sslmode=verify-full", () => {
+      expect(needsSsl("postgres://localhost/test?sslmode=verify-full")).toBe(
+        true,
+      );
+    });
+
+    it("respects sslmode=disable", () => {
+      expect(needsSsl("postgres://remote.host.com/db?sslmode=disable")).toBe(
+        false,
+      );
+    });
+
+    it("returns true for unparseable URLs (safe default)", () => {
+      expect(needsSsl("not-a-url")).toBe(true);
     });
   });
 });

--- a/packages/shared/src/pool.ts
+++ b/packages/shared/src/pool.ts
@@ -10,25 +10,44 @@ export interface PoolStatus {
   waitingRequests: number;
 }
 
+const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "[::1]", ""]);
+
+/**
+ * Determines whether SSL should be enabled for a database connection.
+ *
+ * Parses the connection string as a URL to extract the hostname and
+ * `sslmode` query parameter. SSL is enabled for all non-local hosts
+ * unless explicitly disabled via `sslmode=disable`.
+ */
+export function needsSsl(connectionString: string): boolean {
+  try {
+    const url = new URL(connectionString);
+    const sslmode = url.searchParams.get("sslmode");
+    if (sslmode === "disable") return false;
+    if (sslmode === "require" || sslmode === "verify-full") return true;
+    return !LOCAL_HOSTNAMES.has(url.hostname);
+  } catch {
+    // Unparseable URL — fall back to safe default (SSL on)
+    return true;
+  }
+}
+
 /**
  * Returns a singleton database pool instance.
  * Uses getDatabaseUrl() to resolve the connection string from
  * DATABASE_URL env var or SST Secret binding.
- * Enables SSL automatically for Neon Postgres connections.
+ * Enables SSL automatically for all non-local connections (SEC-2).
  */
 export function getPool(): Pool {
   if (!pool) {
     const connectionString = getDatabaseUrl();
-    const needsSsl =
-      connectionString.includes("neon.tech") ||
-      connectionString.includes("sslmode=require");
     pool = new Pool({
       connectionString,
       max: 10,
       idleTimeoutMillis: 30000,
       connectionTimeoutMillis: 5000,
       allowExitOnIdle: true,
-      ...(needsSsl ? { ssl: true } : {}),
+      ...(needsSsl(connectionString) ? { ssl: true } : {}),
     });
 
     // Prevent process crash on idle connection backend errors (SEC-1).


### PR DESCRIPTION
## Summary

- Replace fragile `connectionString.includes("neon.tech")` SSL detection with proper URL parsing
- SSL now enabled by default for all non-local connections (not just Neon)
- Respects `sslmode` query parameter: `require`/`verify-full` force SSL on, `disable` forces SSL off
- Falls back to SSL-on for unparseable connection strings (safe default)
- Extract `needsSsl()` as a testable exported function with 8 dedicated unit tests

## Review Finding

Resolves **SEC-2** (Medium, CVSS 5.9, CWE-319) from `.full-review/02-security-performance.md`.

**Before:** Migrating from Neon to another managed Postgres would silently disable SSL.
**After:** Any non-localhost connection gets SSL automatically, regardless of provider.

## Test Plan

- [x] `pnpm --filter @usopc/shared test` — 17 tests pass (8 new for `needsSsl`)
- [x] `npx prettier --write` — formatted
- [x] `pnpm typecheck` — full monorepo passes

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)