### PR TITLE
fix(ci): extract DATABASE_URL from sst secret list for migrations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -95,7 +95,10 @@ jobs:
           aws-region: us-east-1
 
       - name: Run database migrations
-        run: npx sst shell --stage staging --print-logs -- ./node_modules/.bin/tsx scripts/run-migrations.ts
+        run: |
+          DB_URL=$(npx sst secret list --stage staging 2>/dev/null | grep '^DatabaseUrl=' | cut -d= -f2-)
+          echo "::add-mask::$DB_URL"
+          DATABASE_URL="$DB_URL" ./node_modules/.bin/tsx scripts/run-migrations.ts
 
       - name: Deploy to staging
         id: deploy
@@ -140,7 +143,10 @@ jobs:
           aws-region: us-east-1
 
       - name: Run database migrations
-        run: npx sst shell --stage production -- ./node_modules/.bin/tsx scripts/run-migrations.ts
+        run: |
+          DB_URL=$(npx sst secret list --stage production 2>/dev/null | grep '^DatabaseUrl=' | cut -d= -f2-)
+          echo "::add-mask::$DB_URL"
+          DATABASE_URL="$DB_URL" ./node_modules/.bin/tsx scripts/run-migrations.ts
 
       - name: Deploy to production
         id: deploy


### PR DESCRIPTION
## Summary

- `sst shell` doesn't reliably inject secrets as env vars in CI (works locally on macOS but not in GitHub Actions with OIDC credentials)
- Work around by extracting `DATABASE_URL` from `sst secret list` output and passing it directly to the migration script
- Uses `::add-mask::` to prevent the URL from appearing in CI logs
- Fixes both staging and production migration steps

Refs #576

## Test plan

- [ ] CI passes
- [ ] Deploy workflow migration step connects to Neon database successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 84.0% | +0.0% |
| shared | 94.5% | +0.0% |
| ingestion | 77.8% | +0.0% |
| evals | 43.8% | +0.0% |
| slack | 75.9% | +0.0% |
| web | 68.5% | +0.0% |
<!-- coverage-summary-end -->