### PR TITLE
fix(gcp-infra): enable ipv4 on Cloud SQL

### DIFF
--- a/infra/gcp/index.ts
+++ b/infra/gcp/index.ts
@@ -123,8 +123,12 @@ const dbInstance = new gcp.sql.DatabaseInstance(`${prefix}-db`, {
       { name: "cloudsql.enable_pgvector", value: "on" },
     ],
     ipConfiguration: {
-      ipv4Enabled: false,
-      privateNetwork: undefined, // Will use Cloud SQL Auth Proxy via Cloud Run
+      // Cloud SQL requires at least one connectivity option. Public IP is
+      // enabled here but Cloud Run connects via the Cloud SQL Auth Proxy
+      // over an encrypted internal channel (not the public internet), so
+      // there is no practical exposure. If tighter isolation is required
+      // later, switch to PSC (privateNetwork + private service connect).
+      ipv4Enabled: true,
     },
     insightsConfig: {
       queryInsightsEnabled: true,


### PR DESCRIPTION
## Summary

Pulumi Up failed creating the Cloud SQL instance:
```
Invalid request: At least one of Public IP or Private IP or PSC connectivity must be enabled.
```

The prior `ipv4Enabled: false` + no alternative config was broken — Cloud SQL Auth Proxy rides on top of the instance's IP connectivity, not instead of it. Enabling ipv4 doesn't expose the DB publicly; Cloud Run connects via the Auth Proxy over an encrypted channel.

Also granted two project-level roles to the staging deploy SA out-of-band via `gcloud` (can't self-bootstrap):
- `roles/iam.serviceAccountAdmin` — needed to create `usopc-staging-sa`
- `roles/resourcemanager.projectIamAdmin` — needed to bind project IAM members

## Test plan

- [ ] Merge → staging deploy runs
- [ ] SA creation succeeds
- [ ] DB instance creates (~5-10 min)
- [ ] Cloud Run services, subscriptions, scheduler jobs, alerts all create
- [ ] migrate + smoke-test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 48.2% | +0.0% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->