### PR TITLE
fix: enable ingestion infrastructure and monitoring in staging

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -147,7 +147,7 @@ export default $config({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let monitoringRefs: Record<string, any> | undefined;
 
-    if (isProd) {
+    if (isDeployed) {
       // Dead-letter queue (must also be FIFO to match main queue)
       ingestionDlq = new sst.aws.Queue("IngestionDLQ", {
         fifo: true,
@@ -182,10 +182,9 @@ export default $config({
       },
     );
 
-    // Source discovery (weekly) - production only
-    // Document ingestion (weekly) - production only
+    // Source discovery, document ingestion, monitoring — deployed stages only
 
-    if (isProd) {
+    if (isDeployed) {
       const discoveryCron = new sst.aws.Cron("DiscoveryCron", {
         schedule: "cron(0 2 ? * MON *)", // Every Monday at 2 AM UTC
         job: {
@@ -458,7 +457,7 @@ export default $config({
     });
 
     // Web Lambda alarms + CloudWatch dashboard (needs web to be declared)
-    if (isProd && alarmTopic && monitoringRefs) {
+    if (isDeployed && alarmTopic && monitoringRefs) {
       // Web/Next.js server Lambda alarms
       new aws.cloudwatch.MetricAlarm("WebErrorsAlarm", {
         alarmDescription: "Web Lambda errors > 5 in 5 minutes",
@@ -662,7 +661,7 @@ export default $config({
       );
 
       new aws.cloudwatch.Dashboard("MonitoringDashboard", {
-        dashboardName: "usopc-athlete-support-production",
+        dashboardName: `usopc-athlete-support-${stage}`,
         dashboardBody: dashboardBody,
       });
     }


### PR DESCRIPTION
## Summary

Closes #597

Manual ingestion from the admin console in staging returns 501 because the `IngestionQueue`, worker Lambda, crons, and monitoring are all gated behind `if (isProd)` — but staging is not production.

- Changed two `if (isProd)` gates to `if (isDeployed)` in `sst.config.ts`
- Staging now gets: IngestionQueue, IngestionDLQ, ingestion worker, all crons, and full monitoring
- Parameterized CloudWatch dashboard name to include stage (`usopc-athlete-support-${stage}`)

## Test plan

- [x] `pnpm typecheck` — clean
- [ ] Deploy staging and verify IngestionQueue is created
- [ ] Trigger manual ingestion from admin console — should succeed
- [ ] Verify CloudWatch dashboard created as `usopc-athlete-support-staging`

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 84.0% | +0.0% |
| shared | 94.7% | +0.0% |
| ingestion | 77.8% | +0.0% |
| evals | 43.8% | +0.0% |
| slack | 75.9% | +0.0% |
| web | 67.3% | +0.0% |
<!-- coverage-summary-end -->