### PR TITLE
fix: remove --print-logs from sst shell to prevent .env.ec2 corruption

### DIFF
--- a/.hours.json
+++ b/.hours.json
@@ -1,5 +1,5 @@
 {
   "hours": 160.1,
   "idleCutoffMin": 10,
-  "updatedAt": "2026-04-09T12:24:26.856Z"
+  "updatedAt": "2026-04-09T12:37:44.887Z"
 }

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 **Tracked build time:** 160.1 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-04-09T12:24:26.856Z
+- Last updated: 2026-04-09T12:37:44.887Z
 <!-- HOURS:END -->
 
 ## License

--- a/scripts/sync-sst-env.sh
+++ b/scripts/sync-sst-env.sh
@@ -32,10 +32,14 @@ SST="$APP_DIR/node_modules/.bin/sst"
 echo "==> Installing SST platform binaries"
 "$SST" install
 
-"$SST" shell --print-logs --stage "$STAGE" -- env | grep '^SST_RESOURCE_' >> "$ENV_FILE"
+# Run sst shell without --print-logs. With --print-logs, SST mixes its
+# internal log lines into stdout alongside the actual env output, which
+# corrupts the env file with bare text fragments.  Logs go to
+# .sst/log/sst.log — check that file if sst shell fails unexpectedly.
+"$SST" shell --stage "$STAGE" -- env | grep '^SST_RESOURCE_' >> "$ENV_FILE"
 
 # Also extract the computed APP_URL and EMAIL_FROM if set
-"$SST" shell --print-logs --stage "$STAGE" -- env | grep -E '^(APP_URL|EMAIL_FROM)=' >> "$ENV_FILE" 2>/dev/null || true
+"$SST" shell --stage "$STAGE" -- env | grep -E '^(APP_URL|EMAIL_FROM)=' >> "$ENV_FILE" 2>/dev/null || true
 
 chmod 600 "$ENV_FILE"
 echo "==> Written to $ENV_FILE ($(wc -l < "$ENV_FILE") lines)"


### PR DESCRIPTION
## Problem

After v0.5.27, `sync-sst-env.sh` succeeds writing `.env.ec2` (28 lines), but then `deploy-ec2.sh` fails when sourcing it:

```
/home/ec2-user/app/.env.ec2: line 28: usopc-athlete-support,: command not found
```

## Root Cause

The `--print-logs` flag added in #647 causes SST to mix its internal log output into stdout alongside the actual `env` output. Some of those log lines get through the `grep '^SST_RESOURCE_'` filter (e.g. a log line containing the app name `usopc-athlete-support,` at the start) and land in `.env.ec2` as bare text fragments. When bash sources the file, it tries to execute those fragments as commands.

## Fix

Remove `--print-logs`. SST logs go to `.sst/log/sst.log` by default — the `sst install` step already confirmed `sst shell` connects to AWS successfully.

## Changes

- `scripts/sync-sst-env.sh`: remove `--print-logs` from both `sst shell` invocations

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.9% | +0.0% |
| shared | 92.2% | +0.0% |
| ingestion | 77.8% | +0.0% |
| evals | 43.8% | +0.0% |
| slack | 75.0% | +0.0% |
| web | 65.6% | +0.0% |
<!-- coverage-summary-end -->