### PR TITLE
fix(deps): override undici to >=7.24.0 for WebSocket CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
       "@modelcontextprotocol/sdk": ">=1.25.2",
       "h3": ">=1.15.5",
       "axios": ">=1.13.5",
-      "rollup": ">=4.59.0"
+      "rollup": ">=4.59.0",
+      "undici": ">=7.24.0"
     },
     "patchedDependencies": {
       "@langchain/community": "patches/@langchain__community.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   h3: '>=1.15.5'
   axios: '>=1.13.5'
   rollup: '>=4.59.0'
+  undici: '>=7.24.0'
 
 patchedDependencies:
   '@langchain/community':
@@ -4484,8 +4485,8 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici@7.22.0:
-    resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
+  undici@7.24.3:
+    resolution: {integrity: sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==}
     engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
@@ -7212,7 +7213,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.22.0
+      undici: 7.24.3
       whatwg-mimetype: 4.0.0
 
   client-only@0.0.1: {}
@@ -7874,7 +7875,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.0
-      undici: 7.22.0
+      undici: 7.24.3
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -9253,7 +9254,7 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici@7.22.0: {}
+  undici@7.24.3: {}
 
   unified@11.0.5:
     dependencies:


### PR DESCRIPTION
## Summary

- Add `"undici": ">=7.24.0"` to `pnpm.overrides` to patch two high-severity WebSocket vulnerabilities in `undici@7.22.0`
- Resolves all high-severity findings from `pnpm audit`

Closes #561

## Test plan

- [x] `pnpm audit` no longer reports high-severity undici vulnerabilities
- [ ] CI passes (tests, typecheck, prettier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 84.0% | +0.0% |
| shared | 94.7% | +0.0% |
| ingestion | 77.8% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 75.9% | +0.0% |
| web | 68.5% | +0.0% |
<!-- coverage-summary-end -->