### PR TITLE
fix(ci): add tsx to root devDependencies for sst shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "node-pg-migrate": "^8.0.4",
     "prettier": "^3.4.2",
     "sst": "4.1.10",
+    "tsx": "^4.19.2",
     "typescript": "^5.7.3",
     "vitest": "^2.1.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       sst:
         specifier: 4.1.10
         version: 4.1.10
+      tsx:
+        specifier: ^4.19.2
+        version: 4.21.0
       typescript:
         specifier: ^5.7.3
         version: 5.9.3


### PR DESCRIPTION
## Summary

- Add `tsx` to root `devDependencies` so it's available at `./node_modules/.bin/tsx`
- `sst shell` uses `fork/exec` to run the command after `--`, so it needs the binary on disk — `npx tsx` doesn't work because npx isn't available in sst shell's exec context
- Previously tsx was only in sub-package devDependencies (`apps/slack`, `packages/evals`, `packages/ingestion`)

Fixes the deploy failure: `fork/exec ./node_modules/.bin/tsx: no such file or directory`

Refs #576

## Test plan

- [ ] CI passes
- [ ] Deploy workflow migration step finds tsx and runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 84.0% | +0.0% |
| shared | 94.7% | +0.0% |
| ingestion | 77.8% | +0.0% |
| evals | 43.8% | +0.0% |
| slack | 75.9% | +0.0% |
| web | 68.5% | +0.0% |
<!-- coverage-summary-end -->