### PR TITLE
fix(web): static asset paths + disable REQUIRE_AUTH in staging

### DIFF
--- a/apps/web/server/app.ts
+++ b/apps/web/server/app.ts
@@ -1,6 +1,13 @@
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
 import express from "express";
 import { createRequestHandler } from "@react-router/express";
 import { authHandler } from "./auth.js";
+
+// Resolve paths relative to this file so the server works regardless of
+// process.cwd() (Cloud Run runs `tsx apps/web/server/app.ts` from /app).
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const webRoot = resolve(__dirname, "..");
 
 const app = express();
 
@@ -74,11 +81,11 @@ if (isDev) {
   );
 } else {
   // Production: serve static assets + pre-built server bundle
-  app.use(express.static("build/client", { maxAge: "1h" }));
+  app.use(express.static(resolve(webRoot, "build/client"), { maxAge: "1h" }));
   // The server build is produced by `react-router build` at deploy time and
   // doesn't exist during typecheck. Use a dynamic specifier so TS can't try
   // to resolve it statically.
-  const serverBuildPath = "../build/server/index.js";
+  const serverBuildPath = resolve(webRoot, "build/server/index.js");
   app.all(
     "*splat",
     createRequestHandler({

--- a/infra/gcp/index.ts
+++ b/infra/gcp/index.ts
@@ -308,7 +308,7 @@ const webService = new gcp.cloudrunv2.Service(`${prefix}-web`, {
         volumeMounts: [cloudSqlMount],
         envs: [
           { name: "NODE_ENV", value: "production" },
-          { name: "REQUIRE_AUTH", value: "true" },
+          { name: "REQUIRE_AUTH", value: "false" },
           { name: "STORAGE_PROVIDER", value: "gcs" },
           { name: "QUEUE_PROVIDER", value: "pubsub" },
           {


### PR DESCRIPTION
## Summary

Two fixes:

### 1. Static asset paths (CSS/JS not loading)
- Page rendered without CSS/JS in production: every \`/assets/*\` request returned 404 and the inlined stylesheet failed strict MIME checking
- Root cause: \`express.static(\"build/client\")\` resolved against \`process.cwd()\` (\`/app\` in Cloud Run), but assets are at \`/app/apps/web/build/client\`
- Resolve both the static directory and the server build entry relative to \`import.meta.url\`

### 2. REQUIRE_AUTH=false for staging
- Staging was forcing sign-in for chat and category links
- Set \`REQUIRE_AUTH=false\` in the Cloud Run web service so the anonymous fallback session is used (matches local dev behavior)

## Test plan

- [x] Typecheck passes
- [ ] CSS and client JS load on staging (no 404s for \`/assets/*\`)
- [ ] Clicking a category card navigates to chat without redirect to /auth/login

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 48.2% | +0.0% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->