### PR TITLE
fix(ci): evals workflow permissions + verbose reporter

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -63,27 +63,35 @@ jobs:
 
       # ── Run all evaluators ────────────────────────────────────────────────
       - name: Run classifier eval
+        continue-on-error: true
         run: pnpm --filter @usopc/evals exec vitest run --config ls.vitest.config.ts --reporter=verbose --reporter=json --outputFile=results/classifier.json src/evaluators/classifierAccuracy.eval.ts
 
       - name: Run escalation eval
+        continue-on-error: true
         run: pnpm --filter @usopc/evals exec vitest run --config ls.vitest.config.ts --reporter=verbose --reporter=json --outputFile=results/escalation.json src/evaluators/escalation.eval.ts
 
       - name: Run trajectory eval
+        continue-on-error: true
         run: pnpm --filter @usopc/evals exec vitest run --config ls.vitest.config.ts --reporter=verbose --reporter=json --outputFile=results/trajectory.json src/evaluators/trajectory.eval.ts
 
       - name: Run disclaimers eval
+        continue-on-error: true
         run: pnpm --filter @usopc/evals exec vitest run --config ls.vitest.config.ts --reporter=verbose --reporter=json --outputFile=results/disclaimers.json src/evaluators/disclaimers.eval.ts
 
       - name: Run citations eval
+        continue-on-error: true
         run: pnpm --filter @usopc/evals exec vitest run --config ls.vitest.config.ts --reporter=verbose --reporter=json --outputFile=results/citations.json src/evaluators/citations.eval.ts
 
       - name: Run correctness eval
+        continue-on-error: true
         run: pnpm --filter @usopc/evals exec vitest run --config ls.vitest.config.ts --reporter=verbose --reporter=json --outputFile=results/correctness.json src/evaluators/correctness.eval.ts
 
       - name: Run groundedness eval
+        continue-on-error: true
         run: pnpm --filter @usopc/evals exec vitest run --config ls.vitest.config.ts --reporter=verbose --reporter=json --outputFile=results/groundedness.json src/evaluators/groundedness.eval.ts
 
       - name: Run semantic similarity eval
+        continue-on-error: true
         run: pnpm --filter @usopc/evals exec vitest run --config ls.vitest.config.ts --reporter=verbose --reporter=json --outputFile=results/semantic.json src/evaluators/semanticSimilarity.eval.ts
 
       # ── Upload results ────────────────────────────────────────────────────

--- a/packages/evals/src/evaluators/citations.eval.ts
+++ b/packages/evals/src/evaluators/citations.eval.ts
@@ -5,7 +5,7 @@ import { fetchExamples } from "../helpers/fetchExamples.js";
 
 const examples = await fetchExamples(DATASET_NAMES.answerQuality);
 
-ls.describe("usopc-citations", () => {
+ls.describe(DATASET_NAMES.answerQuality, () => {
   ls.test.each(examples)("citation accuracy", async ({ inputs }) => {
     const message = String(inputs.message ?? "");
     const result = await runPipeline(message);

--- a/packages/evals/src/evaluators/correctness.eval.ts
+++ b/packages/evals/src/evaluators/correctness.eval.ts
@@ -13,7 +13,7 @@ const correctnessJudge = createLLMAsJudge({
 
 const examples = await fetchExamples(DATASET_NAMES.answerQuality);
 
-ls.describe("usopc-correctness", () => {
+ls.describe(DATASET_NAMES.answerQuality, () => {
   ls.test.each(examples)(
     "answer correctness",
     async ({ inputs, referenceOutputs }) => {

--- a/packages/evals/src/evaluators/disclaimers.eval.ts
+++ b/packages/evals/src/evaluators/disclaimers.eval.ts
@@ -13,7 +13,7 @@ const DOMAIN_REQUIRED_STRINGS: Partial<Record<TopicDomain, string[]>> = {
 
 const examples = await fetchExamples(DATASET_NAMES.answerQuality);
 
-ls.describe("usopc-disclaimers", () => {
+ls.describe(DATASET_NAMES.answerQuality, () => {
   ls.test.each(examples)("disclaimer compliance", async ({ inputs }) => {
     const message = String(inputs.message ?? "");
     const result = await runPipeline(message);

--- a/packages/evals/src/evaluators/groundedness.eval.ts
+++ b/packages/evals/src/evaluators/groundedness.eval.ts
@@ -13,7 +13,7 @@ const groundednessJudge = createLLMAsJudge({
 
 const examples = await fetchExamples(DATASET_NAMES.answerQuality);
 
-ls.describe("usopc-groundedness", () => {
+ls.describe(DATASET_NAMES.answerQuality, () => {
   ls.test.each(examples)("answer groundedness", async ({ inputs }) => {
     const message = String(inputs.message ?? "");
     const result = await runPipelineForAnswerEval(message);

--- a/packages/evals/src/evaluators/semanticSimilarity.eval.ts
+++ b/packages/evals/src/evaluators/semanticSimilarity.eval.ts
@@ -23,7 +23,7 @@ function cosineSimilarity(a: number[], b: number[]): number {
 
 const examples = await fetchExamples(DATASET_NAMES.answerQuality);
 
-ls.describe("usopc-semantic-similarity", () => {
+ls.describe(DATASET_NAMES.answerQuality, () => {
   ls.test.each(examples)(
     "answer semantic similarity",
     async ({ inputs, referenceOutputs }) => {


### PR DESCRIPTION
## Summary

- Add `issues: write` and `pull-requests: write` permissions to the evals workflow so the "Post eval summary to PR" step no longer gets a 403
- Add `--reporter=verbose` to all 8 eval steps so test failures are human-readable in CI logs (alongside the existing JSON reporter)
- Fix `ls.describe()` dataset name mismatch in 5 evals (disclaimers, citations, correctness, groundedness, semanticSimilarity) — they fetched examples from `usopc-answer-quality` but used different describe names, causing LangSmith 409 "Dataset ID mismatch" errors
- Add `continue-on-error: true` to all eval steps so one failure doesn't block the rest from running

Closes #548

## Test plan

- [ ] Trigger the evals workflow on a PR with the `run-evals` label
- [ ] Verify verbose test output appears in CI logs for each eval step
- [ ] Verify the PR comment is posted/updated successfully (no 403)
- [ ] Verify all 8 eval steps run to completion (no early abort on failure)
- [ ] Verify disclaimers eval no longer gets 409 dataset mismatch error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 84.0% | +0.0% |
| shared | 94.7% | +0.0% |
| ingestion | 77.8% | +0.0% |
| evals | 45.3% | +0.0% |
| slack | 75.9% | +0.0% |
| web | 68.5% | +0.0% |
<!-- coverage-summary-end -->