### PR TITLE
fix(shared): initialize discovered_sources.status on insert

### DIFF
--- a/packages/shared/src/entities/pg/DiscoveredSourceEntityPg.test.ts
+++ b/packages/shared/src/entities/pg/DiscoveredSourceEntityPg.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Pool } from "pg";
+import { DiscoveredSourceEntityPg } from "./DiscoveredSourceEntityPg.js";
+
+function makePool(): { pool: Pool; query: ReturnType<typeof vi.fn> } {
+  const query = vi.fn().mockResolvedValue({
+    rows: [
+      {
+        id: "abc",
+        url: "https://example.com",
+        title: "Example",
+        discovery_method: "search",
+        discovered_at: new Date(),
+        discovered_from: null,
+        status: "pending_metadata",
+        metadata_confidence: null,
+        content_confidence: null,
+        combined_confidence: null,
+        document_type: null,
+        topic_domains: [],
+        format: null,
+        ngb_id: null,
+        priority: null,
+        description: null,
+        authority_level: null,
+        metadata_reasoning: null,
+        content_reasoning: null,
+        reviewed_at: null,
+        reviewed_by: null,
+        rejection_reason: null,
+        source_config_id: null,
+        last_error: null,
+        error_count: 0,
+        created_at: new Date(),
+        updated_at: new Date(),
+      },
+    ],
+  });
+  return { pool: { query } as unknown as Pool, query };
+}
+
+describe("DiscoveredSourceEntityPg.create", () => {
+  it("inserts status='pending_metadata' so the NOT NULL constraint is satisfied", async () => {
+    const { pool, query } = makePool();
+    const entity = new DiscoveredSourceEntityPg(pool);
+
+    await entity.create({
+      id: "abc",
+      url: "https://example.com",
+      title: "Example",
+      discoveryMethod: "search",
+    });
+
+    expect(query).toHaveBeenCalledTimes(1);
+    const [sql] = query.mock.calls[0]!;
+    expect(sql).toMatch(/INSERT INTO discovered_sources/);
+    expect(sql).toMatch(/status/);
+    expect(sql).toMatch(/'pending_metadata'/);
+  });
+});

--- a/packages/shared/src/entities/pg/DiscoveredSourceEntityPg.ts
+++ b/packages/shared/src/entities/pg/DiscoveredSourceEntityPg.ts
@@ -9,9 +9,11 @@ export class DiscoveredSourceEntityPg {
   constructor(private pool: Pool) {}
 
   async create(input: CreateDiscoveredSourceInput): Promise<DiscoveredSource> {
+    // `status` is NOT NULL with no DB default; the feed worker transitions
+    // it to `pending_content` / `approved` / `rejected` as evaluation runs.
     const { rows } = await this.pool.query(
-      `INSERT INTO discovered_sources (id, url, title, discovery_method, discovered_at, discovered_from)
-       VALUES ($1, $2, $3, $4, NOW(), $5)
+      `INSERT INTO discovered_sources (id, url, title, discovery_method, discovered_at, discovered_from, status)
+       VALUES ($1, $2, $3, $4, NOW(), $5, 'pending_metadata')
        RETURNING *`,
       [
         input.id,


### PR DESCRIPTION
## Summary

- `DiscoveredSourceEntityPg.create` was not setting `status`, which is `NOT NULL` with no DB default. Every insert failed with `null value in column "status" of relation "discovered_sources" violates not-null constraint`, so discovery rows never reached the admin console even though Pub/Sub pushes were succeeding.
- Set initial status to `'pending_metadata'` in the INSERT. Add a unit test asserting the literal is present.

## Root cause

After #685 fixed the IAM so push subscriptions could reach the worker, the follow-up discovery run produced 1029 "discovered, 996 enqueued" and 200s on every `/discovery-feed` push — but logs showed:

```
Error processing URL: … null value in column "status" of relation "discovered_sources" violates not-null constraint
```

`packages/shared/src/entities/pg/DiscoveredSourceEntityPg.ts` `create(...)` omitted `status`; the schema (`scripts/migrations/002_dynamo_entities_to_postgres.sql:45`) declares it NOT NULL with no default. The feed worker's lifecycle expects `pending_metadata` as the starting state (it immediately calls `markMetadataEvaluated` to advance it).

## Deploy

Per #687, merging does not auto-deploy. After merge, cut a `v*` tag to deploy staging.

## Test plan

- [x] `pnpm --filter @usopc/shared test` passes (new test included).
- [x] `pnpm typecheck` clean across the monorepo.
- [ ] After tagged deploy, trigger Run Discovery on staging and confirm rows appear in the `discovered_sources` admin table.

Closes #689

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 50.7% | +2.5% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->