### PR TITLE
fix: add debug logging to sync-sst-env.sh to diagnose .env.ec2 corruption

### DIFF
--- a/scripts/sync-sst-env.sh
+++ b/scripts/sync-sst-env.sh
@@ -32,14 +32,28 @@ SST="$APP_DIR/node_modules/.bin/sst"
 echo "==> Installing SST platform binaries"
 "$SST" install
 
-# Run sst shell without --print-logs. With --print-logs, SST mixes its
-# internal log lines into stdout alongside the actual env output, which
-# corrupts the env file with bare text fragments.  Logs go to
-# .sst/log/sst.log — check that file if sst shell fails unexpectedly.
-"$SST" shell --stage "$STAGE" -- env | grep '^SST_RESOURCE_' >> "$ENV_FILE"
+# Capture raw sst shell output to a temp file for debugging.
+# This lets us see exactly what SST outputs before filtering — useful for
+# diagnosing cases where unexpected lines end up in .env.ec2.
+SST_RAW=$(mktemp)
+trap 'rm -f "$SST_RAW"' EXIT
+
+echo "==> Running: sst shell --stage $STAGE -- env"
+"$SST" shell --stage "$STAGE" -- env > "$SST_RAW"
+
+echo "==> Raw sst shell output: $(wc -l < "$SST_RAW") lines total"
+echo "==> First 10 lines of raw output:"
+head -10 "$SST_RAW" || true
+echo "==> Last 10 lines of raw output:"
+tail -10 "$SST_RAW" || true
+echo "==> Lines NOT matching SST_RESOURCE_|APP_URL|EMAIL_FROM (potential noise):"
+grep -v '^SST_RESOURCE_\|^APP_URL=\|^EMAIL_FROM=' "$SST_RAW" | grep -v '^$' || echo "(none — output is clean)"
+
+# Write filtered vars to env file
+grep '^SST_RESOURCE_' "$SST_RAW" >> "$ENV_FILE"
 
 # Also extract the computed APP_URL and EMAIL_FROM if set
-"$SST" shell --stage "$STAGE" -- env | grep -E '^(APP_URL|EMAIL_FROM)=' >> "$ENV_FILE" 2>/dev/null || true
+grep -E '^(APP_URL|EMAIL_FROM)=' "$SST_RAW" >> "$ENV_FILE" 2>/dev/null || true
 
 chmod 600 "$ENV_FILE"
 echo "==> Written to $ENV_FILE ($(wc -l < "$ENV_FILE") lines)"


### PR DESCRIPTION
Closes #651

## Problem

v0.5.28 deploy fails with:
```
/home/ec2-user/app/.env.ec2: line 28: usopc-athlete-support,: command not found
```

Line 28 of `.env.ec2` is the bare text `usopc-athlete-support,` — not a valid variable assignment. Removing `--print-logs` (PR #650) did not fix it, so the corruption comes from `sst shell -- env` stdout itself.

## Change

Capture raw `sst shell -- env` stdout to a temp file before filtering, then print to the deploy log:
- Total line count
- First 10 lines
- Last 10 lines
- Any lines that are **not** `SST_RESOURCE_*`, `APP_URL=`, or `EMAIL_FROM=` (the noise)

This surfaces exactly what SST outputs so we can see where `usopc-athlete-support,` originates.

The filtering logic is unchanged — this is a pure diagnostic addition.

## Test plan

- [ ] Merge and tag v0.5.29
- [ ] Watch "Deploy apps to EC2" logs — the new debug section will appear before the corruption point
- [ ] Identify the offending line in the raw output
- [ ] Follow up with a targeted fix in the next PR

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.9% | +0.0% |
| shared | 92.2% | +0.0% |
| ingestion | 77.8% | +0.0% |
| evals | 43.8% | +0.0% |
| slack | 75.0% | +0.0% |
| web | 65.6% | +0.0% |
<!-- coverage-summary-end -->