### PR TITLE
fix(ci): remove explicit pnpm version from migrate step

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -122,8 +122,6 @@ jobs:
           chmod +x cloud-sql-proxy
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

Migrate step failed:
```
Multiple versions of pnpm specified:
  - version 9 in the GitHub Action config
  - version pnpm@9.15.4 in package.json with the key "packageManager"
```

`pnpm/action-setup@v4` auto-reads `packageManager` from package.json. Remove the explicit `version: 9` so it uses the lockfile-pinned version.

## Test plan

- [ ] Merge → migrate step passes
- [ ] Smoke test runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 48.2% | +0.0% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->