### PR TITLE
fix(web): declare Google Cloud SDKs as direct deps

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,8 @@
     "@auth/express": "^0.12.1",
     "@auth/pg-adapter": "^1.11.1",
     "@fontsource-variable/inter": "^5.2.8",
+    "@google-cloud/pubsub": "^5.3.0",
+    "@google-cloud/storage": "^7.19.0",
     "@react-router/express": "^7.14.0",
     "@react-router/node": "^7.14.0",
     "@tavily/core": "^0.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,12 @@ importers:
       '@fontsource-variable/inter':
         specifier: ^5.2.8
         version: 5.2.8
+      '@google-cloud/pubsub':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@google-cloud/storage':
+        specifier: ^7.19.0
+        version: 7.19.0
       '@react-router/express':
         specifier: ^7.14.0
         version: 7.14.0(express@5.2.1)(react-router@7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
@@ -9042,7 +9048,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.14.0)
+      retry-axios: 2.6.0(axios@1.14.0(debug@4.4.3))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -10208,7 +10214,7 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  retry-axios@2.6.0(axios@1.14.0):
+  retry-axios@2.6.0(axios@1.14.0(debug@4.4.3)):
     dependencies:
       axios: 1.14.0(debug@4.4.3)
 


### PR DESCRIPTION
## Summary

After externalizing \`@google-cloud/*\` in vite.config.ts (#673), the SSR bundle does \`import \"@google-cloud/storage\"\` at runtime instead of bundling. Without hoisting (default pnpm), those packages are only symlinked into \`packages/shared/node_modules/\` because that's where they're declared. Node's ESM resolver, walking up from \`apps/web/build/server/assets/*.js\`, never finds them and errors with \`ERR_MODULE_NOT_FOUND\`.

Adding them as direct deps of \`@usopc/web\` puts them in \`apps/web/node_modules\` where the bundle's imports can resolve.

## Verified runtime error after #674 deployed

\`\`\`
Cannot find package '@google-cloud/storage' imported from
/app/apps/web/build/server/assets/src-C67t9orK.js
    at packageResolve (node:internal/modules/esm/resolve:873:9)
\`\`\`

The bundle filename changed (was \`src-QUeM2htP.js\`), confirming the SSR fix from #673/#674 deployed correctly — this is the next layer.

## Test plan

- [ ] Deploy succeeds and \`https://usopc-staging-web-otznt36mga-uc.a.run.app/\` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 48.2% | +0.0% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->