### PR TITLE
feat(web): admin action to re-queue stuck discoveries (#694)

### DIFF
--- a/apps/web/app/routes/api.admin.discoveries.bulk.ts
+++ b/apps/web/app/routes/api.admin.discoveries.bulk.ts
@@ -45,6 +45,10 @@ const bulkSchema = z.discriminatedUnion("action", [
     ids: z.array(z.string().min(1)).optional(),
     erroredOnly: z.boolean().optional(),
   }),
+  z.object({
+    action: z.literal("reprocess_stuck"),
+    olderThanMinutes: z.number().int().min(1).max(10_080).optional(),
+  }),
 ]);
 
 // ---------------------------------------------------------------------------
@@ -118,6 +122,22 @@ export async function action({ request }: Route.ActionArgs) {
         duplicateUrl,
         notApproved,
         failed,
+      });
+    }
+
+    // -----------------------------------------------------------------------
+    // reprocess_stuck — republish pending_* rows whose worker delivery
+    // crashed / timed out before completing evaluation.
+    // -----------------------------------------------------------------------
+    if (bulkAction === "reprocess_stuck") {
+      const olderThanMinutes = result.data.olderThanMinutes ?? 10;
+      const discoveries = await entity.getStuckPending(olderThanMinutes);
+      const { queued, failed } = await enqueueForReprocess(discoveries);
+      return Response.json({
+        found: discoveries.length,
+        queued,
+        failed,
+        olderThanMinutes,
       });
     }
 

--- a/apps/web/components/admin/discoveries/DiscoveriesAdminClient.tsx
+++ b/apps/web/components/admin/discoveries/DiscoveriesAdminClient.tsx
@@ -398,6 +398,33 @@ export function DiscoveriesAdminClient() {
     }
   }
 
+  async function bulkReprocessStuck() {
+    setActionError(null);
+    try {
+      const data = await triggerBulk({
+        action: "reprocess_stuck",
+        olderThanMinutes: 10,
+      });
+      const parts: string[] = [];
+      if (data && data.found && data.found > 0)
+        parts.push(`${data.found} stuck`);
+      if (data && data.queued && data.queued > 0)
+        parts.push(`${data.queued} re-queued`);
+      if (data && data.failed && data.failed > 0)
+        parts.push(`${data.failed} failed`);
+      window.alert(
+        parts.length > 0
+          ? `Re-queue stuck: ${parts.join(", ")}`
+          : "No stuck discoveries found",
+      );
+      await mutate();
+    } catch (err) {
+      setActionError(
+        err instanceof Error ? err.message : "Re-queue stuck failed",
+      );
+    }
+  }
+
   // -------------------------------------------------------------------------
   // Sort handler
   // -------------------------------------------------------------------------
