### PR TITLE
fix(gcp-infra): grant worker run.invoker for Pub/Sub pushes and cron

### DIFF
--- a/infra/gcp/index.ts
+++ b/infra/gcp/index.ts
@@ -429,6 +429,18 @@ const workerService = new gcp.cloudrunv2.Service(`${prefix}-worker`, {
   },
 });
 
+// The shared service account is used as the OIDC identity for Pub/Sub push
+// subscriptions and Cloud Scheduler jobs that target the worker. Cloud Run
+// requires the caller to have run.invoker on the target service, so without
+// this binding every push/cron delivery 403s and ends up in the DLQ.
+new gcp.cloudrunv2.ServiceIamMember(`${prefix}-worker-invoker`, {
+  name: workerService.name,
+  location: region,
+  project,
+  role: "roles/run.invoker",
+  member: pulumi.interpolate`serviceAccount:${serviceAccount.email}`,
+});
+
 // ---------------------------------------------------------------------------
 // Pub/Sub Push Subscriptions (to worker)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Grant `roles/run.invoker` on the worker Cloud Run service to the shared service account so Pub/Sub push deliveries and Cloud Scheduler cron jobs (both OIDC as that SA) can reach the worker.
- Unblocks discovery-feed + ingestion message processing and the weekly/daily cron triggers on staging (and production, once deployed).

## Root cause

`infra/gcp/index.ts` only granted `run.invoker` on the **web** service (to `allUsers`). The **worker** service's IAM policy was empty. Pub/Sub push subscriptions and Cloud Scheduler jobs both target `/discovery-feed`, `/ingestion`, `/cron/discovery`, and `/cron/ingestion` on the worker with OIDC tokens — Cloud Run rejected every call with 403, messages retried 5× and landed in the DLQ.

Reproduced on staging: clicking "Run Discovery" in the admin console reported ~800 URLs discovered/enqueued, but `discovered_sources` stayed empty. `gcloud run services get-iam-policy usopc-staging-worker` confirmed no bindings.

## Test plan

- [ ] `pulumi up` runs cleanly in the `deploy-gcp` workflow for the staging stack on merge.
- [ ] After deploy, `gcloud run services get-iam-policy usopc-staging-worker` shows the SA with `roles/run.invoker`.
- [ ] Trigger "Run Discovery" in the admin console; rows appear in the `discovered_sources` table.
- [ ] Existing DLQ messages can optionally be replayed by reseeding the subscription (separate operational step).

Closes #684

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 48.2% | +0.0% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->