### PR TITLE
fix(infra): wire TAVILY_API_KEY into staging web service

### DIFF
--- a/infra/gcp/index.ts
+++ b/infra/gcp/index.ts
@@ -329,6 +329,7 @@ const webService = new gcp.cloudrunv2.Service(`${prefix}-web`, {
           secretEnv("GITHUB_CLIENT_SECRET", "GITHUB_CLIENT_SECRET"),
           secretEnv("ADMIN_EMAILS", "ADMIN_EMAILS"),
           secretEnv("RESEND_API_KEY", "RESEND_API_KEY"),
+          secretEnv("TAVILY_API_KEY", "TAVILY_API_KEY"),
         ],
       },
     ],


### PR DESCRIPTION
## Summary

- After #678, staging \`POST /api/chat\` still 500s with \`Error: Missing required secret: TAVILY_API_KEY\`.
- \`packages/core/src/agent/runnerFactory.ts:75\` calls \`getSecretValue(\"TAVILY_API_KEY\")\`, which throws when the env var isn't set.
- The secret is wired into the slack and worker Cloud Run services but was never added to the web service.
- Fix: add \`secretEnv(\"TAVILY_API_KEY\", \"TAVILY_API_KEY\")\` to the web service's env list. The \`usopc-staging-TAVILY_API_KEY\` Secret Manager secret already exists with an enabled version.

Closes #679

## Test plan

- [ ] Pulumi diff in CI shows only the new env var on the web service.
- [ ] After deploy, \`POST /api/chat\` on staging no longer returns \`Missing required secret: TAVILY_API_KEY\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 48.2% | +0.0% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->