### PR TITLE
fix(gcp-infra): remove non-existent cloudsql.enable_pgvector flag

### DIFF
--- a/infra/gcp/index.ts
+++ b/infra/gcp/index.ts
@@ -118,10 +118,10 @@ const dbInstance = new gcp.sql.DatabaseInstance(`${prefix}-db`, {
       startTime: "03:00",
       pointInTimeRecoveryEnabled: environment === "production",
     },
-    databaseFlags: [
-      // Enable pgvector via shared_preload_libraries
-      { name: "cloudsql.enable_pgvector", value: "on" },
-    ],
+    // pgvector is available on Cloud SQL for Postgres via
+    // `CREATE EXTENSION vector;` at the DB level — no instance flag
+    // needed. (The old `cloudsql.enable_pgvector` flag is not a real
+    // Cloud SQL flag name and was rejected at create time.)
     ipConfiguration: {
       // Cloud SQL requires at least one connectivity option. Public IP is
       // enabled here but Cloud Run connects via the Cloud SQL Auth Proxy


### PR DESCRIPTION
## Summary

Pulumi Up failed creating the DB instance:
```
Error 404: The requested flag is either misspelled or unsupported by Cloud SQL.
```

`cloudsql.enable_pgvector` isn't a real Cloud SQL instance flag. Cloud SQL for Postgres ships pgvector as an available extension — it's enabled per-database via `CREATE EXTENSION vector;` (handled in migrations), not at instance level. Removing the flag.

## Test plan

- [ ] Merge → staging deploy runs
- [ ] DB instance creates (expect ~5-10 min wait)
- [ ] Follow-on: verify `CREATE EXTENSION vector` runs via the migrate job or an existing migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 48.2% | +0.0% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->