### PR TITLE
fix(evals): retry Gemini embedding requests on 429 rate limit

### DIFF
--- a/packages/evals/src/scripts/benchmark-embeddings.ts
+++ b/packages/evals/src/scripts/benchmark-embeddings.ts
@@ -39,6 +39,8 @@ const VOYAGE_BATCH_SIZE = 64; // Voyage API max batch size
 const GEMINI_MODEL = "gemini-embedding-001";
 const GEMINI_DIMS = 1536;
 const GEMINI_BATCH_SIZE = 64;
+const GEMINI_MAX_RETRIES = 3;
+const GEMINI_BASE_DELAY_MS = 45_000; // Free tier resets ~every 60s
 const K_SMALL = 5;
 const K_LARGE = 10;
 
@@ -208,28 +210,41 @@ async function embedWithGemini(
       outputDimensionality: GEMINI_DIMS,
     }));
 
-    const res = await fetch(
-      `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:batchEmbedContents`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-goog-api-key": apiKey,
+    let response: GeminiEmbedResponse | undefined;
+    for (let attempt = 0; attempt <= GEMINI_MAX_RETRIES; attempt++) {
+      const res = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_MODEL}:batchEmbedContents`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-goog-api-key": apiKey,
+          },
+          body: JSON.stringify({ requests }),
         },
-        body: JSON.stringify({ requests }),
-      },
-    );
+      );
 
-    if (!res.ok) {
+      if (res.ok) {
+        response = (await res.json()) as GeminiEmbedResponse;
+        break;
+      }
+
+      if (res.status === 429 && attempt < GEMINI_MAX_RETRIES) {
+        const delayMs = GEMINI_BASE_DELAY_MS * 2 ** attempt;
+        console.warn(
+          `  ⏳ Gemini rate-limited (batch at ${i}), retrying in ${(delayMs / 1000).toFixed(0)}s (attempt ${attempt + 1}/${GEMINI_MAX_RETRIES})...`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        continue;
+      }
+
       const body = await res.text();
       throw new Error(
         `Gemini API error ${res.status} for batch at ${i}: ${body}`,
       );
     }
 
-    const response = (await res.json()) as GeminiEmbedResponse;
-
-    if (!response.embeddings) {
+    if (!response?.embeddings) {
       throw new Error(
         `Gemini returned no embeddings for batch starting at ${i}`,
       );


### PR DESCRIPTION
## Summary
- Add exponential backoff retry (up to 3 attempts) in `embedWithGemini` when Gemini returns HTTP 429
- Base delay of 45s doubles on each retry (45s → 90s → 180s), matching the free tier's ~60s reset window
- Logs a warning on each retry so progress is visible during long benchmark runs

## Context
The Gemini free tier caps at 100 embed requests/minute. With 500 chunks, the benchmark exceeds this quota and crashes. Retry-on-429 is preferred over preemptive throttling since it only pays the delay cost when actually rate-limited.

## Test plan
- [ ] Run `pnpm --filter @usopc/evals benchmark:embeddings` and confirm it completes without 429 crashes
- [ ] Verify retry warning appears in output when rate-limited

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 84.0% | +0.0% |
| shared | 94.7% | +0.0% |
| ingestion | 77.8% | +0.0% |
| evals | 43.8% | -0.1% |
| slack | 75.9% | +0.0% |
| web | 68.5% | +0.0% |
<!-- coverage-summary-end -->