### PR TITLE
feat(web): surface deployed version in admin UI + /api/health

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -180,6 +180,8 @@ jobs:
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           IMAGE_TAG: ${{ github.sha }}
+          APP_VERSION: ${{ github.ref_name }}
+          APP_COMMIT: ${{ github.sha }}
 
       - name: Pulumi Up
         uses: pulumi/actions@v6
@@ -190,6 +192,8 @@ jobs:
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           IMAGE_TAG: ${{ github.sha }}
+          APP_VERSION: ${{ github.ref_name }}
+          APP_COMMIT: ${{ github.sha }}
 
   # -----------------------------------------------------------------------
   # Smoke test

--- a/apps/web/app/routes/admin.tsx
+++ b/apps/web/app/routes/admin.tsx
@@ -1,18 +1,19 @@
 import { Outlet } from "react-router";
 import type { Route } from "./+types/admin";
 import { getAdminSession, requireAdmin } from "../../server/session.js";
+import { getAppVersion } from "../../server/version.js";
 import AdminNav from "../../components/admin/AdminNav.js";
 
 export async function loader({ request }: Route.LoaderArgs) {
   const session = await getAdminSession(request);
   requireAdmin(session);
-  return { session };
+  return { session, version: getAppVersion() };
 }
 
 export default function AdminLayout({ loaderData }: Route.ComponentProps) {
   return (
     <div className="min-h-screen">
-      <AdminNav session={loaderData.session} />
+      <AdminNav session={loaderData.session} version={loaderData.version} />
       <main className="p-8">
         <Outlet />
       </main>

--- a/apps/web/app/routes/api.health.ts
+++ b/apps/web/app/routes/api.health.ts
@@ -1,8 +1,12 @@
 import type { Route } from "./+types/api.health.js";
+import { getAppVersion } from "../../server/version.js";
 
 export async function loader({ request }: Route.LoaderArgs) {
+  const { version, commit } = getAppVersion();
   return Response.json({
     status: "ok",
     timestamp: new Date().toISOString(),
+    version,
+    commit,
   });
 }

--- a/apps/web/components/admin/AdminNav.tsx
+++ b/apps/web/components/admin/AdminNav.tsx
@@ -2,8 +2,15 @@
 
 import { useState, useEffect } from "react";
 import type { AppSession } from "../../server/session.js";
+import type { AppVersion } from "../../server/version.js";
 
-export default function AdminNav({ session }: { session: AppSession }) {
+export default function AdminNav({
+  session,
+  version,
+}: {
+  session: AppSession;
+  version?: AppVersion;
+}) {
   const user = session.user;
   const [csrfToken, setCsrfToken] = useState("");
 
@@ -55,6 +62,24 @@ export default function AdminNav({ session }: { session: AppSession }) {
       </div>
 
       <div className="flex items-center gap-4">
+        {version && (
+          <a
+            href={
+              version.commit === "dev"
+                ? "#"
+                : `https://github.com/rosinbum/usopc-athlete-support-agent/commit/${version.commit}`
+            }
+            target="_blank"
+            rel="noopener noreferrer"
+            title={`Deployed version ${version.version} at commit ${version.commit}`}
+            className="hidden sm:inline-flex items-center gap-1 text-xs text-gray-400 hover:text-gray-600 font-mono"
+          >
+            <span>{version.version}</span>
+            <span>·</span>
+            <span>{version.commitShort}</span>
+          </a>
+        )}
+
         <div className="flex items-center gap-2">
           {user?.image && (
             <img

--- a/apps/web/server/version.test.ts
+++ b/apps/web/server/version.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getAppVersion } from "./version.js";
+
+describe("getAppVersion", () => {
+  const originalVersion = process.env.APP_VERSION;
+  const originalCommit = process.env.APP_COMMIT;
+
+  beforeEach(() => {
+    delete process.env.APP_VERSION;
+    delete process.env.APP_COMMIT;
+  });
+
+  afterEach(() => {
+    if (originalVersion === undefined) delete process.env.APP_VERSION;
+    else process.env.APP_VERSION = originalVersion;
+    if (originalCommit === undefined) delete process.env.APP_COMMIT;
+    else process.env.APP_COMMIT = originalCommit;
+  });
+
+  it("falls back to dev when env vars are unset", () => {
+    expect(getAppVersion()).toEqual({
+      version: "dev",
+      commit: "dev",
+      commitShort: "dev",
+    });
+  });
+
+  it("returns a 7-char short SHA from APP_COMMIT", () => {
+    process.env.APP_VERSION = "v0.6.2";
+    process.env.APP_COMMIT = "2d465321abcdef1234567890";
+    expect(getAppVersion()).toEqual({
+      version: "v0.6.2",
+      commit: "2d465321abcdef1234567890",
+      commitShort: "2d46532",
+    });
+  });
+
+  it("leaves commitShort as 'dev' when commit is 'dev'", () => {
+    process.env.APP_VERSION = "v1.0.0";
+    expect(getAppVersion().commitShort).toBe("dev");
+  });
+});

--- a/apps/web/server/version.ts
+++ b/apps/web/server/version.ts
@@ -1,0 +1,12 @@
+export interface AppVersion {
+  version: string;
+  commit: string;
+  commitShort: string;
+}
+
+export function getAppVersion(): AppVersion {
+  const version = process.env.APP_VERSION ?? "dev";
+  const commit = process.env.APP_COMMIT ?? "dev";
+  const commitShort = commit === "dev" ? "dev" : commit.slice(0, 7);
+  return { version, commit, commitShort };
+}

--- a/infra/gcp/index.ts
+++ b/infra/gcp/index.ts
@@ -255,6 +255,11 @@ const registryUrl = pulumi.interpolate`${region}-docker.pkg.dev/${project}/${reg
 const imageTag = process.env.IMAGE_TAG ?? "latest";
 const appImage = pulumi.interpolate`${registryUrl}/app:${imageTag}`;
 
+// Deploy-time version metadata surfaced in the running app (admin footer,
+// /api/health). Falls back to "dev" for local `pulumi up` without CI env.
+const appVersion = process.env.APP_VERSION ?? "dev";
+const appCommit = process.env.APP_COMMIT ?? "dev";
+
 // Helper: build a secret env var referencing Secret Manager
 function secretEnv(envName: string, secretName: string) {
   return {
@@ -311,6 +316,8 @@ const webService = new gcp.cloudrunv2.Service(`${prefix}-web`, {
           { name: "REQUIRE_AUTH", value: "false" },
           { name: "STORAGE_PROVIDER", value: "gcs" },
           { name: "QUEUE_PROVIDER", value: "pubsub" },
+          { name: "APP_VERSION", value: appVersion },
+          { name: "APP_COMMIT", value: appCommit },
           {
             name: "DOCUMENTS_BUCKET_NAME",
             value: documentsBucket.name,


### PR DESCRIPTION
## Summary

- Pipe `APP_VERSION` (git ref/tag) and `APP_COMMIT` (full SHA) from CI → Pulumi → Cloud Run web container.
- Render `vX.Y.Z · <short-sha>` in the admin nav, linking to the commit on GitHub.
- Include `version` and `commit` in `/api/health` so smoke tests / monitors can assert what's deployed.
- Fall back to `dev` when env is unset (local).

Closes #691.

## Test plan

- [x] `pnpm --filter @usopc/web test server/version.test` passes (new `getAppVersion` unit tests).
- [x] `pnpm typecheck` clean across the monorepo.
- [ ] After deploy, `curl https://<web>/api/health` includes `"version":"v0.6.x"` and `"commit":"<sha>"`.
- [ ] `/admin` nav shows the version pill (hover → full SHA tooltip, click → GitHub commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 50.7% | +0.0% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 47.8% | -0.1% |
<!-- coverage-summary-end -->