### PR TITLE
fix(web): add google-auth-library as direct dep for SSR resolution

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
     "@usopc/shared": "workspace:*",
     "ai": "^6.0.0",
     "express": "^5.2.1",
+    "google-auth-library": "^10.0.0",
     "highlight.js": "^11.11.1",
     "isbot": "^5",
     "lucide-react": "^0.577.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      google-auth-library:
+        specifier: ^10.0.0
+        version: 10.6.2
       highlight.js:
         specifier: ^11.11.1
         version: 11.11.1
@@ -9048,7 +9051,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.3
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.14.0(debug@4.4.3))
+      retry-axios: 2.6.0(axios@1.14.0)
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -10214,7 +10217,7 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  retry-axios@2.6.0(axios@1.14.0(debug@4.4.3)):
+  retry-axios@2.6.0(axios@1.14.0):
     dependencies:
       axios: 1.14.0(debug@4.4.3)
 


### PR DESCRIPTION
## Summary

- Staging chat is currently broken. Every `POST /api/chat` returns 500 with `Error: Cannot find package 'google-auth-library' imported from /app/apps/web/build/server/assets/runner-B2LYSqbN.js`.
- Same class of bug as #675: `@usopc/core` is `noExternal`, so a LangChain / `@ai-sdk` transitive that does `import { GoogleAuth } from "google-auth-library"` ends up in the SSR bundle. `vite.config.ts` lists it under `ssr.external`, so the import stays in `runner-*.js` and must resolve at runtime — but without hoisting pnpm keeps it nested under `.pnpm/@google-cloud+storage@*`, and Node's walk from `apps/web/build/server/assets/` never finds it.
- Fix: declare `google-auth-library` as a direct dep of `@usopc/web` so pnpm symlinks `apps/web/node_modules/google-auth-library`.

Closes #677

## Test plan

- [x] `pnpm install` — pnpm creates `apps/web/node_modules/google-auth-library -> .pnpm/google-auth-library@10.6.2/...` symlink (verified locally).
- [x] `pnpm typecheck` — passes across the monorepo.
- [x] `pnpm --filter @usopc/web build` — still emits `import { GoogleAuth } from "google-auth-library"` in `runner-*.js` (externalization preserved).
- [ ] Staging deploy: confirm `POST /api/chat` stops 500-ing after rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 48.2% | +0.0% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->