### PR TITLE
fix(gcp-infra): cap worker concurrency, bump memory to 4 GiB (#693)

### DIFF
--- a/infra/gcp/index.ts
+++ b/infra/gcp/index.ts
@@ -383,6 +383,13 @@ const slackService = new gcp.cloudrunv2.Service(`${prefix}-slack`, {
 });
 
 // Worker (consolidated ingestion + discovery)
+//
+// Discovery-feed handlers load full webpage content into memory while running
+// LLM calls. The Cloud Run default concurrency (80) meant each instance could
+// be asked to process dozens of requests in parallel off ~2 GiB shared memory,
+// which triggered SIGABRT (OOM) and ~30% 503s during discovery runs. We pin
+// concurrency low enough that each in-flight request gets a realistic memory
+// slice, and bump total memory so scrape + LLM state comfortably fits.
 const workerService = new gcp.cloudrunv2.Service(`${prefix}-worker`, {
   name: `${prefix}-worker`,
   location: region,
@@ -394,6 +401,7 @@ const workerService = new gcp.cloudrunv2.Service(`${prefix}-worker`, {
       maxInstanceCount: maxInstances,
     },
     timeout: "900s", // 15 minutes for long ingestion tasks
+    maxInstanceRequestConcurrency: 10,
     volumes: [cloudSqlVolume],
     containers: [
       {
@@ -403,7 +411,7 @@ const workerService = new gcp.cloudrunv2.Service(`${prefix}-worker`, {
         args: ["packages/ingestion/dist/httpServer.js"],
         ports: { containerPort: 8080 },
         resources: {
-          limits: { cpu: "2", memory: "2Gi" },
+          limits: { cpu: "2", memory: "4Gi" },
         },
         volumeMounts: [cloudSqlMount],
         envs: [


### PR DESCRIPTION
## Summary

- Set `maxInstanceRequestConcurrency: 10` on the worker Cloud Run service so each instance admits far fewer concurrent requests.
- Bump worker memory limit from `2Gi` to `4Gi`.
- Observed cause of the staging incident: discovery-feed handlers load full webpage content while running LLM calls; at Cloud Run's default concurrency (80) each 2 GiB instance was asked to process dozens of these in parallel, triggering SIGABRT (OOM) and ~30% 503s on push delivery.

Closes #693. Pairs with #692 (chunking) — either alone reduces failures; both together should eliminate them.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `tsc` clean on `infra/gcp/index.ts`
- [ ] `pulumi preview` shows only worker template update, no replacement
- [ ] After redeploy, full staging discovery run shows 0 SIGABRTs and < 1% 503s on `/discovery-feed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 50.7% | +0.0% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.0% | +0.0% |
<!-- coverage-summary-end -->