### PR TITLE
fix(web): trust proxy so OAuth redirect_uri uses https on Cloud Run

### DIFF
--- a/apps/web/server/app.ts
+++ b/apps/web/server/app.ts
@@ -11,6 +11,12 @@ const webRoot = resolve(__dirname, "..");
 
 const app = express();
 
+// Cloud Run terminates TLS at the frontend and forwards plain HTTP with
+// X-Forwarded-Proto: https. Without this, req.protocol returns "http" and
+// the OAuth redirect_uri sent to GitHub is http://…/api/auth/callback/github,
+// which doesn't match the https:// callback registered on the OAuth app.
+app.set("trust proxy", true);
+
 // ---------------------------------------------------------------------------
 // Security headers
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Enables Express's \`trust proxy\` so \`req.protocol\` honors \`X-Forwarded-Proto: https\` from Cloud Run's frontend. Without it, \`authHandler\` builds URLs with \`http://\`, producing a \`redirect_uri\` that doesn't match the \`https://\` callback URL registered on the GitHub OAuth app. GitHub rejected every login attempt with *"The redirect_uri is not associated with this application."*

## Verification before merge

- [x] \`pnpm typecheck\` clean.
- [x] \`npx prettier --check\` clean.

## After deploy

- [ ] \`curl -I -X POST https://usopc-staging-web-otznt36mga-uc.a.run.app/api/auth/signin/github\` — \`Location\` header should start with \`https://\` (currently \`http://\`).
- [ ] Full GitHub OAuth round-trip lands on \`/admin\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 48.2% | +0.0% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->