### PR TITLE
feat(infra): add DLQ retention subscriptions

### DIFF
--- a/infra/gcp/index.ts
+++ b/infra/gcp/index.ts
@@ -240,6 +240,28 @@ const discoveryFeedDlqTopic = new gcp.pubsub.Topic(
   },
 );
 
+// DLQ retention subscriptions — Pub/Sub retains messages per-subscription, not
+// per-topic, so without these any message delivered to a DLQ topic is dropped
+// immediately. Pull subscriptions let us inspect or replay dead-lettered
+// payloads via `gcloud pubsub subscriptions pull` or a custom script.
+new gcp.pubsub.Subscription(`${prefix}-ingestion-dlq-sub`, {
+  name: `${prefix}-ingestion-dlq-sub`,
+  topic: ingestionDlqTopic.name,
+  project,
+  ackDeadlineSeconds: 60,
+  messageRetentionDuration: "604800s", // 7 days (Pub/Sub max)
+  expirationPolicy: { ttl: "" }, // never expire
+});
+
+new gcp.pubsub.Subscription(`${prefix}-discovery-feed-dlq-sub`, {
+  name: `${prefix}-discovery-feed-dlq-sub`,
+  topic: discoveryFeedDlqTopic.name,
+  project,
+  ackDeadlineSeconds: 60,
+  messageRetentionDuration: "604800s",
+  expirationPolicy: { ttl: "" },
+});
+
 // ---------------------------------------------------------------------------
 // Cloud Run Services
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add pull subscriptions on `ingestion-dlq` and `discovery-feed-dlq` topics so dead-lettered messages are retained for 7 days instead of dropped on delivery.
- No subscription = no retention in Pub/Sub, which bit us during #684 when ~800 discovery-feed messages could not be inspected or replayed.

Closes #686.

## Test plan

- [ ] CI Pulumi preview shows only two additive `gcp.pubsub.Subscription` resources (no changes to existing infra).
- [ ] After deploy, `gcloud pubsub subscriptions list` includes `usopc-staging-ingestion-dlq-sub` and `usopc-staging-discovery-feed-dlq-sub`.
- [ ] Publish a test message to `usopc-staging-discovery-feed-dlq` and pull it back via `gcloud pubsub subscriptions pull`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 50.7% | +0.0% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->