### PR TITLE
fix(gcp-deploy): attach environment to deploy jobs & adopt AR registry

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -62,6 +62,7 @@ jobs:
   build-image:
     needs: setup
     runs-on: ubuntu-latest
+    environment: ${{ needs.setup.outputs.environment }}
     permissions:
       contents: read
       id-token: write
@@ -100,6 +101,7 @@ jobs:
   migrate:
     needs: [setup, deploy]
     runs-on: ubuntu-latest
+    environment: ${{ needs.setup.outputs.environment }}
     permissions:
       contents: read
       id-token: write
@@ -194,6 +196,7 @@ jobs:
   smoke-test:
     needs: [setup, migrate]
     runs-on: ubuntu-latest
+    environment: ${{ needs.setup.outputs.environment }}
     permissions:
       contents: read
       id-token: write

--- a/infra/gcp/index.ts
+++ b/infra/gcp/index.ts
@@ -76,13 +76,25 @@ roles.forEach(
 // Artifact Registry
 // ---------------------------------------------------------------------------
 
-const registry = new gcp.artifactregistry.Repository(`${prefix}-registry`, {
-  repositoryId: `${prefix}-images`,
-  format: "DOCKER",
-  location: region,
-  project,
-  description: `Docker images for USOPC ${environment}`,
-});
+// `import` adopts the Artifact Registry repository into Pulumi state on first
+// `up`. The repo is created out-of-band via gcloud before the first deploy
+// because the build-image CI step needs somewhere to push before Pulumi runs
+// (chicken-and-egg on cold bootstrap). After one successful `up` the resource
+// is tracked in state and the import option is a no-op — safe to leave in
+// place, but can be removed in a future PR.
+const registry = new gcp.artifactregistry.Repository(
+  `${prefix}-registry`,
+  {
+    repositoryId: `${prefix}-images`,
+    format: "DOCKER",
+    location: region,
+    project,
+    description: `Docker images for USOPC ${environment}`,
+  },
+  {
+    import: `projects/${project}/locations/${region}/repositories/${prefix}-images`,
+  },
+);
 
 // ---------------------------------------------------------------------------
 // Cloud SQL (PostgreSQL + pgvector)


### PR DESCRIPTION
## Summary

First GCP deploy (v0.6.0 / v0.6.1) failed at the `build-image` step with:
```
denied: Permission 'artifactregistry.repositories.uploadArtifacts' denied on resource (or it may not exist)
```

Two interlocking root causes:

### 1. Missing `environment:` on deploy-pipeline jobs

`GCP_SERVICE_ACCOUNT` is scoped to the `staging` / `production` GitHub environments, but `build-image`, `migrate`, and `smoke-test` jobs had no `environment:` directive. Environment-scoped secrets were therefore empty, `google-github-actions/auth@v2` silently fell back to direct WIF (no SA impersonation), and the federated principal lacked `artifactregistry.writer` — so the push was denied.

Evidence: the auth step's `with:` block only logged `workload_identity_provider: ***`, not `service_account: ***`, confirming the SA input was empty.

Fix: add `environment: ${{ needs.setup.outputs.environment }}` to `build-image`, `migrate`, and `smoke-test`. The `deploy` job already had it.

### 2. Artifact Registry cold-bootstrap chicken-and-egg

Workflow ordering: `build-image` (push to AR) → `deploy` (Pulumi creates AR). On first deploy the registry doesn't exist yet when the push runs. I created `usopc-staging-images` manually via `gcloud` to unblock, but now Pulumi `up` will fail on "already exists".

Fix: add `{ import: "projects/<p>/locations/<r>/repositories/<prefix>-images" }` to the Pulumi `Repository` resource. This adopts the existing repo into state on first `up` instead of attempting to create it. After one successful apply the option is a no-op.

## Test plan

- [ ] Merge → staging deploy runs on `main` push
- [ ] `build-image` step succeeds (SA impersonated, push to AR works)
- [ ] `deploy` step succeeds (Pulumi imports the existing registry rather than failing on conflict)
- [ ] `migrate` and `smoke-test` steps succeed with env-scoped secrets
- [ ] Tag `v0.6.2` after green to exercise the production path (note: production GCP project setup still needs to be completed separately — `joel.rosinbum@gmail.com` has no access to `usopc-athlete-support-prod`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 48.2% | +0.0% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->