### PR TITLE
fix(gcp-infra): remove ESM type from Pulumi package.json

### DIFF
--- a/infra/gcp/package.json
+++ b/infra/gcp/package.json
@@ -2,7 +2,6 @@
   "name": "usopc-gcp-infra",
   "version": "1.0.0",
   "private": true,
-  "type": "module",
   "main": "index.ts",
   "scripts": {
     "preview": "pulumi preview",


### PR DESCRIPTION
## Summary

Next deploy failure (run 24472589629): Pulumi Preview crashed with `TypeError: Unknown file extension \".ts\" for infra/gcp/index.ts`.

Pulumi's built-in TypeScript runtime (`runtime: nodejs` + `options: typescript: true`) uses `ts-node` under the hood, which expects CommonJS. With `\"type\": \"module\"` set, Node refuses to load `.ts` as a CJS file and ts-node's loader doesn't kick in. Removing the field unblocks Pulumi.

## Test plan

- [ ] Merge → main push triggers staging deploy
- [ ] `deploy` job's Pulumi Preview + Up succeed (including adopting the existing Artifact Registry via the `import` option shipped in #664)
- [ ] `migrate` and `smoke-test` jobs run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 48.2% | +0.0% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->