### PR TITLE
fix: bundle data files for Lambda — static JSON import + copyFiles

### DIFF
--- a/packages/core/src/tools/lookupContact.test.ts
+++ b/packages/core/src/tools/lookupContact.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { mockContacts, mockReadFile } = vi.hoisted(() => {
-  const mockContacts = [
+const { mockContacts } = vi.hoisted(() => ({
+  mockContacts: [
     {
       organization: "USOPC Athlete Ombuds",
       role: "Independent advocate for athlete concerns",
@@ -52,15 +52,11 @@ const { mockContacts, mockReadFile } = vi.hoisted(() => {
         "Provides support services specific to USA Swimming athletes.",
       domains: ["team_selection", "eligibility"],
     },
-  ];
-  return {
-    mockContacts,
-    mockReadFile: vi.fn().mockResolvedValue(JSON.stringify(mockContacts)),
-  };
-});
+  ],
+}));
 
-vi.mock("node:fs/promises", () => ({
-  readFile: mockReadFile,
+vi.mock("../../../../data/contact-directory.json", () => ({
+  default: mockContacts,
 }));
 
 import { createLookupContactTool } from "./lookupContact.js";
@@ -227,25 +223,11 @@ describe("createLookupContactTool", () => {
     });
 
     it("should return helpful message when no domain match found", async () => {
-      // All valid domains have matches in our mock, but let's test the message format
       const result = await tool.invoke({
         organization: "Nonexistent",
         domain: "safesport",
       });
       expect(result).toContain("No contacts found");
-    });
-  });
-
-  describe("error handling", () => {
-    it("should handle file read errors gracefully", async () => {
-      const { readFile } = await import("node:fs/promises");
-      vi.mocked(readFile).mockRejectedValueOnce(new Error("File not found"));
-
-      // First call caches data, so create and call new tool
-      const newTool = createLookupContactTool();
-      const result = await newTool.invoke({ organization: "USADA" });
-      // Cached data still works
-      expect(result).toContain("USADA");
     });
   });
 

--- a/packages/core/src/tools/lookupContact.ts
+++ b/packages/core/src/tools/lookupContact.ts
@@ -1,10 +1,8 @@
 import { tool } from "@langchain/core/tools";
 import { z } from "zod";
-import { readFile } from "node:fs/promises";
-import { resolve, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
 import type { TopicDomain } from "../types/index.js";
 import { logger } from "@usopc/shared";
+import contactDirectoryData from "../../../../data/contact-directory.json";
 
 const TOPIC_DOMAINS = [
   "team_selection",
@@ -44,33 +42,8 @@ interface ContactEntry {
   domains: TopicDomain[];
 }
 
-/** Cached contacts loaded from the JSON file. */
-let cachedContacts: ContactEntry[] | null = null;
-
-function getDataFilePath(): string {
-  const __filename = fileURLToPath(import.meta.url);
-  const __dirname = dirname(__filename);
-  return resolve(
-    __dirname,
-    "..",
-    "..",
-    "..",
-    "..",
-    "data",
-    "contact-directory.json",
-  );
-}
-
-async function loadContacts(): Promise<ContactEntry[]> {
-  if (cachedContacts) {
-    return cachedContacts;
-  }
-
-  const filePath = getDataFilePath();
-  const raw = await readFile(filePath, "utf-8");
-  cachedContacts = JSON.parse(raw) as ContactEntry[];
-  return cachedContacts;
-}
+/** Contacts bundled at build time from data/contact-directory.json. */
+const contacts: ContactEntry[] = contactDirectoryData as ContactEntry[];
 
 function formatContact(contact: ContactEntry): string {
   const lines: string[] = [
@@ -108,9 +81,7 @@ export function createLookupContactTool() {
       log.debug("Looking up contact", { organization, domain });
 
       try {
-        const contacts = await loadContacts();
-
-        let matches = contacts;
+        let matches: ContactEntry[] = [...contacts];
 
         // Filter by domain if specified
         if (domain) {

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -286,6 +286,7 @@ export default $config({
             NOTIFICATION_EMAIL: process.env.NOTIFICATION_EMAIL ?? "",
             SES_FROM_EMAIL: process.env.SES_FROM_EMAIL ?? "noreply@usopc.org",
           },
+          copyFiles: [{ from: "data/discovery-config.json" }],
         },
       });
 


### PR DESCRIPTION
## Summary

Closes #606

Bundling audit found two Lambdas that load JSON data files from disk via `readFile()` with relative paths — these files don't exist after esbuild bundles everything into `bundle.mjs`.

### Changes

**`packages/core/src/tools/lookupContact.ts`** — replaced `readFile()` + path traversal with a static `import` of `data/contact-directory.json`. esbuild bundles the JSON inline, eliminating filesystem access entirely. Removed unused `node:fs/promises`, `node:path`, and `node:url` imports.

**`sst.config.ts`** — added `copyFiles: [{ from: "data/discovery-config.json" }]` to the DiscoveryCron Lambda config so the config file is included in the Lambda package.

**`packages/core/src/tools/lookupContact.test.ts`** — updated mock from `node:fs/promises` to the JSON module import, using `vi.hoisted()` pattern.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] lookupContact tests — 27/27 passing
- [x] discovery tests — 9/9 passing
- [ ] Deploy staging — verify lookup_contact tool works in chat
- [ ] Verify DiscoveryCron loads config on next weekly run


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.9% | -0.1% |
| shared | 94.8% | +0.0% |
| ingestion | 77.8% | +0.0% |
| evals | 43.8% | +0.0% |
| slack | 75.9% | +0.0% |
| web | 67.3% | +0.0% |
<!-- coverage-summary-end -->