### PR TITLE
fix(gcp-infra): correct Cloud Run v2 field names

### DIFF
--- a/infra/gcp/index.ts
+++ b/infra/gcp/index.ts
@@ -284,9 +284,9 @@ const webService = new gcp.cloudrunv2.Service(`${prefix}-web`, {
       {
         image: appImage,
         // Web — Express + React Router SSR, run via tsx.
-        command: ["tsx"],
+        commands: ["tsx"],
         args: ["apps/web/server/app.ts"],
-        ports: [{ containerPort: 8080 }],
+        ports: { containerPort: 8080 },
         resources: {
           limits: { cpu: "2", memory: "1Gi" },
         },
@@ -337,9 +337,9 @@ const slackService = new gcp.cloudrunv2.Service(`${prefix}-slack`, {
         image: appImage,
         // Slack — compiled .js but imports @usopc/shared/core (.ts main), so
         // tsx is required at runtime.
-        command: ["tsx"],
+        commands: ["tsx"],
         args: ["apps/slack/dist/server.js"],
-        ports: [{ containerPort: 8080 }],
+        ports: { containerPort: 8080 },
         resources: {
           limits: { cpu: "1", memory: "512Mi" },
         },
@@ -373,9 +373,9 @@ const workerService = new gcp.cloudrunv2.Service(`${prefix}-worker`, {
       {
         image: appImage,
         // Worker — same rationale as slack.
-        command: ["tsx"],
+        commands: ["tsx"],
         args: ["packages/ingestion/dist/httpServer.js"],
-        ports: [{ containerPort: 8080 }],
+        ports: { containerPort: 8080 },
         resources: {
           limits: { cpu: "2", memory: "2Gi" },
         },


### PR DESCRIPTION
## Summary

After #665 unblocked Pulumi's TS loader, ts-node surfaced real type errors:

- `command` should be `commands` (string[]) on `ServiceTemplateContainer`
- `ports` expects a single `{ containerPort }` object, not an array

These errors only manifested at Pulumi runtime because the `infra/gcp` program has never successfully typechecked against the real `@pulumi/gcp` types (there's no `tsc --noEmit` step in CI for the Pulumi program).

## Test plan

- [ ] Merge → `deploy` job's Pulumi Preview + Up succeed on staging
- [ ] `migrate` + `smoke-test` run cleanly
- [ ] Follow-up: add a typecheck step for `infra/gcp` to CI so shape bugs don't only surface in prod deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 48.2% | +0.0% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->