### PR TITLE
fix(web): externalize Google Cloud SDKs in SSR build

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -15,5 +15,17 @@ export default defineConfig({
   },
   ssr: {
     noExternal: ["@usopc/shared", "@usopc/core"],
+    // Google Cloud SDKs use CommonJS internals (__dirname, dynamic requires)
+    // that break when bundled into ESM. Keep them external so Node loads them
+    // from node_modules with CJS resolution at runtime.
+    external: [
+      "@google-cloud/pubsub",
+      "@google-cloud/storage",
+      "google-gax",
+      "google-auth-library",
+      "google-proto-files",
+      "@grpc/grpc-js",
+      "@grpc/proto-loader",
+    ],
   },
 });


### PR DESCRIPTION
## Summary

- Web service was returning `500` on `/` with `ReferenceError: __dirname is not defined in ES module scope`
- Vite was bundling `@google-cloud/pubsub`, `@google-cloud/storage`, and their gRPC/`google-gax` transitive deps into the SSR output (because `@usopc/shared` is `noExternal`). Those packages use CommonJS `__dirname`, which breaks once the bundle is loaded as ESM (`apps/web/package.json` has `"type": "module"`)
- Mark Google Cloud SDKs as `ssr.external` so Node loads them from `node_modules` with CJS resolution at runtime

## Root cause

The bundle at `apps/web/build/server/assets/src-*.js` contained gRPC internals like:
```
includeDirs: [`${__dirname}/../../proto`]
var googleProtoFilesDir = path.join(__dirname, "..", "..", "build", "protos");
```
These come from `google-proto-files` / `@grpc/proto-loader`, pulled in transitively by the Google Cloud SDKs.

## Test plan

- [x] `pnpm --filter @usopc/web build` succeeds locally
- [x] `grep __dirname build/server/**/*.js` returns no matches after the fix
- [x] `pnpm --filter @usopc/web typecheck` passes
- [ ] Staging deploy succeeds and `https://usopc-staging-web-otznt36mga-uc.a.run.app/` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 48.2% | +0.0% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->