### PR TITLE
fix(gcp-infra): make web service public, auth smoke test for worker

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -223,10 +223,13 @@ jobs:
 
       - name: Health checks
         run: |
+          # Web is public (allUsers invoker), no auth needed.
           echo "Checking web service..."
           curl -sf "${{ steps.urls.outputs.web_url }}/api/health" || exit 1
 
+          # Worker is private — use an identity token from the deploy SA.
+          TOKEN=$(gcloud auth print-identity-token --audiences="${{ steps.urls.outputs.worker_url }}")
           echo "Checking worker service..."
-          curl -sf "${{ steps.urls.outputs.worker_url }}/health" || exit 1
+          curl -sf -H "Authorization: Bearer $TOKEN" "${{ steps.urls.outputs.worker_url }}/health" || exit 1
 
           echo "All health checks passed!"

--- a/infra/gcp/index.ts
+++ b/infra/gcp/index.ts
@@ -330,6 +330,16 @@ const webService = new gcp.cloudrunv2.Service(`${prefix}-web`, {
   },
 });
 
+// Allow unauthenticated access to the web service — the app handles its
+// own auth (GitHub OAuth) and needs to be reachable from browsers.
+new gcp.cloudrunv2.ServiceIamMember(`${prefix}-web-public`, {
+  name: webService.name,
+  location: region,
+  project,
+  role: "roles/run.invoker",
+  member: "allUsers",
+});
+
 // Slack bot
 const slackService = new gcp.cloudrunv2.Service(`${prefix}-slack`, {
   name: `${prefix}-slack`,


### PR DESCRIPTION
## Summary

Smoke test failed because the web service requires authentication (Cloud Run default) but the curl had no auth token. The web app handles its own auth (GitHub OAuth) and should be publicly accessible.

- Add `allUsers` → `roles/run.invoker` IAM binding on the web service via Pulumi
- Update smoke test to include an identity token when curling the private worker service

## Test plan

- [ ] Merge → full pipeline green (build → deploy → migrate → smoke)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 48.2% | +0.0% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->