### PR TITLE
fix(ingestion,web): detect PG unique-violation (23505) instead of DynamoDB error

### DIFF
--- a/apps/web/app/routes/api.admin.sources.bulk-create.ts
+++ b/apps/web/app/routes/api.admin.sources.bulk-create.ts
@@ -90,10 +90,8 @@ export async function action({ request }: Route.ActionArgs) {
         await entity.create(source);
         results.push({ id: source.id, title: source.title, status: "created" });
       } catch (err) {
-        if (
-          err instanceof Error &&
-          err.name === "ConditionalCheckFailedException"
-        ) {
+        // Postgres unique-violation (SQLSTATE 23505) means duplicate ID.
+        if ((err as { code?: string }).code === "23505") {
           results.push({
             id: source.id,
             title: source.title,

--- a/apps/web/app/routes/api.admin.sources.ts
+++ b/apps/web/app/routes/api.admin.sources.ts
@@ -102,11 +102,8 @@ export async function action({ request }: Route.ActionArgs) {
 
     return Response.json({ source }, { status: 201 });
   } catch (error) {
-    // Unique constraint violation means ID already exists
-    if (
-      error instanceof Error &&
-      error.name === "ConditionalCheckFailedException"
-    ) {
+    // Postgres unique-violation (SQLSTATE 23505) means the ID already exists.
+    if ((error as { code?: string }).code === "23505") {
       return apiError("A source with this ID already exists", 409);
     }
 

--- a/packages/ingestion/src/discoveryFeedWorker.test.ts
+++ b/packages/ingestion/src/discoveryFeedWorker.test.ts
@@ -67,6 +67,17 @@ const mockNormalizeUrl = vi.mocked(normalizeUrl);
 // Helpers
 // ---------------------------------------------------------------------------
 
+// Shape of a PG unique-constraint error: `pg` attaches `.code` with
+// SQLSTATE 23505 when an INSERT collides on a primary/unique key.
+function pgUniqueViolation(): Error {
+  return Object.assign(
+    new Error(
+      'duplicate key value violates unique constraint "discovered_sources_pkey"',
+    ),
+    { code: "23505" },
+  );
+}
+
 function makeMessage(
   urls: Array<{ url: string; title?: string }>,
   opts?: { autoApprovalThreshold?: number },
@@ -264,10 +275,8 @@ describe("discoveryFeedWorker", () => {
     );
   });
 
-  it("skips existing URLs (conditional put failure)", async () => {
-    mockEntity.create.mockRejectedValueOnce(
-      new Error("Conditional check failed"),
-    );
+  it("skips existing URLs (duplicate-key on PG insert)", async () => {
+    mockEntity.create.mockRejectedValueOnce(pgUniqueViolation());
 
     await handleDiscoveryFeedMessage(
       makeMessage([{ url: "https://usopc.org/existing" }]),
@@ -275,6 +284,26 @@ describe("discoveryFeedWorker", () => {
 
     expect(mockEvalService.evaluateMetadata).not.toHaveBeenCalled();
     expect(mockLoadWeb).not.toHaveBeenCalled();
+  });
+
+  // Regression for #701: pre-fix code matched on `msg.includes("Conditional")`
+  // (DynamoDB-era), which never matched PG's "duplicate key" message — so
+  // re-queued stuck rows always rethrew, hit recordError, and after 3 attempts
+  // were rejected. Now the duplicate-key path is taken on `code === "23505"`,
+  // so `recordError` should NOT be called for that case.
+  it("does not record an error when PG duplicate-key triggers the re-evaluate path", async () => {
+    mockEntity.create.mockRejectedValueOnce(pgUniqueViolation());
+    mockEntity.getById.mockResolvedValueOnce({
+      id: "test-id-hash",
+      status: "pending_metadata",
+      url: "https://usopc.org/stuck",
+    });
+
+    await handleDiscoveryFeedMessage(
+      makeMessage([{ url: "https://usopc.org/stuck" }]),
+    );
+
+    expect(mockEntity.recordError).not.toHaveBeenCalled();
   });
 
   it("individual URL failures don't block others", async () => {
@@ -315,9 +344,7 @@ describe("discoveryFeedWorker", () => {
   });
 
   it("re-evaluates existing pending_metadata record instead of skipping", async () => {
-    mockEntity.create.mockRejectedValueOnce(
-      new Error("Conditional check failed"),
-    );
+    mockEntity.create.mockRejectedValueOnce(pgUniqueViolation());
     mockEntity.getById.mockResolvedValueOnce({
       id: "test-id-hash",
       status: "pending_metadata",
@@ -332,9 +359,7 @@ describe("discoveryFeedWorker", () => {
   });
 
   it("re-evaluates existing pending_content record instead of skipping", async () => {
-    mockEntity.create.mockRejectedValueOnce(
-      new Error("Conditional check failed"),
-    );
+    mockEntity.create.mockRejectedValueOnce(pgUniqueViolation());
     mockEntity.getById.mockResolvedValueOnce({
       id: "test-id-hash",
       status: "pending_content",
@@ -349,9 +374,7 @@ describe("discoveryFeedWorker", () => {
   });
 
   it("still skips existing approved record", async () => {
-    mockEntity.create.mockRejectedValueOnce(
-      new Error("Conditional check failed"),
-    );
+    mockEntity.create.mockRejectedValueOnce(pgUniqueViolation());
     mockEntity.getById.mockResolvedValueOnce({
       id: "test-id-hash",
       status: "approved",
@@ -366,9 +389,7 @@ describe("discoveryFeedWorker", () => {
   });
 
   it("clears error after successful re-evaluation of stuck URL", async () => {
-    mockEntity.create.mockRejectedValueOnce(
-      new Error("Conditional check failed"),
-    );
+    mockEntity.create.mockRejectedValueOnce(pgUniqueViolation());
     mockEntity.getById.mockResolvedValueOnce({
       id: "test-id-hash",
       status: "pending_metadata",

--- a/packages/ingestion/src/discoveryFeedWorker.ts
+++ b/packages/ingestion/src/discoveryFeedWorker.ts
@@ -99,8 +99,10 @@ async function processUrl(
       discoveredFrom: urlEntry.discoveredFrom,
     });
   } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    if (msg.includes("Conditional")) {
+    // Postgres unique-violation on discovered_sources.id: the URL already
+    // exists. `pg` surfaces SQLSTATE 23505 on the error object's `code`.
+    const code = (error as { code?: string }).code;
+    if (code === "23505") {
       // Check if the existing record is stuck and should be re-evaluated
       const existing = await entity.getById(id);
       if (existing && REPROCESSABLE_STATUSES.has(existing.status)) {

--- a/scripts/migrations/003_recover_wrongly_rejected_discoveries.sql
+++ b/scripts/migrations/003_recover_wrongly_rejected_discoveries.sql
@@ -1,0 +1,29 @@
+-- Migration: Recover discoveries wrongly rejected by the v0.6.3
+-- "Re-queue Stuck" admin action.
+--
+-- Background (#701): the worker's duplicate-row detection still used the
+-- DynamoDB-era substring match `msg.includes("Conditional")`, which never
+-- matched PG's `duplicate key value violates unique constraint` error. So
+-- when the admin re-queued stuck rows, the worker rethrew the unique-
+-- violation, recorded it as an extraction error, and after 3 attempts
+-- marked the row `status='rejected'` with the duplicate-key text in
+-- `rejection_reason`.
+--
+-- This migration flips those rows back to `pending_metadata` so they get
+-- re-evaluated by the now-fixed worker. It is a no-op in any environment
+-- where the v0.6.3 reprocess action was never run (production was not
+-- promoted to v0.6.3 before the fix landed).
+
+BEGIN;
+
+UPDATE discovered_sources
+SET
+  status = 'pending_metadata',
+  error_count = 0,
+  last_error = NULL,
+  rejection_reason = NULL,
+  updated_at = NOW()
+WHERE status = 'rejected'
+  AND rejection_reason LIKE '%duplicate key value violates unique constraint%';
+
+COMMIT;


### PR DESCRIPTION
## Summary

Three sites still used DynamoDB-era error detection (\`msg.includes(\"Conditional\")\` / \`error.name === \"ConditionalCheckFailedException\"\`) that never matches Postgres. This silently broke duplicate-row handling across the AWS→GCP migration. Postgres surfaces unique-violations as SQLSTATE \`23505\` on the error's \`code\` field; all three sites now check that.

The most visible symptom: the v0.6.3 \"Re-queue Stuck\" admin action (#694) was non-functional — the worker rethrew on every re-published URL, recorded each as an extraction error, and after 3 retries marked the row \`rejected\`. Staging logs from 2026-04-19 showed **1003 / 1003** worker errors with the same root cause.

## Changes

**Implementation**

- \`packages/ingestion/src/discoveryFeedWorker.ts\` — duplicate-on-insert branch now uses \`code === \"23505\"\` instead of \`msg.includes(\"Conditional\")\`.
- \`apps/web/app/routes/api.admin.sources.ts\` — duplicate source create now returns **409** instead of a generic 500.
- \`apps/web/app/routes/api.admin.sources.bulk-create.ts\` — duplicates now get \`status: \"duplicate\"\` instead of being lumped into \`status: \"failed\", error: \"Internal error\"\`.

**Tests**

- \`packages/ingestion/src/discoveryFeedWorker.test.ts\` — mocked errors now use the real PG shape (\`Object.assign(new Error(...), { code: \"23505\" })\`) via a \`pgUniqueViolation()\` helper. Adds a regression test asserting \`recordError\` is **not** called when duplicate-key triggers the re-evaluate path (the failure mode that broke #694 in production).

**Data recovery**

- \`scripts/migrations/003_recover_wrongly_rejected_discoveries.sql\` — flips rows whose \`rejection_reason\` matches the duplicate-key text back to \`pending_metadata\` so they can be re-evaluated by the now-fixed worker. No-op in any environment that never ran the broken re-queue (production was not promoted to v0.6.3 before this fix landed).

## Test plan

- [x] \`pnpm --filter @usopc/ingestion test\` — 263 tests pass
- [x] \`pnpm --filter @usopc/web test\` — 242 tests pass
- [x] \`pnpm typecheck\` — clean across all 6 packages
- [x] \`prettier --write\` on all touched files
- [ ] After deploy to staging: invoke \"Re-queue Stuck\" admin action; worker logs should show \"Re-evaluating stuck URL\" + metadata/content evaluation, not \"Error processing URL: duplicate key value violates unique constraint\"

Closes #701, closes #702

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.3% | +0.0% |
| shared | 58.0% | +0.0% |
| ingestion | 78.9% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.1% | +0.0% |
<!-- coverage-summary-end -->