### PR TITLE
fix: install PM2 in deploy-ec2.sh if not found on PATH

### DIFF
--- a/scripts/deploy-ec2.sh
+++ b/scripts/deploy-ec2.sh
@@ -25,6 +25,14 @@ if ! command -v pnpm &>/dev/null; then
   npm install -g --prefix /home/ec2-user/.local pnpm@9
 fi
 
+# Ensure PM2 is available. PM2 is installed globally via userData but may not
+# be on PATH in non-login SSH sessions. Use the same user-local prefix as pnpm
+# so the binary lands in ~/.local/bin, which is already on PATH above.
+if ! command -v pm2 &>/dev/null; then
+  echo "==> PM2 not found — installing to /home/ec2-user/.local"
+  npm install -g --prefix /home/ec2-user/.local pm2
+fi
+
 # Clone on first deploy, otherwise just fetch
 if [ ! -d "$APP_DIR/.git" ]; then
   echo "==> First deploy — cloning repo"


### PR DESCRIPTION
Closes #655

## Problem

v0.5.30 deploy fails at \"Starting/restarting PM2 processes\":
```
==> Starting/restarting PM2 processes
/home/***/app/scripts/deploy-ec2.sh: line 81: pm2: command not found
```

PM2 is installed globally via EC2 `userData` (`npm install -g pm2`) but is not accessible in the non-login SSH session's PATH during deployment.

## Fix

Add a PM2 install guard at the top of `deploy-ec2.sh`, immediately after the pnpm guard, using the same `--prefix /home/ec2-user/.local` pattern:

```bash
if ! command -v pm2 &>/dev/null; then
  echo "==> PM2 not found — installing to /home/ec2-user/.local"
  npm install -g --prefix /home/ec2-user/.local pm2
fi
```

Since `~/.local/bin` is already prepended to PATH earlier in the script, PM2 is immediately findable after install. The guard is idempotent — no-op on subsequent deploys.

## Test plan

- [ ] Merge and tag v0.5.31
- [ ] Watch "Deploy apps to EC2" — PM2 installs on first run (if needed), then `pm2 restart` succeeds
- [ ] Health checks pass
- [ ] Smoke tests pass

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.9% | +0.0% |
| shared | 92.2% | +0.0% |
| ingestion | 77.8% | +0.0% |
| evals | 43.8% | +0.0% |
| slack | 75.0% | +0.0% |
| web | 65.6% | +0.0% |
<!-- coverage-summary-end -->