### PR TITLE
fix(discovery): mark URLs rejected instead of leaking to pending_content

### DIFF
--- a/packages/ingestion/src/discoveryCoordinator.ts
+++ b/packages/ingestion/src/discoveryCoordinator.ts
@@ -207,12 +207,18 @@ export class DiscoveryCoordinator {
       metadataEval.preliminaryDocumentType,
     );
 
-    // If not relevant, reject and stop
+    // If not relevant, reject and stop. markMetadataEvaluated leaves status
+    // at 'pending_content' — transition to 'rejected' explicitly so the row
+    // isn't treated as stuck and re-queued forever (#706).
     if (!metadataEval.isRelevant || metadataEval.confidence < 0.5) {
+      const reason = metadataEval.isRelevant
+        ? `Auto-rejected: metadata confidence ${metadataEval.confidence.toFixed(2)} below 0.5`
+        : `Auto-rejected: not relevant — ${metadataEval.reasoning}`;
       logger.info(`URL rejected after metadata evaluation: ${url}`, {
         url,
         confidence: metadataEval.confidence,
       });
+      await this.discoveredSourceEntity.reject(id, "auto", reason);
       return;
     }
 

--- a/packages/ingestion/src/discoveryFeedWorker.test.ts
+++ b/packages/ingestion/src/discoveryFeedWorker.test.ts
@@ -233,6 +233,29 @@ describe("discoveryFeedWorker", () => {
     expect(mockEntity.markContentEvaluated).not.toHaveBeenCalled();
   });
 
