### PR TITLE
fix: single-quote SST_RESOURCE_* values in .env.ec2 to prevent word-splitting

### DIFF
--- a/.hours.json
+++ b/.hours.json
@@ -1,5 +1,5 @@
 {
   "hours": 160.1,
   "idleCutoffMin": 10,
-  "updatedAt": "2026-04-09T12:37:44.887Z"
+  "updatedAt": "2026-04-09T13:44:00.951Z"
 }

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 **Tracked build time:** 160.1 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-04-09T12:37:44.887Z
+- Last updated: 2026-04-09T13:44:00.951Z
 <!-- HOURS:END -->
 
 ## License

--- a/scripts/sync-sst-env.sh
+++ b/scripts/sync-sst-env.sh
@@ -32,9 +32,7 @@ SST="$APP_DIR/node_modules/.bin/sst"
 echo "==> Installing SST platform binaries"
 "$SST" install
 
-# Capture raw sst shell output to a temp file for debugging.
-# This lets us see exactly what SST outputs before filtering — useful for
-# diagnosing cases where unexpected lines end up in .env.ec2.
+# Capture raw sst shell output to a temp file.
 SST_RAW=$(mktemp)
 trap 'rm -f "$SST_RAW"' EXIT
 
@@ -42,15 +40,16 @@ echo "==> Running: sst shell --stage $STAGE -- env"
 "$SST" shell --stage "$STAGE" -- env > "$SST_RAW"
 
 echo "==> Raw sst shell output: $(wc -l < "$SST_RAW") lines total"
-echo "==> First 10 lines of raw output:"
-head -10 "$SST_RAW" || true
-echo "==> Last 10 lines of raw output:"
-tail -10 "$SST_RAW" || true
-echo "==> Lines NOT matching SST_RESOURCE_|APP_URL|EMAIL_FROM (potential noise):"
-grep -v '^SST_RESOURCE_\|^APP_URL=\|^EMAIL_FROM=' "$SST_RAW" | grep -v '^$' || echo "(none — output is clean)"
 
-# Write filtered vars to env file
-grep '^SST_RESOURCE_' "$SST_RAW" >> "$ENV_FILE"
+# Write SST_RESOURCE_* vars to env file, single-quoting each value.
+# SST_RESOURCE_App contains spaces (e.g. {"name": "app", "stage": "staging" })
+# which bash word-splits on source if the value is unquoted — causing
+# "command not found" errors. Wrapping in single quotes prevents this.
+while IFS= read -r line; do
+  key="${line%%=*}"
+  value="${line#*=}"
+  printf "%s='%s'\n" "$key" "$value"
+done < <(grep '^SST_RESOURCE_' "$SST_RAW") >> "$ENV_FILE"
 
 # Also extract the computed APP_URL and EMAIL_FROM if set
 grep -E '^(APP_URL|EMAIL_FROM)=' "$SST_RAW" >> "$ENV_FILE" 2>/dev/null || true


### PR DESCRIPTION
Closes #653

## Root Cause

`SST_RESOURCE_App` has spaces in its JSON value:
```
SST_RESOURCE_App={"name": "usopc-athlete-support", "stage": "staging" }
```

When `.env.ec2` is sourced with `set -a; source`, bash word-splits the unquoted value on spaces and tries to execute `"usopc-athlete-support,"` as a command — exit 127.

Discovered via the debug logging added in PR #652 (v0.5.29). The raw SST shell output shows `SST_RESOURCE_App` is always written with spaces in the JSON.

## Fix

Use a `while read` loop to split each line at the first `=`, then write `KEY='VALUE'` to the env file. Single quotes prevent word-splitting on source.

```
# Before
SST_RESOURCE_App={"name": "usopc-athlete-support", "stage": "staging" }

# After
SST_RESOURCE_App='{"name": "usopc-athlete-support", "stage": "staging" }'
```

Also removes the verbose first/last 10-line debug output now that the root cause is known (keeps the line-count summary for confirmation).

## Test plan

- [ ] Merge and tag v0.5.30
- [ ] Watch "Deploy apps to EC2" — `.env.ec2` should source cleanly
- [ ] PM2 restarts successfully, smoke tests pass

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.9% | +0.0% |
| shared | 92.2% | +0.0% |
| ingestion | 77.8% | +0.0% |
| evals | 43.8% | +0.0% |
| slack | 75.0% | +0.0% |
| web | 65.6% | +0.0% |
<!-- coverage-summary-end -->