### PR TITLE
fix: discovery dedup broken — exists:null overwrites records

### DIFF
--- a/packages/shared/src/entities/DiscoveredSourceEntity.test.ts
+++ b/packages/shared/src/entities/DiscoveredSourceEntity.test.ts
@@ -102,7 +102,7 @@ describe("DiscoveredSourceEntity", () => {
           id: "abc123",
           status: "pending_metadata",
         }),
-        { exists: null },
+        { exists: false },
       );
     });
 

--- a/packages/shared/src/entities/DiscoveredSourceEntity.ts
+++ b/packages/shared/src/entities/DiscoveredSourceEntity.ts
@@ -192,7 +192,7 @@ export class DiscoveredSourceEntity {
     });
 
     await this.model.create(this.toInternal(discovery) as never, {
-      exists: null,
+      exists: false,
     });
     return discovery;
   }


### PR DESCRIPTION
## Summary

- Fix `DiscoveredSourceEntity.create()` to use `exists: false` (conditional put) instead of `exists: null` (unconditional overwrite)
- OneTable's `exists: null` means "overwrite if exists" — the opposite of what was intended
- This caused every discovery run to silently reset ~500 existing records back to `pending_metadata`, wasting Anthropic credits on redundant LLM evaluations

Fixes #615

## Test plan

- [x] `pnpm --filter @usopc/shared test` — 319 tests pass (including updated assertion)
- [x] `pnpm typecheck` passes
- [ ] Manual: run discovery on staging twice, verify second run shows "Skipping existing" log messages instead of "Creating discovered source" for known URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.9% | +0.0% |
| shared | 92.2% | +0.0% |
| ingestion | 77.8% | +0.0% |
| evals | 43.8% | +0.0% |
| slack | 75.9% | +0.0% |
| web | 65.6% | +0.0% |
<!-- coverage-summary-end -->