### PR TITLE
ci(gcp): deploy staging on v* tag, production via manual dispatch only

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -2,14 +2,13 @@ name: Deploy to GCP
 
 on:
   push:
-    branches: [main]
     tags: ["v*"]
   workflow_dispatch:
     inputs:
       environment:
         description: "Target environment"
         required: true
-        default: "staging"
+        default: "production"
         type: choice
         options:
           - staging
@@ -38,10 +37,12 @@ jobs:
     steps:
       - id: env
         run: |
+          # Tag pushes → staging (automatic release cut).
+          # Production deploys are manual only, via workflow_dispatch.
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             ENV="${{ inputs.environment }}"
           elif [[ "${{ github.ref }}" == refs/tags/v* ]]; then
-            ENV="production"
+            ENV="staging"
           else
             ENV="staging"
           fi

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -161,10 +161,10 @@ pulumi preview --stack staging
 
 Create two environments in **Settings > Environments**:
 
-| Environment  | Protection Rules                     |
-| ------------ | ------------------------------------ |
-| `staging`    | None (auto-deploy on push to `main`) |
-| `production` | Required reviewers                   |
+| Environment  | Protection Rules                              |
+| ------------ | --------------------------------------------- |
+| `staging`    | None (auto-deploy on `v*` tag push)           |
+| `production` | Required reviewers (manual workflow dispatch) |
 
 ### Secrets
 
@@ -180,24 +180,24 @@ Add these repository secrets (or environment-scoped secrets if using different v
 
 ## 5. First Deployment
 
-### Option A: Automatic (via CI)
+### Option A: Automatic staging deploy (via tag)
 
-Push to `main` to trigger a staging deploy:
-
-```bash
-git push origin main
-```
-
-Tag a release to trigger a production deploy:
+Tag a commit with `v*` to trigger a staging deploy:
 
 ```bash
 git tag v1.0.0
 git push origin v1.0.0
 ```
 
-### Option B: Manual Trigger
+Pushing to `main` on its own does **not** deploy — merges only run CI
+(tests, typecheck). Cut a tag when you want staging to move.
 
-Go to **Actions > Deploy to GCP > Run workflow** and select the environment.
+### Option B: Manual production deploy
+
+Go to **Actions > Deploy to GCP > Run workflow**, pick the ref (usually
+the tag you just promoted through staging), and select `production`.
+This is the only path that deploys production — there is no automatic
+prod trigger.
 
 ### What the Workflow Does
 


### PR DESCRIPTION
## Summary

- Remove the `push.branches: [main]` trigger from `deploy-gcp.yml`. Merges to `main` will no longer kick off a Pulumi up / migrate / smoke cycle — that happens only on tags or manual dispatch now.
- `v*` tag pushes now deploy **staging** (was production).
- `workflow_dispatch` remains the only path to production; default input flipped to `production` since that's the primary manual use case.
- Update `docs/deployment.md` to match.

## Why

Every merge was triggering a staging deploy. Most commits don't need one, and the churn was drowning out deploys that actually matter. Moving the auto-trigger to tags gives a deliberate "cut a release" moment.

## Test plan

- [ ] Merge this PR — confirm no `Deploy to GCP` run fires from the `push` event on main.
- [ ] Cut a throwaway `v0.0.0-test` tag — confirm staging deploys.
- [ ] Trigger `Deploy to GCP` manually with `production` selected — confirm production path still works.

Closes #687

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 48.2% | +0.0% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->