### PR TITLE
fix: grant EC2 role S3 access to SST state bucket

### DIFF
--- a/sst.config.ts
+++ b/sst.config.ts
@@ -596,6 +596,22 @@ export default $config({
               ],
               Resource: queueArns,
             },
+            // SST Pulumi state bucket — sst shell reads Pulumi state from S3
+            // to resolve resource bindings. The bucket has a random suffix so
+            // we match with a prefix wildcard; sst-state-* is unique to SST.
+            {
+              Effect: "Allow",
+              Action: [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject",
+                "s3:ListBucket",
+              ],
+              Resource: [
+                "arn:aws:s3:::sst-state-*",
+                "arn:aws:s3:::sst-state-*/*",
+              ],
+            },
           ],
         });
       });


### PR DESCRIPTION
## Problem

`sst shell --stage staging -- env` fails with:

```
AccessDenied: AppEc2Role is not authorized to perform: s3:GetObject on resource:
"arn:aws:s3:::sst-state-vdbtshhzssdv/app/usopc-athlete-support/staging.json"
```

`sst shell` reads Pulumi state from S3 to resolve which resources exist and what their bindings are, before reading their values from SSM Parameter Store. The EC2 instance role had no S3 access to the SST state bucket.

## Fix

Add S3 CRUD access for `sst-state-*` to the `AppEc2ResourcePolicy` inline policy in `sst.config.ts`. The bucket suffix is random per account, so a prefix wildcard is used.

## Changes

- `sst.config.ts`: add S3 statement for `arn:aws:s3:::sst-state-*` to the EC2 role inline policy

Fixes #648

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.9% | +0.0% |
| shared | 92.2% | +0.0% |
| ingestion | 77.8% | +0.0% |
| evals | 43.8% | +0.0% |
| slack | 75.0% | +0.0% |
| web | 65.6% | +0.0% |
<!-- coverage-summary-end -->