### PR TITLE
refactor(ingestion): extract updateSourceConfig helper [CQ-5]

### DIFF
--- a/packages/ingestion/src/services/sourceProcessor.ts
+++ b/packages/ingestion/src/services/sourceProcessor.ts
@@ -103,6 +103,41 @@ async function uploadToS3(
   }
 }
 
+/**
+ * Best-effort DynamoDB source config update. Swallows errors so ingestion
+ * flow is never interrupted by stats bookkeeping failures.
+ */
+async function updateSourceConfig(
+  entity: SourceConfigEntity | undefined,
+  sourceId: string,
+  update:
+    | {
+        type: "success";
+        contentHash: string;
+        s3Key?: string | undefined;
+        s3VersionId?: string | undefined;
+      }
+    | { type: "failure"; error: string },
+): Promise<void> {
+  if (!entity) return;
+  try {
+    if (update.type === "success") {
+      await entity.markSuccess(sourceId, update.contentHash, {
+        ...(update.s3Key !== undefined ? { s3Key: update.s3Key } : {}),
+        ...(update.s3VersionId !== undefined
+          ? { s3VersionId: update.s3VersionId }
+          : {}),
+      });
+    } else {
+      await entity.markFailure(sourceId, update.error);
+    }
+  } catch (err) {
+    logger.warn(
+      `Failed to update DynamoDB stats for ${sourceId}: ${err instanceof Error ? err.message : "Unknown error"}`,
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
@@ -134,15 +169,10 @@ export async function processSource(
     const msg =
       fetchError instanceof Error ? fetchError.message : "Unknown error";
     logger.warn(`Fetch failed for ${source.id}: ${msg}`);
-
-    if (sourceConfigEntity) {
-      try {
-        await sourceConfigEntity.markFailure(source.id, msg);
-      } catch {
-        /* best-effort */
-      }
-    }
-
+    await updateSourceConfig(sourceConfigEntity, source.id, {
+      type: "failure",
+      error: msg,
+    });
     return { status: "failed", chunksCount: 0, error: msg };
   }
 
@@ -182,19 +212,12 @@ export async function processSource(
       "completed",
       { contentHash, chunksCount: result.chunksCount },
     );
-
-    if (sourceConfigEntity) {
-      try {
-        await sourceConfigEntity.markSuccess(source.id, contentHash, {
-          ...(s3Key !== undefined ? { s3Key } : {}),
-          ...(s3VersionId !== undefined ? { s3VersionId } : {}),
-        });
-      } catch (statsError) {
-        logger.warn(
-          `Failed to update DynamoDB stats for ${source.id}: ${statsError instanceof Error ? statsError.message : "Unknown error"}`,
-        );
-      }
-    }
+    await updateSourceConfig(sourceConfigEntity, source.id, {
+      type: "success",
+      contentHash,
+      s3Key,
+      s3VersionId,
+    });
   } else {
     await upsertIngestionStatus(
       ingestionLogEntity,
@@ -203,19 +226,10 @@ export async function processSource(
       "failed",
       result.error !== undefined ? { errorMessage: result.error } : {},
     );
-
-    if (sourceConfigEntity) {
-      try {
-        await sourceConfigEntity.markFailure(
-          source.id,
-          result.error ?? "Unknown error",
-        );
-      } catch (statsError) {
-        logger.warn(
-          `Failed to update DynamoDB stats for ${source.id}: ${statsError instanceof Error ? statsError.message : "Unknown error"}`,
-        );
-      }
-    }
+    await updateSourceConfig(sourceConfigEntity, source.id, {
+      type: "failure",
+      error: result.error ?? "Unknown error",
+    });
   }
 
   return {


### PR DESCRIPTION
## Summary

- Extract `updateSourceConfig()` helper that handles the repeated `if (entity) { try { await entity.markXxx(); } catch { logger.warn(); } }` pattern
- Reduces cyclomatic complexity in `processSource` by consolidating 3 near-identical DynamoDB update blocks into a single typed helper with discriminated union

## Review Finding

Resolves code review finding **CQ-5** from `.full-review/01-quality-architecture.md`.

## Test plan

- [x] `pnpm --filter @usopc/ingestion test` — 282 tests pass (all existing tests unmodified)
- [x] `pnpm typecheck` — clean across all 6 packages
- [x] `npx prettier --write` — formatted

Closes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)