### PR TITLE
fix: skip AWS profile in CI for OIDC deploy

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -7,7 +7,10 @@ export default $config({
       removal: input?.stage === "production" ? "retain" : "remove",
       home: "aws",
       providers: {
-        aws: { region: "us-east-1", profile: "default" },
+        aws: {
+          region: "us-east-1",
+          ...(process.env.CI ? {} : { profile: "default" }),
+        },
       },
     };
   },


### PR DESCRIPTION
## Summary

- Only set `profile: "default"` in `sst.config.ts` when not running in CI
- GitHub Actions OIDC sets credentials via env vars; the hardcoded profile caused `failed to get shared config profile, default`

Fixes #574

## Test plan

- [ ] Merge, retag, and verify staging deploy gets past the migration step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|

<!-- coverage-summary-end -->