### PR TITLE
fix(gcp-infra): pin Cloud SQL to ENTERPRISE edition, enable Compute API

### DIFF
--- a/infra/gcp/index.ts
+++ b/infra/gcp/index.ts
@@ -30,6 +30,8 @@ const apis = [
   "artifactregistry.googleapis.com",
   "cloudscheduler.googleapis.com",
   "monitoring.googleapis.com",
+  // Provider needs this to list regions (warning-only today, but silencing).
+  "compute.googleapis.com",
 ];
 
 const enabledApis = apis.map(
@@ -106,6 +108,10 @@ const dbInstance = new gcp.sql.DatabaseInstance(`${prefix}-db`, {
   project,
   settings: {
     tier: dbTier,
+    // Pin to ENTERPRISE edition — db-custom-* tiers are only valid there.
+    // ENTERPRISE_PLUS (the new default on fresh projects) requires a
+    // different tier family (db-perf-optimized-N-*).
+    edition: "ENTERPRISE",
     availabilityType: environment === "production" ? "REGIONAL" : "ZONAL",
     backupConfiguration: {
       enabled: true,


### PR DESCRIPTION
## Summary

Staging Pulumi Up failed creating the DB instance:
```
Invalid Tier (db-custom-2-7680) for (ENTERPRISE_PLUS) Edition.
```

New GCP projects default to `ENTERPRISE_PLUS`, which only accepts the `db-perf-optimized-N-*` tier family. Our configured tier (`db-custom-2-7680`) is only valid for `ENTERPRISE`. Pin the instance to `ENTERPRISE`.

Also added `compute.googleapis.com` to the enabled APIs list — the provider was emitting a warning about not being able to list regions.

## Test plan

- [ ] Merge → main push triggers staging deploy
- [ ] Pulumi Up creates the remaining resources (DB instance + Cloud Run services + subscriptions + scheduler jobs)
- [ ] `migrate` + `smoke-test` run and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 48.2% | +0.0% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->