### PR TITLE
fix(ingestion): chunk discovery-feed messages (#692)

### DIFF
--- a/packages/ingestion/src/discoveryOrchestrator.test.ts
+++ b/packages/ingestion/src/discoveryOrchestrator.test.ts
@@ -35,7 +35,10 @@ vi.mock("./services/discoveryService.js", () => ({
 }));
 
 // Import after mocks
-import { DiscoveryOrchestrator } from "./discoveryOrchestrator.js";
+import {
+  DiscoveryOrchestrator,
+  DISCOVERY_FEED_CHUNK_SIZE,
+} from "./discoveryOrchestrator.js";
 import { DiscoveryService } from "./services/discoveryService.js";
 
 describe("DiscoveryOrchestrator", () => {
@@ -311,6 +314,111 @@ describe("DiscoveryOrchestrator", () => {
       expect(body.autoApprovalThreshold).toBe(0.9);
       expect(body.urls).toHaveLength(1);
       expect(body.timestamp).toBeDefined();
+    });
+  });
+
+  describe("Chunking", () => {
+    function makeUrls(count: number) {
+      return Array.from({ length: count }, (_, i) => ({
+        url: `https://usopc.org/doc-${i}`,
+        title: `Doc ${i}`,
+        method: "map" as const,
+      }));
+    }
+
+    it("publishes a single message when URL count is at or below the chunk size", async () => {
+      vi.mocked(DiscoveryService).mockImplementation(
+        () =>
+          ({
+            discoverFromMap: vi
+              .fn()
+              .mockResolvedValue(makeUrls(DISCOVERY_FEED_CHUNK_SIZE)),
+            discoverFromSearch: vi.fn().mockResolvedValue([]),
+            generateId: vi.fn(),
+          }) as any,
+      );
+
+      const orchestrator = new DiscoveryOrchestrator({
+        tavilyApiKey: "test-key",
+        autoApprovalThreshold: 0.85,
+      });
+
+      const stats = await orchestrator.discoverFromDomains(["usopc.org"], 100);
+
+      expect(stats.enqueued).toBe(DISCOVERY_FEED_CHUNK_SIZE);
+      expect(mockSendMessage).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(mockSendMessage.mock.calls[0]![1] as string);
+      expect(body.urls).toHaveLength(DISCOVERY_FEED_CHUNK_SIZE);
+    });
+
+    it("splits URLs into chunks when above the chunk size", async () => {
+      const total = DISCOVERY_FEED_CHUNK_SIZE * 3 + 2; // 47 URLs for chunk size 15
+      vi.mocked(DiscoveryService).mockImplementation(
+        () =>
+          ({
+            discoverFromMap: vi.fn().mockResolvedValue(makeUrls(total)),
+            discoverFromSearch: vi.fn().mockResolvedValue([]),
+            generateId: vi.fn(),
+          }) as any,
+      );
+
+      const orchestrator = new DiscoveryOrchestrator({
+        tavilyApiKey: "test-key",
+        autoApprovalThreshold: 0.85,
+      });
+
+      const stats = await orchestrator.discoverFromDomains(["usopc.org"], 100);
+
+      const expectedChunks = Math.ceil(total / DISCOVERY_FEED_CHUNK_SIZE);
+      expect(mockSendMessage).toHaveBeenCalledTimes(expectedChunks);
+      expect(stats.enqueued).toBe(total);
+
+      const sentCalls = mockSendMessage.mock.calls;
+      // Every chunk respects the chunk size ceiling
+      for (const call of sentCalls) {
+        const body = JSON.parse(call[1] as string);
+        expect(body.urls.length).toBeLessThanOrEqual(DISCOVERY_FEED_CHUNK_SIZE);
+        expect(body.urls.length).toBeGreaterThan(0);
+      }
+      // Last chunk holds the remainder
+      const lastBody = JSON.parse(
+        sentCalls[sentCalls.length - 1]![1] as string,
+      );
+      expect(lastBody.urls).toHaveLength(total % DISCOVERY_FEED_CHUNK_SIZE);
+
+      // URLs are partitioned, not duplicated
+      const flattened = sentCalls.flatMap(
+        (c) => JSON.parse(c[1] as string).urls as Array<{ url: string }>,
+      );
+      expect(flattened).toHaveLength(total);
+      expect(new Set(flattened.map((u) => u.url)).size).toBe(total);
+    });
+
+    it("continues publishing remaining chunks when one send fails", async () => {
+      const total = DISCOVERY_FEED_CHUNK_SIZE * 2;
+      vi.mocked(DiscoveryService).mockImplementation(
+        () =>
+          ({
+            discoverFromMap: vi.fn().mockResolvedValue(makeUrls(total)),
+            discoverFromSearch: vi.fn().mockResolvedValue([]),
+            generateId: vi.fn(),
+          }) as any,
+      );
+
+      mockSendMessage
+        .mockRejectedValueOnce(new Error("Pub/Sub unavailable"))
+        .mockResolvedValueOnce(undefined);
+
+      const orchestrator = new DiscoveryOrchestrator({
+        tavilyApiKey: "test-key",
+        autoApprovalThreshold: 0.85,
+      });
+
+      const stats = await orchestrator.discoverFromDomains(["usopc.org"], 100);
+
+      expect(mockSendMessage).toHaveBeenCalledTimes(2);
+      expect(stats.enqueued).toBe(DISCOVERY_FEED_CHUNK_SIZE);
+      expect(stats.errors).toBe(1);
     });
   });
 });

