### PR TITLE
fix(core): reset per-turn agent state to stop multi-turn reply leak

### DIFF
--- a/packages/core/src/agent/runner.test.ts
+++ b/packages/core/src/agent/runner.test.ts
@@ -283,6 +283,35 @@ describe("AgentRunner", () => {
       );
     });
 
+    it("resets per-turn output fields so prior-turn checkpoint state can't leak (invoke)", async () => {
+      // Regression: multi-turn conversations were replaying the prior turn's
+      // answer/citations/disclaimer because those fields use replace reducers
+      // and the Postgres checkpointer loads them for the new turn. The new
+      // turn must start with clean output channels so the streamAdapter never
+      // sees stale values before nodes have run.
+      const graph = makeFakeGraph();
+      mockCreateAgentGraph.mockReturnValue(graph);
+
+      const runner = await AgentRunner.create(defaultConfig);
+      await runner.invoke({
+        messages: [new HumanMessage("follow-up question")],
+        conversationId: "conv-multi-turn",
+      });
+
+      const initialState = graph.invoke.mock.calls[0]![0] as Record<
+        string,
+        unknown
+      >;
+      expect(initialState.answer).toBeUndefined();
+      expect(initialState.citations).toEqual([]);
+      expect(initialState.disclaimer).toBeUndefined();
+      expect(initialState.escalation).toBeUndefined();
+      expect(initialState.qualityCheckResult).toBeUndefined();
+      expect(initialState.qualityRetryCount).toBe(0);
+      expect(initialState.needsClarification).toBe(false);
+      expect(initialState.clarificationQuestion).toBeUndefined();
+    });
+
     it("passes metadata.session_id when conversationId is provided", async () => {
       const graph = makeFakeGraph();
       mockCreateAgentGraph.mockReturnValue(graph);

--- a/packages/core/src/agent/runner.ts
+++ b/packages/core/src/agent/runner.ts
@@ -245,10 +245,38 @@ export class AgentRunner {
       });
       conversationId = undefined;
     }
+    // Output/derived fields use replace reducers, so the Postgres checkpointer
+    // would otherwise hand the next turn the prior turn's answer, citations,
+    // etc. Reset them explicitly so each turn starts with clean channels.
+    // `messages` accumulates correctly via the add-messages reducer.
     return {
       messages: input.messages,
       userSport: input.userSport,
       conversationId,
+      answer: undefined,
+      citations: [],
+      disclaimer: undefined,
+      escalation: undefined,
+      escalationReason: undefined,
+      qualityCheckResult: undefined,
+      qualityRetryCount: 0,
+      needsClarification: false,
+      clarificationQuestion: undefined,
+      retrievedDocuments: [],
+      webSearchResults: [],
+      webSearchResultUrls: [],
+      retrievalConfidence: 0,
+      retrievalStatus: "success",
+      topicDomain: undefined,
+      queryIntent: undefined,
+      detectedNgbIds: [],
+      emotionalState: "neutral",
+      emotionalSupportContext: undefined,
+      hasTimeConstraint: false,
+      expansionAttempted: false,
+      reformulatedQueries: [],
+      isComplexQuery: false,
+      subQueries: [],
     };
   }
 }

--- a/packages/core/src/agent/streamAdapter.test.ts
+++ b/packages/core/src/agent/streamAdapter.test.ts
@@ -1022,4 +1022,52 @@ describe("agentStreamToEvents (dual-mode)", () => {
 
     expect(events[events.length - 1]!.type).toBe("done");
   });
+
+  it("streams a clean multi-turn response when runner resets per-turn fields", async () => {
+    // The runner's buildInitialState() resets per-turn output fields
+    // (answer, citations, disclaimer, qualityCheckResult, ...) before each
+    // graph run, so LangGraph emits an initial values chunk with those
+    // fields empty/undefined even on turn 2. This test verifies the adapter
+    // streams the new turn's answer cleanly without any prior-turn content.
+    const cleanInitialSnapshot = {
+      answer: undefined,
+      citations: [],
+      disclaimer: undefined,
+      qualityCheckResult: undefined,
+    };
+
+    const events = await collectEvents(
+      mockDualStream([
+        ["values", cleanInitialSnapshot],
+        ["messages", [{ content: "New" }, { langgraph_node: "synthesizer" }]],
+        [
+          "messages",
+          [{ content: " answer" }, { langgraph_node: "synthesizer" }],
+        ],
+        [
+          "values",
+          {
+            answer: "New answer",
+            qualityCheckResult: {
+              passed: true,
+              score: 0.95,
+              issues: [],
+              critique: "",
+            },
+          },
+        ],
+      ]),
+    );
+
+    const textDeltas = events
+      .filter((e) => e.type === "text-delta")
+      .map((e) => e.textDelta);
+    expect(textDeltas.join("")).toBe("New answer");
+
+    const citationEvents = events.filter((e) => e.type === "citations");
+    expect(citationEvents).toHaveLength(0);
+
+    const disclaimerEvents = events.filter((e) => e.type === "disclaimer");
+    expect(disclaimerEvents).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

Multi-turn chats in the web UI were prepending the prior turn's answer to every follow-up response. Ask "How does team selection work?", then follow up with "I'm a downhill skier" — the second stream re-emits the first answer verbatim and appends the new content.

### Root cause

`AgentRunner.buildInitialState` passed only `messages`, `userSport`, and `conversationId` as input; everything else relied on Annotation defaults. That assumption only holds on a fresh thread. With `conversationId` set, the Postgres checkpointer loads the prior turn's entire state — and fields like `answer`, `citations`, `disclaimer`, `qualityCheckResult` use replace reducers, so they survive into the new turn.

On turn 2:
- LangGraph's first "values" chunk is the checkpoint snapshot, still holding the prior `answer`.
- `streamAdapter.ts` detects `state.answer.length > previousAnswerFromValues.length` (where `previousAnswerFromValues` starts at `""`) and yields the prior answer as a `text-delta`.
- The synthesizer then streams the new turn's tokens via the buffer path, flushed after the quality check — appending them to the prior answer in the UI.

### Fix

Explicitly reset per-turn output fields in `buildInitialState` (`answer`, `citations`, `disclaimer`, `escalation`, `qualityCheckResult`, `retrievedDocuments`, classifier-derived fields, etc.). `messages` continues to accumulate correctly via the `add-messages` reducer; `conversationId` and `userSport` pass through unchanged.

## Changes

- `packages/core/src/agent/runner.ts` — reset per-turn fields in `buildInitialState`.
- `packages/core/src/agent/runner.test.ts` — regression test verifying the initial state handed to `graph.invoke` has clean output channels.
- `packages/core/src/agent/streamAdapter.test.ts` — companion test for the adapter's multi-turn behavior given a clean initial snapshot.

## Test plan

- [x] `pnpm --filter @usopc/core test` — 841 passed
- [x] `pnpm test` — all packages pass (841 core + 242 web + others)
- [x] `pnpm typecheck` — all packages clean
- [ ] Manual smoke test in dev: ask "How does team selection work?", follow up with "I'm a downhill skier"; confirm only the new turn's answer streams.

Closes #704

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.4% | +0.1% |
| shared | 58.0% | +0.0% |
| ingestion | 78.9% | +0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.1% | +0.0% |
<!-- coverage-summary-end -->