@@ -591,7 +618,7 @@ export function DiscoveriesAdminClient() {
       {(stats.approvedUnlinked > 0 ||
         stats.pendingReview > 0 ||
         stats.withErrors > 0) && (
-        <div className="flex items-center gap-3 mb-4">
+        <div className="flex items-center gap-3 mb-4 flex-wrap">
           {stats.approvedUnlinked > 0 && (
             <button
               onClick={() => bulkSendToSources()}
@@ -634,6 +661,19 @@ export function DiscoveriesAdminClient() {
               Retry Errored ({stats.withErrors})
             </button>
           )}
+          <button
+            onClick={bulkReprocessStuck}
+            disabled={bulkLoading}
+            className="px-4 py-2 text-sm rounded-lg font-medium bg-slate-700 text-white hover:bg-slate-800 disabled:opacity-50 flex items-center gap-2"
+            title="Republish pending rows whose worker delivery stalled (updated_at older than 10 minutes)"
+          >
+            {bulkLoading ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <RefreshCw className="w-4 h-4" />
+            )}
+            Re-queue Stuck
+          </button>
         </div>
       )}
 

--- a/apps/web/components/admin/hooks/use-discoveries.ts
+++ b/apps/web/components/admin/hooks/use-discoveries.ts
@@ -75,10 +75,16 @@ export function useDiscoveryAction(id: string) {
 }
 
 interface BulkDiscoveryActionArg {
-  action: "approve" | "reject" | "send_to_sources" | "reprocess";
+  action:
+    | "approve"
+    | "reject"
+    | "send_to_sources"
+    | "reprocess"
+    | "reprocess_stuck";
   ids?: string[] | undefined;
   reason?: string | undefined;
   erroredOnly?: boolean | undefined;
+  olderThanMinutes?: number | undefined;
 }
 
 interface BulkDiscoveryResponse {
@@ -89,6 +95,8 @@ interface BulkDiscoveryResponse {
   failed?: number;
   queued?: number;
   skipped?: number;
+  found?: number;
+  olderThanMinutes?: number;
 }
 
 export function useBulkDiscoveryAction() {

--- a/apps/web/lib/services/discovery-reprocess.test.ts
+++ b/apps/web/lib/services/discovery-reprocess.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const { mockSendMessage } = vi.hoisted(() => ({
+  mockSendMessage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@usopc/shared", () => ({
+  getResource: vi.fn((key: string) => {
+    if (key === "DiscoveryFeedQueue")
+      return { url: "https://pubsub.example.com/discovery-feed" };
+    throw new Error(`Resource '${key}' not available`);
+  }),
+  createQueueService: () => ({
+    sendMessage: mockSendMessage,
+    sendMessageBatch: vi.fn(),
+    purge: vi.fn(),
+    getStats: vi.fn(),
+  }),
+}));
+
+import {
+  enqueueForReprocess,
+  REPROCESS_CHUNK_SIZE,
+} from "./discovery-reprocess.js";
+
+function makeDiscoveries(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    url: `https://usopc.org/stuck-${i}`,
+    title: `Stuck ${i}`,
+  }));
+}
+
+describe("enqueueForReprocess", () => {
+  beforeEach(() => {
+    mockSendMessage.mockReset();
+    mockSendMessage.mockResolvedValue(undefined);
+  });
+
+  it("returns 0/0 for an empty list without contacting the queue", async () => {
+    const result = await enqueueForReprocess([]);
+    expect(result).toEqual({ queued: 0, failed: 0 });
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it("packs up to REPROCESS_CHUNK_SIZE URLs into each Pub/Sub message", async () => {
+    const total = REPROCESS_CHUNK_SIZE * 2 + 3;
+    const discoveries = makeDiscoveries(total);
+
+    const result = await enqueueForReprocess(discoveries);
+
+    const expectedChunks = Math.ceil(total / REPROCESS_CHUNK_SIZE);
+    expect(mockSendMessage).toHaveBeenCalledTimes(expectedChunks);
+    expect(result).toEqual({ queued: total, failed: 0 });
+
+    for (const call of mockSendMessage.mock.calls) {
+      const body = JSON.parse(call[1] as string);
+      expect(body.urls.length).toBeLessThanOrEqual(REPROCESS_CHUNK_SIZE);
+      expect(body.urls.length).toBeGreaterThan(0);
+      for (const u of body.urls) {
+        expect(u.discoveryMethod).toBe("manual");
+        expect(u.discoveredFrom).toBe("admin-reprocess");
+      }
+    }
+  });
+
+  it("counts a failed chunk send as `failed = chunk.length`, not 1", async () => {
+    const total = REPROCESS_CHUNK_SIZE + 2;
+    mockSendMessage
+      .mockRejectedValueOnce(new Error("Pub/Sub timeout"))
+      .mockResolvedValueOnce(undefined);
+
+    const result = await enqueueForReprocess(makeDiscoveries(total));
+
+    expect(mockSendMessage).toHaveBeenCalledTimes(2);
+    expect(result.queued + result.failed).toBe(total);
+    // The rejected call was the first chunk (size REPROCESS_CHUNK_SIZE)
+    expect(result.failed).toBe(REPROCESS_CHUNK_SIZE);
+    expect(result.queued).toBe(total - REPROCESS_CHUNK_SIZE);
+  });
+});

--- a/apps/web/lib/services/discovery-reprocess.ts
+++ b/apps/web/lib/services/discovery-reprocess.ts
@@ -3,34 +3,54 @@ import type { DiscoveryFeedMessage } from "@usopc/core";
 
 const queue = createQueueService();
 
+// Mirrors DISCOVERY_FEED_CHUNK_SIZE in packages/ingestion/src/discoveryOrchestrator.ts
+// (#692). Keeping the batch small prevents the feed worker from running out of
+// memory / exceeding the ack deadline when processing a republish.
+export const REPROCESS_CHUNK_SIZE = 15;
+
 /**
  * Send one or more discovered sources to the DiscoveryFeedQueue for
- * re-evaluation. Each discovery becomes a single message with
- * discoveryMethod "manual" and discoveredFrom "admin-reprocess".
+ * re-evaluation. URLs are batched into messages of at most
+ * REPROCESS_CHUNK_SIZE with discoveryMethod "manual" and
+ * discoveredFrom "admin-reprocess".
  */
 export async function enqueueForReprocess(
   discoveries: Array<{ url: string; title: string }>,
 ): Promise<{ queued: number; failed: number }> {
+  if (discoveries.length === 0) return { queued: 0, failed: 0 };
+
   const queueUrl = getResource("DiscoveryFeedQueue").url;
+  const timestamp = new Date().toISOString();
+
+  const chunks: Array<typeof discoveries> = [];
+  for (let i = 0; i < discoveries.length; i += REPROCESS_CHUNK_SIZE) {
+    chunks.push(discoveries.slice(i, i + REPROCESS_CHUNK_SIZE));
+  }
 
   const results = await Promise.allSettled(
-    discoveries.map((d) => {
+    chunks.map((chunk) => {
       const message: DiscoveryFeedMessage = {
-        urls: [
-          {
-            url: d.url,
-            title: d.title,
-            discoveryMethod: "manual",
-            discoveredFrom: "admin-reprocess",
-          },
-        ],
-        timestamp: new Date().toISOString(),
+        urls: chunk.map((d) => ({
+          url: d.url,
+          title: d.title,
+          discoveryMethod: "manual",
+          discoveredFrom: "admin-reprocess",
+        })),
+        timestamp,
       };
-      return queue.sendMessage(queueUrl, JSON.stringify(message));
+      return queue
+        .sendMessage(queueUrl, JSON.stringify(message))
+        .then(() => chunk.length);
     }),
   );
 
-  const queued = results.filter((r) => r.status === "fulfilled").length;
-  const failed = results.filter((r) => r.status === "rejected").length;
+  let queued = 0;
+  let failed = 0;
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i]!;
+    const size = chunks[i]!.length;
+    if (r.status === "fulfilled") queued += size;
+    else failed += size;
+  }
   return { queued, failed };
 }

--- a/packages/shared/src/entities/pg/DiscoveredSourceEntityPg.test.ts
+++ b/packages/shared/src/entities/pg/DiscoveredSourceEntityPg.test.ts
@@ -58,3 +58,32 @@ describe("DiscoveredSourceEntityPg.create", () => {
     expect(sql).toMatch(/'pending_metadata'/);
   });
 });