--- a/packages/ingestion/src/discoveryOrchestrator.ts
+++ b/packages/ingestion/src/discoveryOrchestrator.ts
@@ -12,6 +12,8 @@ import { DiscoveryConfig } from "./types.js";
 const logger = createLogger({ service: "discovery-orchestrator" });
 const queueService = createQueueService();
 
+export const DISCOVERY_FEED_CHUNK_SIZE = 15;
+
 export interface DiscoveryStats {
   discovered: number;
   enqueued: number;
@@ -199,32 +201,41 @@ export class DiscoveryOrchestrator {
       return;
     }
 
-    const message: DiscoveryFeedMessage = {
-      urls: newUrls.map((u) => ({
-        url: u.url,
-        title: u.title,
-        discoveryMethod: u.discoveryMethod,
-        discoveredFrom: u.discoveredFrom,
-      })),
-      autoApprovalThreshold: this.config.autoApprovalThreshold,
-      timestamp: new Date().toISOString(),
-    };
+    // Chunk URLs into smaller messages so the feed worker doesn't exceed its
+    // ack deadline or run out of memory processing 100+ URLs sequentially.
+    const chunks: (typeof newUrls)[] = [];
+    for (let i = 0; i < newUrls.length; i += DISCOVERY_FEED_CHUNK_SIZE) {
+      chunks.push(newUrls.slice(i, i + DISCOVERY_FEED_CHUNK_SIZE));
+    }
 
-    try {
-      const queueUrl = getResource("DiscoveryFeedQueue").url;
+    const queueUrl = getResource("DiscoveryFeedQueue").url;
 
-      await queueService.sendMessage(queueUrl, JSON.stringify(message));
+    for (const chunk of chunks) {
+      const message: DiscoveryFeedMessage = {
+        urls: chunk.map((u) => ({
+          url: u.url,
+          title: u.title,
+          discoveryMethod: u.discoveryMethod,
+          discoveredFrom: u.discoveredFrom,
+        })),
+        autoApprovalThreshold: this.config.autoApprovalThreshold,
+        timestamp: new Date().toISOString(),
+      };
 
-      this.stats.enqueued += newUrls.length;
-      logger.info(`Enqueued ${newUrls.length} URLs to discovery feed`, {
-        count: newUrls.length,
-      });
-    } catch (error) {
-      logger.error("Failed to enqueue URLs to discovery feed", {
-        error: error instanceof Error ? error.message : String(error),
-        count: newUrls.length,
-      });
-      this.stats.errors++;
+      try {
+        await queueService.sendMessage(queueUrl, JSON.stringify(message));
+
+        this.stats.enqueued += chunk.length;
+        logger.info(`Enqueued ${chunk.length} URLs to discovery feed`, {
+          count: chunk.length,
+        });
+      } catch (error) {
+        logger.error("Failed to enqueue URLs to discovery feed", {
+          error: error instanceof Error ? error.message : String(error),
+          count: chunk.length,
+        });
+        this.stats.errors++;
+      }
     }
     this.notifyProgress();
   }


### PR DESCRIPTION
## Summary

- Split `DiscoveryOrchestrator.enqueueUrls()` output into Pub/Sub messages of at most `DISCOVERY_FEED_CHUNK_SIZE` (15) URLs each.
- A single seed map/search was publishing 100+ URLs in one `DiscoveryFeedMessage`. The feed worker processes URLs sequentially (LLM metadata → scrape → LLM content), so large batches exceeded the 300s ack deadline or hit OOM, triggering re-delivery and eventual silent DLQ drops.
- Introduces an exported `DISCOVERY_FEED_CHUNK_SIZE` constant for reuse in related work (#694 re-queueing stuck rows).
- If a single chunk's send fails, remaining chunks still publish and the failure is counted in `stats.errors`.

Closes #692.

## Test plan

- [x] `pnpm --filter @usopc/ingestion test discoveryOrchestrator` — 14/14 pass
- [x] `pnpm typecheck` — clean
- [x] New tests cover: ≤ chunk size → one message, > chunk size → partitioned chunks with no duplicates, send failure on one chunk doesn't stop the rest
- [ ] After deploy, staging discovery run shows ~0 503s on `/discovery-feed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 50.7% | +0.0% |
| ingestion | 79.2% | +0.1% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->