### PR TITLE
fix(evals): use correct Gemini embedding 2 model ID

### DIFF
--- a/packages/evals/src/scripts/benchmark-embeddings.ts
+++ b/packages/evals/src/scripts/benchmark-embeddings.ts
@@ -2,7 +2,7 @@
 
 /**
  * Embedding Model Benchmark: OpenAI text-embedding-3-small vs Voyage AI voyage-law-2
- * vs Google Gemini gemini-embedding-002
+ * vs Google Gemini gemini-embedding-2-preview
  *
  * Compares retrieval quality (recall@5, recall@10) between the current OpenAI
  * embedding model, Voyage AI's legal-domain specialist model, and Google's
@@ -36,7 +36,7 @@ const VOYAGE_MODEL = "voyage-law-2";
 const VOYAGE_DIMS = 1024;
 const SAMPLE_SIZE = 500;
 const VOYAGE_BATCH_SIZE = 64; // Voyage API max batch size
-const GEMINI_MODEL = "gemini-embedding-002";
+const GEMINI_MODEL = "gemini-embedding-2-preview";
 const GEMINI_DIMS = 3072;
 const GEMINI_BATCH_SIZE = 64;
 const GEMINI_MAX_RETRIES = 3;


### PR DESCRIPTION
## Summary
- Fix model ID from `gemini-embedding-002` (doesn't exist) to `gemini-embedding-2-preview` (the actual Gemini Embedding 2 model ID)

## Context
The previous PR used an incorrect model ID that returns 404. The Gemini Embedding 2 model is still in preview and uses `gemini-embedding-2-preview` as its API identifier.

## Test plan
- [ ] Run `pnpm --filter @usopc/evals benchmark:embeddings` and confirm Gemini embedding calls succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 84.0% | +0.0% |
| shared | 94.7% | +0.0% |
| ingestion | 77.8% | +0.0% |
| evals | 43.8% | +0.0% |
| slack | 75.9% | +0.0% |
| web | 68.5% | +0.0% |
<!-- coverage-summary-end -->