+
+describe("DiscoveredSourceEntityPg.getStuckPending", () => {
+  it("selects pending_* rows whose updated_at is older than the threshold", async () => {
+    const { pool, query } = makePool();
+    const entity = new DiscoveredSourceEntityPg(pool);
+
+    const results = await entity.getStuckPending(10);
+
+    expect(query).toHaveBeenCalledTimes(1);
+    const [sql, params] = query.mock.calls[0]!;
+    expect(sql).toMatch(/status IN \('pending_metadata', 'pending_content'\)/);
+    expect(sql).toMatch(
+      /updated_at < NOW\(\) - \(\$1 \|\| ' minutes'\)::interval/,
+    );
+    expect(sql).toMatch(/ORDER BY updated_at ASC/);
+    expect(params).toEqual([10, 1000]);
+    expect(results).toHaveLength(1);
+  });
+
+  it("honors a custom limit", async () => {
+    const { pool, query } = makePool();
+    const entity = new DiscoveredSourceEntityPg(pool);
+
+    await entity.getStuckPending(30, { limit: 50 });
+
+    const [, params] = query.mock.calls[0]!;
+    expect(params).toEqual([30, 50]);
+  });
+});

--- a/packages/shared/src/entities/pg/DiscoveredSourceEntityPg.ts
+++ b/packages/shared/src/entities/pg/DiscoveredSourceEntityPg.ts
@@ -66,6 +66,28 @@ export class DiscoveredSourceEntityPg {
     return rows.map((r) => this.toExternal(r));
   }
 
+  /**
+   * Rows stuck in pending_* for longer than `olderThanMinutes`. These likely
+   * represent messages whose feed-worker delivery crashed or timed out — the
+   * worker already re-evaluates pending_* rows on redelivery, so republishing
+   * them is safe.
+   */
+  async getStuckPending(
+    olderThanMinutes: number,
+    options?: { limit?: number },
+  ): Promise<DiscoveredSource[]> {
+    const limit = options?.limit ?? 1000;
+    const { rows } = await this.pool.query(
+      `SELECT * FROM discovered_sources
+       WHERE status IN ('pending_metadata', 'pending_content')
+         AND updated_at < NOW() - ($1 || ' minutes')::interval
+       ORDER BY updated_at ASC
+       LIMIT $2`,
+      [olderThanMinutes, limit],
+    );
+    return rows.map((r) => this.toExternal(r));
+  }
+
   async update(
     id: string,
     updates: Partial<Omit<DiscoveredSource, "id" | "createdAt">>,


### PR DESCRIPTION
## Summary

- Adds an admin action to republish discoveries stuck in `pending_metadata` / `pending_content` when the worker crashed or timed out mid-message.
- New entity method `DiscoveredSourceEntityPg.getStuckPending(olderThanMinutes)` that selects pending rows whose `updated_at` is older than the threshold (default 10 min).
- New bulk action `reprocess_stuck` on `/api/admin/discoveries/bulk` that queries and republishes those rows.
- \"Re-queue Stuck\" button on the Discoveries admin page.
- `enqueueForReprocess` now batches URLs into Pub/Sub messages of at most `REPROCESS_CHUNK_SIZE` (15) URLs each, matching the outgoing chunk size from #692. A failed chunk now counts `chunk.length` failed URLs instead of 1.
- Unit tests: SQL shape for the stuck query, chunk sizing, empty-input fast path, and accurate fail counting on a rejected chunk.

Mitigates #686 (silent DLQ drops). Closes #694. Pairs with #692 / #693.

## Test plan

- [x] `pnpm --filter @usopc/shared test DiscoveredSourceEntityPg` — 3/3 pass
- [x] `pnpm --filter @usopc/web test discovery-reprocess` — 3/3 pass
- [x] `pnpm typecheck` clean
- [ ] On staging: after running once, `pending_metadata`/`pending_content` count for rows older than 10 min drops to near-zero
- [ ] Admin button visibly works (toasts with \"Re-queue stuck: N stuck, M re-queued\")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.7% | +0.0% |
| shared | 51.0% | +0.3% |
| ingestion | 79.1% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.1% | +0.3% |
<!-- coverage-summary-end -->