### PR TITLE
fix(web): separate admin auth so /admin requires real login

### DIFF
--- a/apps/web/app/routes/admin.tsx
+++ b/apps/web/app/routes/admin.tsx
@@ -1,10 +1,10 @@
 import { Outlet } from "react-router";
 import type { Route } from "./+types/admin";
-import { getSession, requireAdmin } from "../../server/session.js";
+import { getAdminSession, requireAdmin } from "../../server/session.js";
 import AdminNav from "../../components/admin/AdminNav.js";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const session = await getSession(request);
+  const session = await getAdminSession(request);
   requireAdmin(session);
   return { session };
 }

--- a/apps/web/app/routes/api.admin.discoveries.$id.ts
+++ b/apps/web/app/routes/api.admin.discoveries.$id.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.admin.discoveries.$id.js";
 import { z } from "zod";
 import { REPROCESSABLE_STATUSES, logger } from "@usopc/shared";
-import { getSession } from "../../server/session.js";
+import { getAdminSession } from "../../server/session.js";
 
 const log = logger.child({ service: "admin-discoveries" });
 import { createDiscoveredSourceEntity } from "../../lib/discovered-source.js";
@@ -16,7 +16,7 @@ import { enqueueForReprocess } from "../../lib/services/discovery-reprocess.js";
 // ---------------------------------------------------------------------------
 
 async function requireAdmin(request: Request) {
-  const session = await getSession(request);
+  const session = await getAdminSession(request);
   if (!session?.user?.email) return apiError("Unauthorized", 401);
   if (session.user.role !== "admin") return apiError("Forbidden", 403);
   return null;
@@ -140,7 +140,7 @@ export async function action({ request, params }: Route.ActionArgs) {
     // -----------------------------------------------------------------------
     // approve / reject
     // -----------------------------------------------------------------------
-    const session = await getSession(request);
+    const session = await getAdminSession(request);
     const reviewedBy = session?.user?.email ?? "unknown";
 
     if (patchAction === "approve") {

--- a/apps/web/app/routes/api.admin.discoveries.bulk.ts
+++ b/apps/web/app/routes/api.admin.discoveries.bulk.ts
@@ -1,7 +1,7 @@
 import type { Route } from "./+types/api.admin.discoveries.bulk.js";
 import { z } from "zod";
 import { REPROCESSABLE_STATUSES, logger } from "@usopc/shared";
-import { getSession } from "../../server/session.js";
+import { getAdminSession } from "../../server/session.js";
 
 const log = logger.child({ service: "admin-discoveries-bulk" });
 import { createDiscoveredSourceEntity } from "../../lib/discovered-source.js";
@@ -16,7 +16,7 @@ import { enqueueForReprocess } from "../../lib/services/discovery-reprocess.js";
 // ---------------------------------------------------------------------------
 
 async function requireAdmin(request: Request) {
-  const session = await getSession(request);
+  const session = await getAdminSession(request);
   if (!session?.user?.email) return apiError("Unauthorized", 401);
   if (session.user.role !== "admin") return apiError("Forbidden", 403);
   return null;
@@ -159,7 +159,7 @@ export async function action({ request }: Route.ActionArgs) {
     // -----------------------------------------------------------------------
     // approve / reject
     // -----------------------------------------------------------------------
-    const session = await getSession(request);
+    const session = await getAdminSession(request);
     const reviewedBy = session?.user?.email ?? "unknown";
     const { ids } = result.data as { ids: string[] };
 

--- a/apps/web/app/routes/api.admin.discoveries.ts
+++ b/apps/web/app/routes/api.admin.discoveries.ts
@@ -3,7 +3,7 @@ import { logger } from "@usopc/shared";
 import type { DiscoveryStatus } from "@usopc/shared";
 
 const log = logger.child({ service: "admin-discoveries" });
-import { getSession } from "../../server/session.js";
+import { getAdminSession } from "../../server/session.js";
 import { createDiscoveredSourceEntity } from "../../lib/discovered-source.js";
 import { apiError } from "../../lib/apiResponse.js";
 
@@ -19,7 +19,7 @@ const VALID_STATUSES = new Set<DiscoveryStatus>([
 // ---------------------------------------------------------------------------
 
 async function requireAdmin(request: Request) {
-  const session = await getSession(request);
+  const session = await getAdminSession(request);
   if (!session?.user?.email) return apiError("Unauthorized", 401);
   if (session.user.role !== "admin") return apiError("Forbidden", 403);
   return null;

--- a/apps/web/app/routes/api.admin.discovery.run.ts
+++ b/apps/web/app/routes/api.admin.discovery.run.ts
@@ -1,13 +1,13 @@
 import type { Route } from "./+types/api.admin.discovery.run.js";
 import { logger, createDiscoveryRunEntity } from "@usopc/shared";
-import { getSession } from "../../server/session.js";
+import { getAdminSession } from "../../server/session.js";
 import { apiError } from "../../lib/apiResponse.js";
 import { runDiscovery } from "../../lib/services/discovery-service.js";
 
 const log = logger.child({ service: "admin-discovery-run" });
 
 export async function action({ request }: Route.ActionArgs) {
-  const session = await getSession(request);
+  const session = await getAdminSession(request);
   if (!session?.user?.email) return apiError("Unauthorized", 401);
   if (session.user.role !== "admin") return apiError("Forbidden", 403);
 

--- a/apps/web/app/routes/api.admin.invites.ts
+++ b/apps/web/app/routes/api.admin.invites.ts
@@ -1,5 +1,5 @@
 import type { Route } from "./+types/api.admin.invites.js";
-import { getSession } from "../../server/session.js";
+import { getAdminSession } from "../../server/session.js";
 import { sendInviteEmail } from "../../lib/send-invite-email.js";
 import { createInviteEntity, logger } from "@usopc/shared";
 import { z } from "zod";
@@ -11,7 +11,7 @@ const log = logger.child({ route: "admin/invites" });
 // ---------------------------------------------------------------------------
 
 async function requireAdmin(request: Request) {
-  const session = await getSession(request);
+  const session = await getAdminSession(request);
   if (!session?.user?.email)
     return {
       denied: Response.json({ error: "Unauthorized" }, { status: 401 }),
@@ -84,7 +84,7 @@ export async function action({ request }: Route.ActionArgs) {
 
 async function handlePost(
   request: Request,
-  session: NonNullable<Awaited<ReturnType<typeof getSession>>>,
+  session: NonNullable<Awaited<ReturnType<typeof getAdminSession>>>,
 ) {
   let body: unknown;
   try {
@@ -158,7 +158,7 @@ async function handleDelete(request: Request) {
 
 async function handlePatch(
   request: Request,
-  session: NonNullable<Awaited<ReturnType<typeof getSession>>>,
+  session: NonNullable<Awaited<ReturnType<typeof getAdminSession>>>,
 ) {
   let body: unknown;
   try {

--- a/apps/web/app/routes/api.admin.monitoring.ts
+++ b/apps/web/app/routes/api.admin.monitoring.ts
@@ -8,7 +8,7 @@ import {
   getResource,
   type DiscoveryStatus,
 } from "@usopc/shared";
-import { getSession } from "../../server/session.js";
+import { getAdminSession } from "../../server/session.js";
 import { apiError } from "../../lib/apiResponse.js";
 
 const log = logger.child({ service: "admin-monitoring" });
@@ -65,7 +65,7 @@ async function getDiscoveryCounts(
 // ---------------------------------------------------------------------------
 
 async function requireAdmin(request: Request) {
-  const session = await getSession(request);
+  const session = await getAdminSession(request);
   if (!session?.user?.email) return apiError("Unauthorized", 401);
   if (session.user.role !== "admin") return apiError("Forbidden", 403);
   return null;

--- a/apps/web/app/routes/api.admin.sources.$id.ingest.ts
+++ b/apps/web/app/routes/api.admin.sources.$id.ingest.ts
@@ -1,6 +1,6 @@
 import type { Route } from "./+types/api.admin.sources.$id.ingest.js";
 import { logger } from "@usopc/shared";
-import { getSession } from "../../server/session.js";
+import { getAdminSession } from "../../server/session.js";
 import { apiError } from "../../lib/apiResponse.js";
 
 const log = logger.child({ service: "admin-sources-ingest" });
@@ -12,7 +12,7 @@ import { triggerIngestion } from "../../lib/services/source-service.js";
 // ---------------------------------------------------------------------------
 
 async function requireAdmin(request: Request) {
-  const session = await getSession(request);
+  const session = await getAdminSession(request);
   if (!session?.user?.email) return apiError("Unauthorized", 401);
   if (session.user.role !== "admin") return apiError("Forbidden", 403);
   return null;

--- a/apps/web/app/routes/api.admin.sources.$id.ts
+++ b/apps/web/app/routes/api.admin.sources.$id.ts
@@ -10,7 +10,7 @@ import {
 } from "@usopc/shared";
 
 const log = logger.child({ service: "admin-sources" });
-import { getSession } from "../../server/session.js";
+import { getAdminSession } from "../../server/session.js";
 import { createSourceConfigEntity } from "../../lib/source-config.js";
 import { apiError } from "../../lib/apiResponse.js";
 import {
@@ -23,7 +23,7 @@ import {
 // ---------------------------------------------------------------------------
 
 async function requireAdmin(request: Request) {
-  const session = await getSession(request);
+  const session = await getAdminSession(request);
   if (!session?.user?.email) return apiError("Unauthorized", 401);
   if (session.user.role !== "admin") return apiError("Forbidden", 403);
   return null;

--- a/apps/web/app/routes/api.admin.sources.bulk-create.ts
+++ b/apps/web/app/routes/api.admin.sources.bulk-create.ts
@@ -10,7 +10,7 @@ import {
 } from "@usopc/shared";
 
 const log = logger.child({ service: "admin-sources-bulk-create" });
-import { getSession } from "../../server/session.js";
+import { getAdminSession } from "../../server/session.js";
 import { createSourceConfigEntity } from "../../lib/source-config.js";
 import { apiError } from "../../lib/apiResponse.js";
 
@@ -19,7 +19,7 @@ import { apiError } from "../../lib/apiResponse.js";
 // ---------------------------------------------------------------------------
 
 async function requireAdmin(request: Request) {
-  const session = await getSession(request);
+  const session = await getAdminSession(request);
   if (!session?.user?.email) return apiError("Unauthorized", 401);
   if (session.user.role !== "admin") return apiError("Forbidden", 403);
   return null;

--- a/apps/web/app/routes/api.admin.sources.bulk.ts
+++ b/apps/web/app/routes/api.admin.sources.bulk.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { getPool, getResource, logger } from "@usopc/shared";
 
 const log = logger.child({ service: "admin-sources-bulk" });
-import { getSession } from "../../server/session.js";
+import { getAdminSession } from "../../server/session.js";
 import { createSourceConfigEntity } from "../../lib/source-config.js";
 import { apiError } from "../../lib/apiResponse.js";
 import {
@@ -16,7 +16,7 @@ import {
 // ---------------------------------------------------------------------------
 
 async function requireAdmin(request: Request) {
-  const session = await getSession(request);
+  const session = await getAdminSession(request);
   if (!session?.user?.email) return apiError("Unauthorized", 401);
   if (session.user.role !== "admin") return apiError("Forbidden", 403);
   return null;

--- a/apps/web/app/routes/api.admin.sources.ts
+++ b/apps/web/app/routes/api.admin.sources.ts
@@ -10,7 +10,7 @@ import {
 } from "@usopc/shared";
 
 const log = logger.child({ service: "admin-sources" });
-import { getSession } from "../../server/session.js";
+import { getAdminSession } from "../../server/session.js";
 import { createSourceConfigEntity } from "../../lib/source-config.js";
 import { apiError } from "../../lib/apiResponse.js";
 
@@ -19,7 +19,7 @@ import { apiError } from "../../lib/apiResponse.js";
 // ---------------------------------------------------------------------------
 
 async function requireAdmin(request: Request) {
-  const session = await getSession(request);
+  const session = await getAdminSession(request);
   if (!session?.user?.email) return apiError("Unauthorized", 401);
   if (session.user.role !== "admin") return apiError("Forbidden", 403);
   return null;

--- a/apps/web/app/routes/auth.login.tsx
+++ b/apps/web/app/routes/auth.login.tsx
@@ -2,10 +2,10 @@ import { redirect } from "react-router";
 import { useState, useEffect } from "react";
 import { useSearchParams } from "react-router";
 import type { Route } from "./+types/auth.login";
-import { getSession } from "../../server/session.js";
+import { getAdminSession } from "../../server/session.js";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const session = await getSession(request);
+  const session = await getAdminSession(request);
   const url = new URL(request.url);
   const callbackUrl = url.searchParams.get("callbackUrl") ?? "/admin";
   if (session?.user?.email) {

--- a/apps/web/server/session.test.ts
+++ b/apps/web/server/session.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@auth/core", () => ({
+  Auth: vi.fn(),
+}));
+
+vi.mock("./auth.js", () => ({
+  authConfig: { basePath: "/api/auth" },
+}));
+
+import { Auth } from "@auth/core";
+
+const mockAuth = vi.mocked(Auth);
+
+function makeRequest(cookie = "session=abc") {
+  return new Request("https://example.com/some/page", {
+    headers: { cookie },
+  });
+}
+
+describe("session", () => {
+  const originalRequireAuth = process.env.REQUIRE_AUTH;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalRequireAuth === undefined) {
+      delete process.env.REQUIRE_AUTH;
+    } else {
+      process.env.REQUIRE_AUTH = originalRequireAuth;
+    }
+  });
+
+  describe("getAdminSession", () => {
+    it("returns null when Auth returns non-200, even with REQUIRE_AUTH=false", async () => {
+      process.env.REQUIRE_AUTH = "false";
+      mockAuth.mockResolvedValue(
+        new Response(null, { status: 401 }) as unknown as Response,
+      );
+
+      const { getAdminSession } = await import("./session.js");
+      const result = await getAdminSession(makeRequest());
+
+      expect(result).toBeNull();
+      expect(mockAuth).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns the parsed session when Auth returns 200 JSON", async () => {
+      process.env.REQUIRE_AUTH = "false";
+      const session = {
+        user: { email: "admin@example.com", role: "admin" },
+      };
+      mockAuth.mockResolvedValue(
+        new Response(JSON.stringify(session), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }) as unknown as Response,
+      );
+
+      const { getAdminSession } = await import("./session.js");
+      const result = await getAdminSession(makeRequest());
+
+      expect(result).toEqual(session);
+    });
+
+    it("returns null when Auth returns an empty object", async () => {
+      process.env.REQUIRE_AUTH = "false";
+      mockAuth.mockResolvedValue(
+        new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }) as unknown as Response,
+      );
+
+      const { getAdminSession } = await import("./session.js");
+      const result = await getAdminSession(makeRequest());
+
+      expect(result).toBeNull();
+    });
+
+    it("forwards the cookie header to @auth/core", async () => {
+      process.env.REQUIRE_AUTH = "true";
+      mockAuth.mockResolvedValue(
+        new Response(null, { status: 401 }) as unknown as Response,
+      );
+
+      const { getAdminSession } = await import("./session.js");
+      await getAdminSession(makeRequest("my-cookie=xyz"));
+
+      const forwarded = mockAuth.mock.calls[0]?.[0] as Request;
+      expect(forwarded.headers.get("cookie")).toBe("my-cookie=xyz");
+    });
+  });
+
+  describe("getSession", () => {
+    it("returns ANONYMOUS_SESSION when REQUIRE_AUTH !== 'true'", async () => {
+      process.env.REQUIRE_AUTH = "false";
+
+      const { getSession } = await import("./session.js");
+      const result = await getSession(makeRequest());
+
+      expect(result).toEqual({
+        user: {
+          email: "anonymous@local",
+          name: "Anonymous",
+          role: "athlete",
+        },
+      });
+      expect(mockAuth).not.toHaveBeenCalled();
+    });
+
+    it("hits @auth/core when REQUIRE_AUTH === 'true'", async () => {
+      process.env.REQUIRE_AUTH = "true";
+      mockAuth.mockResolvedValue(
+        new Response(null, { status: 401 }) as unknown as Response,
+      );
+
+      const { getSession } = await import("./session.js");
+      const result = await getSession(makeRequest());
+
+      expect(result).toBeNull();
+      expect(mockAuth).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/web/server/session.ts
+++ b/apps/web/server/session.ts
@@ -27,7 +27,22 @@ const ANONYMOUS_SESSION: AppSession = {
  */
 export async function getSession(request: Request): Promise<AppSession | null> {
   if (AUTH_DISABLED) return ANONYMOUS_SESSION;
+  return readAuthSession(request);
+}
 
+/**
+ * Like getSession, but ignores REQUIRE_AUTH — always hits @auth/core so
+ * the anonymous shim never masks the real session. Use for admin-gated
+ * loaders/actions so /admin keeps requiring a real GitHub login even
+ * when REQUIRE_AUTH=false.
+ */
+export async function getAdminSession(
+  request: Request,
+): Promise<AppSession | null> {
+  return readAuthSession(request);
+}
+
+async function readAuthSession(request: Request): Promise<AppSession | null> {
   const url = new URL(request.url);
   const sessionUrl = `${url.protocol}//${url.host}/api/auth/session`;
 


### PR DESCRIPTION
## Summary

- Adds `getAdminSession()` in `apps/web/server/session.ts` that always calls `@auth/core` regardless of `REQUIRE_AUTH`, so the anonymous-session shim used for the public chat UI can't mask a real login check.
- Switches the `/admin` layout loader, the `/auth/login` loader, and the 11 inline `requireAdmin` helpers in admin API routes to the new function. Public chat callers (`chat.tsx`, `home.tsx`, `api.chat.ts`, etc.) keep `getSession()` unchanged.
- Adds `apps/web/server/session.test.ts` covering the split: `getAdminSession` returns `null` on non-200 and returns parsed JSON on 200 even with `REQUIRE_AUTH=false`; `getSession` still returns the anonymous shim when `REQUIRE_AUTH !== "true"`.

## Why

Staging runs with `REQUIRE_AUTH=false` (PR #676) so the public chat works without GitHub OAuth. That made the anonymous shim hand every caller a `role: "athlete"` session, so `requireAdmin()` always redirected `/admin` back to `/` — the admin console was unreachable.

## Test plan

- [x] `pnpm --filter @usopc/web exec vitest run` — 230 tests pass (6 new).
- [x] `pnpm typecheck` — monorepo clean.
- [x] `pnpm --filter @usopc/web build` — SSR build succeeds.
- [ ] After deploy: `curl -I https://usopc-staging-web-otznt36mga-uc.a.run.app/admin` → 302 to `/auth/login`.
- [ ] After deploy: GitHub OAuth with an email in `ADMIN_EMAILS` lands on `/admin` with admin nav rendered.
- [ ] After deploy: `/` and `POST /api/chat` still work anonymously (regression check).

### Staging prerequisites

- GitHub OAuth app must have `https://usopc-staging-web-otznt36mga-uc.a.run.app/api/auth/callback/github` registered.
- `usopc-staging-ADMIN_EMAILS` secret must include the tester's email.

Closes #681

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 48.2% | +0.0% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->