### PR TITLE
fix: correct server.js path in ecosystem.config.cjs for pnpm monorepo

### DIFF
--- a/.hours.json
+++ b/.hours.json
@@ -1,5 +1,5 @@
 {
   "hours": 160.1,
   "idleCutoffMin": 10,
-  "updatedAt": "2026-04-09T13:44:00.951Z"
+  "updatedAt": "2026-04-09T14:18:13.046Z"
 }

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ See [CLAUDE.md](./CLAUDE.md) for detailed development guidelines.
 **Tracked build time:** 160.1 hours
 
 - Method: terminal-activity-based (idle cutoff: 10 min)
-- Last updated: 2026-04-09T13:44:00.951Z
+- Last updated: 2026-04-09T14:18:13.046Z
 <!-- HOURS:END -->
 
 ## License

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -5,7 +5,7 @@ module.exports = {
   apps: [
     {
       name: "web",
-      script: "apps/web/.next/standalone/server.js",
+      script: "apps/web/.next/standalone/apps/web/server.js",
       env: {
         NODE_ENV: "production",
         PORT: 3000,


### PR DESCRIPTION
Closes #657

## Problem

v0.5.31 deploy fails with:
```
[PM2][ERROR] Error: Script not found: /home/***/app/apps/web/.next/standalone/server.js
```

## Root Cause

In a pnpm workspace, Next.js standalone output preserves the full monorepo directory structure. The actual server.js location is:
```
apps/web/.next/standalone/apps/web/server.js
```

Not at the standalone root (`apps/web/.next/standalone/server.js`).

**Evidence already in the codebase:** `deploy-ec2.sh` copies static assets to `standalone/apps/web/.next/static`, confirming the monorepo-rooted output structure.

## Fix

One-line change to `ecosystem.config.cjs`:
```js
// Before
script: "apps/web/.next/standalone/server.js",

// After
script: "apps/web/.next/standalone/apps/web/server.js",
```

## Test plan

- [ ] Merge and tag v0.5.32
- [ ] PM2 starts web process successfully
- [ ] Health checks pass on :3000
- [ ] Smoke tests pass

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.9% | +0.0% |
| shared | 92.2% | +0.0% |
| ingestion | 77.8% | +0.0% |
| evals | 43.8% | +0.0% |
| slack | 75.0% | +0.0% |
| web | 65.6% | +0.0% |
<!-- coverage-summary-end -->