### PR TITLE
fix(ci): use direct path for tsx in sst shell

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,7 +95,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Run database migrations
-        run: npx sst shell --stage staging --print-logs -- npx tsx scripts/run-migrations.ts
+        run: npx sst shell --stage staging --print-logs -- ./node_modules/.bin/tsx scripts/run-migrations.ts
 
       - name: Deploy to staging
         id: deploy
@@ -140,7 +140,7 @@ jobs:
           aws-region: us-east-1
 
       - name: Run database migrations
-        run: npx sst shell --stage production -- npx tsx scripts/run-migrations.ts
+        run: npx sst shell --stage production -- ./node_modules/.bin/tsx scripts/run-migrations.ts
 
       - name: Deploy to production
         id: deploy


### PR DESCRIPTION
## Summary

- Use `./node_modules/.bin/tsx` instead of `npx tsx` in the `sst shell` migration steps
- `sst shell` spawns a subshell where `npx`/`tsx` aren't on the PATH, causing `sh: 1: tsx: not found`
- Fixes both staging and production migration steps

Refs #576

## Test plan

- [ ] CI passes
- [ ] Deploy workflow migration step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 84.0% | +0.0% |
| shared | 94.7% | +0.0% |
| ingestion | 77.8% | +0.0% |
| evals | 43.8% | +0.0% |
| slack | 75.9% | +0.0% |
| web | 68.5% | +0.0% |
<!-- coverage-summary-end -->