+  // Regression for #706: metadata rejection used to just return, leaving
+  // status at 'pending_content' (set by markMetadataEvaluated) — which put
+  // the row back into REPROCESSABLE_STATUSES and looped forever.
+  it("marks row 'rejected' when metadata eval flags as not relevant", async () => {
+    mockEvalService.evaluateMetadata.mockResolvedValueOnce({
+      isRelevant: false,
+      confidence: 0.2,
+      reasoning: "Off-topic",
+      suggestedTopicDomains: [],
+      preliminaryDocumentType: "",
+    });
+
+    await handleDiscoveryFeedMessage(
+      makeMessage([{ url: "https://usopc.org/doc1" }]),
+    );
+
+    expect(mockEntity.reject).toHaveBeenCalledWith(
+      "test-id-hash",
+      "auto",
+      expect.stringContaining("not relevant"),
+    );
+  });
+
   it("stops at metadata eval when confidence < 0.5", async () => {
     mockEvalService.evaluateMetadata.mockResolvedValueOnce({
       isRelevant: true,
@@ -247,6 +270,35 @@ describe("discoveryFeedWorker", () => {
     );
 
     expect(mockLoadWeb).not.toHaveBeenCalled();
+  });
+
+  // Regression for #706: low-metadata-confidence also leaked as 'pending_content'.
+  it("marks row 'rejected' when metadata confidence is below 0.5", async () => {
+    mockEvalService.evaluateMetadata.mockResolvedValueOnce({
+      isRelevant: true,
+      confidence: 0.3,
+      reasoning: "Borderline",
+      suggestedTopicDomains: [],
+      preliminaryDocumentType: "",
+    });
+
+    await handleDiscoveryFeedMessage(
+      makeMessage([{ url: "https://usopc.org/doc1" }]),
+    );
+
+    expect(mockEntity.reject).toHaveBeenCalledWith(
+      "test-id-hash",
+      "auto",
+      expect.stringContaining("confidence"),
+    );
+  });
+
+  it("does not call reject() when metadata eval passes", async () => {
+    await handleDiscoveryFeedMessage(
+      makeMessage([{ url: "https://usopc.org/doc1" }]),
+    );
+
+    expect(mockEntity.reject).not.toHaveBeenCalled();
   });
 
   it("calls loadWeb, evaluateContent, markContentEvaluated for passing metadata", async () => {

--- a/packages/ingestion/src/discoveryFeedWorker.ts
+++ b/packages/ingestion/src/discoveryFeedWorker.ts
@@ -140,12 +140,18 @@ async function processUrl(
     metadataEval.preliminaryDocumentType,
   );
 
-  // Reject if not relevant or low confidence
+  // Reject if not relevant or low confidence. markMetadataEvaluated leaves
+  // status at 'pending_content'; we must transition to 'rejected' here or the
+  // row re-enters the reprocess set forever (#706).
   if (!metadataEval.isRelevant || metadataEval.confidence < 0.5) {
+    const reason = metadataEval.isRelevant
+      ? `Auto-rejected: metadata confidence ${metadataEval.confidence.toFixed(2)} below 0.5`
+      : `Auto-rejected: not relevant — ${metadataEval.reasoning}`;
     logger.info(`URL rejected after metadata evaluation: ${normalized}`, {
       url: normalized,
       confidence: metadataEval.confidence,
     });
+    await entity.reject(id, "auto", reason);
     if (isReprocess) await entity.clearError(id);
     return;
   }

--- a/packages/shared/src/entities/pg/DiscoveredSourceEntityPg.test.ts
+++ b/packages/shared/src/entities/pg/DiscoveredSourceEntityPg.test.ts
@@ -59,6 +59,59 @@ describe("DiscoveredSourceEntityPg.create", () => {
   });
 });
 
+describe("DiscoveredSourceEntityPg.markContentEvaluated", () => {
+  const extracted = {
+    documentType: "policy",
+    topicDomains: ["governance"],
+    authorityLevel: "usopc_governance",
+    priority: "high" as const,
+    description: "Test doc",
+    ngbId: null,
+    format: "html" as const,
+  };
+
+  it("sets status='approved' when combined confidence meets threshold", async () => {
+    const { pool, query } = makePool();
+    const entity = new DiscoveredSourceEntityPg(pool);
+
+    await entity.markContentEvaluated(
+      "abc",
+      0.9,
+      0.85,
+      extracted,
+      "Looks good",
+      0.7,
+    );
+
+    const [, params] = query.mock.calls[0]!;
+    expect(params![1]).toBe("approved");
+    expect(params![12]).toBeNull(); // rejection_reason
+  });
+
+  // Regression for #706: below-threshold used to set status='pending_content',
+  // which put the row back into REPROCESSABLE_STATUSES and looped forever.
+  it("sets status='rejected' (not 'pending_content') when combined confidence is below threshold", async () => {
+    const { pool, query } = makePool();
+    const entity = new DiscoveredSourceEntityPg(pool);
+
+    await entity.markContentEvaluated(
+      "abc",
+      0.4,
+      0.5,
+      extracted,
+      "Low quality",
+      0.7,
+    );
+
+    const [sql, params] = query.mock.calls[0]!;
+    expect(params![1]).toBe("rejected");
+    expect(params![12]).toMatch(/below threshold/);
+    // Must stamp reviewed_at + reviewed_by='auto' so admin UI shows it as auto-reviewed
+    expect(sql).toMatch(/reviewed_at = NOW\(\)/);
+    expect(sql).toMatch(/reviewed_by = 'auto'/);
+  });
+});
+
 describe("DiscoveredSourceEntityPg.getStuckPending", () => {
   it("selects pending_* rows whose updated_at is older than the threshold", async () => {
     const { pool, query } = makePool();

--- a/packages/shared/src/entities/pg/DiscoveredSourceEntityPg.ts
+++ b/packages/shared/src/entities/pg/DiscoveredSourceEntityPg.ts
@@ -184,12 +184,14 @@ export class DiscoveredSourceEntityPg {
     reasoning: string,
     autoApprovalThreshold: number,
   ): Promise<void> {
-    const status =
-      combinedConfidence >= autoApprovalThreshold
-        ? "approved"
-        : "pending_content";
-    const reviewedAt =
-      combinedConfidence >= autoApprovalThreshold ? "NOW()" : "NULL";
+    // Every path through here transitions to a terminal state. Previously the
+    // below-threshold branch left status at 'pending_content', which leaked
+    // rejected URLs back into the reprocess set and piled up stuck rows (#706).
+    const approved = combinedConfidence >= autoApprovalThreshold;
+    const status = approved ? "approved" : "rejected";
+    const rejectionReason = approved
+      ? null
+      : `Auto-rejected: combined confidence ${combinedConfidence.toFixed(2)} below threshold ${autoApprovalThreshold.toFixed(2)}`;
 
     await this.pool.query(
       `UPDATE discovered_sources
@@ -197,7 +199,8 @@ export class DiscoveredSourceEntityPg {
            document_type = $5, topic_domains = $6, authority_level = $7,
            priority = $8, description = $9, ngb_id = $10, format = $11,
            content_reasoning = $12,
-           reviewed_at = ${reviewedAt}, reviewed_by = CASE WHEN $2 = 'approved' THEN 'auto' ELSE reviewed_by END,
+           reviewed_at = NOW(), reviewed_by = 'auto',
+           rejection_reason = $13,
            updated_at = NOW()
        WHERE id = $1`,
       [
@@ -213,6 +216,7 @@ export class DiscoveredSourceEntityPg {
         extracted.ngbId,
         extracted.format,
         reasoning,
+        rejectionReason,
       ],
     );
   }

--- a/scripts/migrations/004_resolve_stuck_pending_content.sql
+++ b/scripts/migrations/004_resolve_stuck_pending_content.sql
@@ -1,0 +1,66 @@
+-- Migration: Resolve rows stuck at `status='pending_content'` due to #706.
+--
+-- Background: two evaluation paths in the discovery feed worker and the
+-- discovery coordinator wrote `status='pending_content'` when they should
+-- have written `status='rejected'`:
+--
+--   1. Metadata rejection: worker/coordinator called `markMetadataEvaluated`
+--      (which sets status='pending_content') then returned early without a
+--      reject() call when the URL failed metadata evaluation.
+--
+--   2. Content rejection: `markContentEvaluated` wrote 'pending_content'
+--      (not 'rejected') when combined confidence was below threshold.
+--
+-- Since 'pending_content' is in REPROCESSABLE_STATUSES, admin "Re-queue
+-- Stuck" actions looped these rows through the same failing evaluation
+-- forever. Staging accumulated 723+ stuck rows; production is unaffected
+-- only if it has not run enough discovery cycles to trigger the bug.
+--
+-- This migration flips two cohorts of stuck rows to 'rejected':
+--
+--   Cohort A: metadata-stage rejections
+--     - status = 'pending_content'
+--     - metadata_confidence IS NOT NULL
+--     - content_confidence IS NULL  (content eval never ran)
+--     - updated_at older than 1 hour (not currently in-flight)
+--
+--   Cohort B: content-stage rejections
+--     - status = 'pending_content'
+--     - content_confidence IS NOT NULL  (content eval did run)
+--     - combined_confidence IS NOT NULL
+--     - updated_at older than 1 hour
+
+BEGIN;
+
+-- Cohort A: rejected at metadata stage
+UPDATE discovered_sources
+SET
+  status = 'rejected',
+  reviewed_at = NOW(),
+  reviewed_by = 'auto-backfill-706',
+  rejection_reason = COALESCE(
+    'Backfill (#706): metadata-stage rejection — ' || metadata_reasoning,
+    'Backfill (#706): metadata confidence ' || COALESCE(metadata_confidence::text, 'null') || ' below 0.5'
+  ),
+  updated_at = NOW()
+WHERE status = 'pending_content'
+  AND metadata_confidence IS NOT NULL
+  AND content_confidence IS NULL
+  AND updated_at < NOW() - INTERVAL '1 hour';
+
+-- Cohort B: rejected at content stage
+UPDATE discovered_sources
+SET
+  status = 'rejected',
+  reviewed_at = NOW(),
+  reviewed_by = 'auto-backfill-706',
+  rejection_reason = 'Backfill (#706): combined confidence ' ||
+                     COALESCE(combined_confidence::text, 'null') ||
+                     ' below auto-approval threshold',
+  updated_at = NOW()
+WHERE status = 'pending_content'
+  AND content_confidence IS NOT NULL
+  AND combined_confidence IS NOT NULL
+  AND updated_at < NOW() - INTERVAL '1 hour';
+
+COMMIT;


### PR DESCRIPTION
Fixes #706.

## Summary

- Unsticks 723+ staging discoveries looping forever in `status='pending_content'`
- Two rejection paths in the discovery pipeline now set `status='rejected'` instead of leaving rows at `'pending_content'`, which was a REPROCESSABLE_STATUS and caused infinite re-queue loops
- Backfill migration flips existing stuck rows to `'rejected'`

## Root cause

### Bug 1: metadata-stage rejection
`packages/ingestion/src/discoveryFeedWorker.ts:135-151` + `packages/ingestion/src/discoveryCoordinator.ts:202-217`

1. `markMetadataEvaluated` sets status → `'pending_content'`
2. If not relevant or low confidence, the worker logs and returns early
3. **No call to mark rejected** — status stays `'pending_content'`

### Bug 2: content-stage rejection
`packages/shared/src/entities/pg/DiscoveredSourceEntityPg.ts:187-190`

`markContentEvaluated` wrote status=`'approved'` when combined confidence ≥ threshold, else **back to `'pending_content'`**. Below-threshold URLs stay pending forever.

### Why re-queue makes it worse
`REPROCESSABLE_STATUSES` in `packages/shared/src/entities/types.ts:96` includes `'pending_content'`. Admin "Re-queue Stuck" loops these rows through the same failing evaluation → same status → forever.

## Changes

- `markContentEvaluated` sets `status='rejected'` when below threshold, stamps `reviewed_at`/`reviewed_by='auto'`/`rejection_reason`
- Metadata-stage rejection in `discoveryFeedWorker` and `discoveryCoordinator` now calls `reject(id, 'auto', reason)`
- Migration `004_resolve_stuck_pending_content.sql` backfills both cohorts (metadata-stage and content-stage stuck rows) to `'rejected'` with `reviewed_by='auto-backfill-706'` for traceability. Safe: only touches rows older than 1 hour at `pending_content` with eval signals present.

## Test plan

- [x] `pnpm --filter @usopc/ingestion test` — 266 passed
- [x] `pnpm --filter @usopc/shared test` — 252 passed (including 2 new regression tests for `markContentEvaluated`)
- [x] `pnpm typecheck` across the monorepo — clean
- [x] Prettier — clean
- [ ] After merge: verify staging stuck count drops from 723 → 0 after migration runs
- [ ] After merge: run admin re-queue on a fresh batch and confirm rejected URLs don't return to the review queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- coverage-summary-start -->
---
### Test Coverage

| Package | Coverage | Delta |
|---------|----------|-------|
| core | 83.4% | +0.0% |
| shared | 59.5% | +1.5% |
| ingestion | 78.9% | -0.0% |
| evals | 44.0% | +0.0% |
| slack | 74.9% | +0.0% |
| web | 48.1% | +0.0% |
<!-- coverage-summary-end -->