### PR TITLE
fix(deploy): pin Cloud Run image to commit SHA

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -178,6 +178,7 @@ jobs:
           work-dir: ${{ env.PULUMI_DIR }}
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          IMAGE_TAG: ${{ github.sha }}
 
       - name: Pulumi Up
         uses: pulumi/actions@v6
@@ -187,6 +188,7 @@ jobs:
           work-dir: ${{ env.PULUMI_DIR }}
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          IMAGE_TAG: ${{ github.sha }}
 
   # -----------------------------------------------------------------------
   # Smoke test

--- a/infra/gcp/index.ts
+++ b/infra/gcp/index.ts
@@ -248,7 +248,12 @@ const registryUrl = pulumi.interpolate`${region}-docker.pkg.dev/${project}/${reg
 
 // All three Cloud Run services share one image; they're differentiated by the
 // `command` passed to the container. See Dockerfile at the repo root.
-const appImage = pulumi.interpolate`${registryUrl}/app:latest`;
+//
+// Pin to the commit SHA so Cloud Run forces a new revision on every deploy.
+// Referencing `:latest` would leave Pulumi seeing an unchanged string even as
+// the underlying digest moves, so no revision would be created.
+const imageTag = process.env.IMAGE_TAG ?? "latest";
+const appImage = pulumi.interpolate`${registryUrl}/app:${imageTag}`;
 
 // Helper: build a secret env var referencing Secret Manager
 function secretEnv(envName: string, secretName: string) {


### PR DESCRIPTION
## Summary

- Pulumi was referencing `app:latest` for Cloud Run images. The string never changes between deploys, so Pulumi sees no diff and skips updating the service — Cloud Run keeps running the previous revision even though a fresh image was pushed at the same tag
- This silently masked the SSR fix in #673: the new bundle was built and pushed, but Cloud Run never picked it up. Logs at 20:20 still showed the old `src-QUeM2htP.js` chunk failing with `__dirname is not defined`
- Pin the image to `app:<github.sha>` so each deploy produces a unique service spec and forces a fresh revision
- The build job already pushes both `:latest` and `:<sha>` tags, so no Dockerfile changes needed

## Changes

- `infra/gcp/index.ts`: read `process.env.IMAGE_TAG` (defaults to `latest` for local pulumi runs)
- `.github/workflows/deploy-gcp.yml`: pass `IMAGE_TAG: \${{ github.sha }}` to both `pulumi preview` and `pulumi up` steps

## Test plan

- [x] Pulumi index.ts changes are env-driven (defaults to `:latest` if `IMAGE_TAG` unset)
- [ ] Deploy run creates new Cloud Run revisions for all three services (web/slack/worker)
- [ ] Root URL `https://usopc-staging-web-otznt36mga-uc.a.run.app/` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 48.2% | +0.0% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->