### PR TITLE
fix(web): escape HTML in email notification [SEC-01]

### DIFF
--- a/apps/web/lib/send-access-request-notification.test.ts
+++ b/apps/web/lib/send-access-request-notification.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("resend", () => ({
+  Resend: vi.fn().mockImplementation(() => ({
+    emails: { send: vi.fn().mockResolvedValue({ id: "mock-id" }) },
+  })),
+}));
+
+vi.mock("./auth-env.js", () => ({
+  getResendApiKey: vi.fn().mockReturnValue("re_test_key"),
+}));
+
+vi.mock("@usopc/shared", () => ({
+  logger: { child: () => ({ warn: vi.fn(), error: vi.fn() }) },
+}));
+
+import { Resend } from "resend";
+import { sendAccessRequestNotification } from "./send-access-request-notification.js";
+
+const mockSend = vi.fn().mockResolvedValue({ id: "mock-id" });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSend.mockResolvedValue({ id: "mock-id" });
+  vi.mocked(Resend).mockImplementation(
+    () => ({ emails: { send: mockSend } }) as unknown as Resend,
+  );
+  process.env.ADMIN_EMAIL = "admin@example.com";
+  process.env.EMAIL_FROM = "test@example.com";
+});
+
+function lastSendArgs() {
+  return mockSend.mock.calls[0]![0] as { html: string; subject: string };
+}
+
+function makeRequest(overrides = {}) {
+  return {
+    email: "user@example.com",
+    name: "Jane Doe",
+    status: "pending" as const,
+    requestedAt: "2026-03-10T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("sendAccessRequestNotification", () => {
+  describe("HTML escaping", () => {
+    it("escapes HTML entities in name", async () => {
+      await sendAccessRequestNotification(
+        makeRequest({ name: '<img src=x onerror="alert(1)">' }),
+      );
+
+      const html = lastSendArgs().html;
+      expect(html).not.toContain("<img");
+      expect(html).toContain("&lt;img");
+      expect(html).toContain("&gt;");
+    });
+
+    it("escapes HTML entities in email field", async () => {
+      await sendAccessRequestNotification(
+        makeRequest({ email: '<script>alert("xss")</script>' }),
+      );
+
+      const html = lastSendArgs().html;
+      expect(html).not.toContain("<script>");
+      expect(html).toContain("&lt;script&gt;");
+    });
+
+    it("escapes HTML entities in sport", async () => {
+      await sendAccessRequestNotification(
+        makeRequest({ sport: '"><script>alert(1)</script>' }),
+      );
+
+      const html = lastSendArgs().html;
+      expect(html).not.toContain("<script>");
+      expect(html).toContain("&quot;&gt;&lt;script&gt;");
+    });
+
+    it("escapes HTML entities in role", async () => {
+      await sendAccessRequestNotification(
+        makeRequest({ role: "<b>admin</b>" }),
+      );
+
+      const html = lastSendArgs().html;
+      expect(html).not.toContain("<b>");
+      expect(html).toContain("&lt;b&gt;");
+    });
+
+    it("escapes ampersands and single quotes", async () => {
+      await sendAccessRequestNotification(
+        makeRequest({ name: "O'Brien & Co" }),
+      );
+
+      const html = lastSendArgs().html;
+      expect(html).toContain("O&#39;Brien &amp; Co");
+    });
+  });
+
+  describe("subject line sanitization", () => {
+    it("strips CRLF from name in subject", async () => {
+      await sendAccessRequestNotification(
+        makeRequest({ name: "Evil\r\nBcc: victim@evil.com" }),
+      );
+
+      const subject = lastSendArgs().subject;
+      expect(subject).not.toContain("\r");
+      expect(subject).not.toContain("\n");
+      expect(subject).toContain("EvilBcc: victim@evil.com");
+    });
+
+    it("strips CRLF from email in subject", async () => {
+      await sendAccessRequestNotification(
+        makeRequest({ email: "user@test.com\r\nBcc: spy@evil.com" }),
+      );
+
+      const subject = lastSendArgs().subject;
+      expect(subject).not.toContain("\r");
+      expect(subject).not.toContain("\n");
+    });
+  });
+
+  describe("basic functionality", () => {
+    it("returns false when ADMIN_EMAIL is not set", async () => {
+      delete process.env.ADMIN_EMAIL;
+      const result = await sendAccessRequestNotification(makeRequest());
+      expect(result).toBe(false);
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it("returns true on success", async () => {
+      const result = await sendAccessRequestNotification(makeRequest());
+      expect(result).toBe(true);
+    });
+
+    it("returns false on send failure", async () => {
+      mockSend.mockRejectedValueOnce(new Error("send failed"));
+      const result = await sendAccessRequestNotification(makeRequest());
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/apps/web/lib/send-access-request-notification.ts
+++ b/apps/web/lib/send-access-request-notification.ts
@@ -5,17 +5,34 @@ import type { AccessRequest } from "@usopc/shared";
 
 const log = logger.child({ module: "access-request-notification" });
 
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function stripCrlf(str: string): string {
+  return str.replace(/[\r\n]/g, "");
+}
+
 function buildNotificationHtml(req: AccessRequest): string {
+  const name = escapeHtml(req.name);
+  const email = escapeHtml(req.email);
   const sportLine = req.sport
-    ? `<p><strong>Sport:</strong> ${req.sport}</p>`
+    ? `<p><strong>Sport:</strong> ${escapeHtml(req.sport)}</p>`
     : "";
-  const roleLine = req.role ? `<p><strong>Role:</strong> ${req.role}</p>` : "";
+  const roleLine = req.role
+    ? `<p><strong>Role:</strong> ${escapeHtml(req.role)}</p>`
+    : "";
 
   return `
 <div style="font-family: sans-serif; max-width: 480px; margin: 0 auto; padding: 24px;">
   <h2 style="color: #002244;">New Access Request</h2>
-  <p><strong>Name:</strong> ${req.name}</p>
-  <p><strong>Email:</strong> ${req.email}</p>
+  <p><strong>Name:</strong> ${name}</p>
+  <p><strong>Email:</strong> ${email}</p>
   ${sportLine}
   ${roleLine}
   <p><strong>Requested:</strong> ${req.requestedAt}</p>
@@ -46,7 +63,7 @@ export async function sendAccessRequestNotification(
     await resend.emails.send({
       from: fromAddress,
       to: adminEmail,
-      subject: `Access Request: ${req.name} (${req.email})`,
+      subject: `Access Request: ${stripCrlf(req.name)} (${stripCrlf(req.email)})`,
       html: buildNotificationHtml(req),
     });
     return true;


### PR DESCRIPTION
## Summary

- Add `escapeHtml()` utility to encode `&`, `<`, `>`, `"`, `'` entities in user-supplied values before HTML interpolation
- Add `stripCrlf()` to prevent email header injection via CRLF in subject line
- Add 10 tests: 5 for HTML escaping (name, email, sport, role, ampersands/quotes), 2 for CRLF stripping, 3 for basic send functionality

## Security

Fixes HTML injection (CWE-79, CVSS 6.1) and email header injection (CWE-93) in `send-access-request-notification.ts`. User-supplied `name`, `email`, `sport`, and `role` were previously interpolated directly into the admin notification HTML template without escaping.

## Test plan

- [x] XSS payloads in name, email, sport, role produce escaped output
- [x] Ampersands and single quotes are escaped
- [x] CRLF in name/email stripped from subject line
- [x] Returns false when ADMIN_EMAIL not set
- [x] Returns true on success, false on failure
- [x] `pnpm typecheck` passes (all packages)
- [x] `npx prettier --check` passes

Closes #542